### PR TITLE
Support activation payloads with inbox items

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ node dist/src/cli.js source add fixture demo
 node dist/src/cli.js subscription add alpha <source_id> --match-json '{"channel":"engineering"}'
 ```
 
+Subscriptions default to `activation_only`. For low-frequency flows, you can push the newly created inbox items directly in the activation webhook body:
+
+```bash
+node dist/src/cli.js subscription add alpha <source_id> \
+  --activation-target http://127.0.0.1:8080/webhooks/agentinbox/alpha \
+  --activation-mode activation_with_items
+```
+
 Register a GitHub repo source backed by `uxc` poll subscription:
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
   if (command === "subscription" && args[1] === "add") {
     const [agentId, sourceId] = args.slice(2, 4);
     if (!agentId || !sourceId) {
-      throw new Error("usage: agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
+      throw new Error("usage: agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
     }
     await printRemote(client, "/subscriptions/register", {
       agentId,
@@ -60,6 +60,7 @@ async function main(): Promise<void> {
       inboxId: takeFlagValue(args, "--inbox-id") ?? undefined,
       matchRules: parseJsonArg(takeFlagValue(args, "--match-json")),
       activationTarget: takeFlagValue(args, "--activation-target") ?? null,
+      activationMode: takeFlagValue(args, "--activation-mode") ?? undefined,
       startPolicy: takeFlagValue(args, "--start-policy") ?? undefined,
       startOffset: parseOptionalNumber(takeFlagValue(args, "--start-offset")),
       startTime: takeFlagValue(args, "--start-time") ?? undefined,
@@ -232,7 +233,7 @@ Commands:
   agentinbox serve --port 4747 [--state ~/.agentinbox/agentinbox.sqlite]
   agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]
   agentinbox source poll <sourceId>
-  agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
+  agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
   agentinbox subscription poll <subscriptionId>
   agentinbox inbox list
   agentinbox inbox read <inboxId>

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,7 @@
 export type SourceType = "fixture" | "github_repo" | "feishu_bot";
 
 export type SubscriptionStartPolicy = "latest" | "earliest" | "at_offset" | "at_time";
+export type ActivationMode = "activation_only" | "activation_with_items";
 
 export interface DeliveryHandle {
   provider: string;
@@ -35,6 +36,7 @@ export interface Subscription {
   inboxId: string;
   matchRules: Record<string, unknown>;
   activationTarget?: string | null;
+  activationMode: ActivationMode;
   startPolicy: SubscriptionStartPolicy;
   startOffset?: number | null;
   startTime?: string | null;
@@ -54,6 +56,18 @@ export interface InboxItem {
   ackedAt?: string | null;
 }
 
+export interface ActivationItem {
+  itemId: string;
+  sourceId: string;
+  sourceNativeId: string;
+  eventVariant: string;
+  inboxId: string;
+  occurredAt: string;
+  metadata: Record<string, unknown>;
+  rawPayload: Record<string, unknown>;
+  deliveryHandle?: DeliveryHandle | null;
+}
+
 export interface Activation {
   kind: "agentinbox.activation";
   activationId: string;
@@ -63,6 +77,7 @@ export interface Activation {
   sourceIds: string[];
   newItemCount: number;
   summary: string;
+  items?: ActivationItem[];
   createdAt: string;
   deliveredAt?: string | null;
 }
@@ -93,6 +108,7 @@ export interface RegisterSubscriptionInput {
   inboxId?: string;
   matchRules?: Record<string, unknown>;
   activationTarget?: string | null;
+  activationMode?: ActivationMode;
   startPolicy?: SubscriptionStartPolicy;
   startOffset?: number | null;
   startTime?: string | null;

--- a/src/service.ts
+++ b/src/service.ts
@@ -30,6 +30,7 @@ import { matchSubscription } from "./matcher";
 const DEFAULT_SUBSCRIPTION_POLL_LIMIT = 100;
 const DEFAULT_ACTIVATION_WINDOW_MS = 3_000;
 const DEFAULT_ACTIVATION_MAX_ITEMS = 20;
+const ACTIVATION_MODES = new Set<Subscription["activationMode"]>(["activation_only", "activation_with_items"]);
 
 interface ActivationBuffer {
   agentId: string;
@@ -79,6 +80,7 @@ export class AgentInboxService {
     if (this.subscriptionInterval) {
       return;
     }
+    this.stopping = false;
     this.subscriptionInterval = setInterval(() => {
       void this.syncAllSubscriptions();
     }, 2_000);
@@ -129,6 +131,7 @@ export class AgentInboxService {
     if (!source) {
       throw new Error(`unknown source: ${input.sourceId}`);
     }
+    const activationMode = normalizeActivationMode(input.activationMode);
 
     const inboxId = input.inboxId ?? defaultInboxIdForAgent(input.agentId);
     this.ensureInbox(inboxId, input.agentId);
@@ -139,7 +142,7 @@ export class AgentInboxService {
       inboxId,
       matchRules: input.matchRules ?? {},
       activationTarget: input.activationTarget ?? null,
-      activationMode: input.activationMode ?? "activation_only",
+      activationMode,
       startPolicy: input.startPolicy ?? "latest",
       startOffset: input.startOffset ?? null,
       startTime: input.startTime ?? null,
@@ -555,4 +558,12 @@ function summarizeActivation(inboxId: string, newItemCount: number, firstSummary
     return `${newItemCount} new ${itemWord} in ${inboxId} from ${firstSummary}`;
   }
   return `${newItemCount} new ${itemWord} in ${inboxId}`;
+}
+
+function normalizeActivationMode(mode: RegisterSubscriptionInput["activationMode"]): Subscription["activationMode"] {
+  const resolved = mode ?? "activation_only";
+  if (!ACTIVATION_MODES.has(resolved)) {
+    throw new Error(`unsupported activation mode: ${String(mode)}`);
+  }
+  return resolved;
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,5 +1,6 @@
 import {
   Activation,
+  ActivationItem,
   AppendSourceEventInput,
   AppendSourceEventResult,
   DeliveryAttempt,
@@ -34,10 +35,13 @@ interface ActivationBuffer {
   agentId: string;
   inboxId: string;
   activationTarget: string | null;
-  newItemCount: number;
-  subscriptionIds: Set<string>;
-  sourceIds: Set<string>;
-  firstSummary: string | null;
+  activationMode: Subscription["activationMode"];
+  pending: Array<{
+    subscriptionId: string;
+    sourceId: string;
+    summary: string;
+    item?: ActivationItem;
+  }>;
   timer: NodeJS.Timeout | null;
   inFlight: boolean;
 }
@@ -54,6 +58,7 @@ export class AgentInboxService {
   private readonly activationMaxItems: number;
   private readonly activationBuffers = new Map<string, ActivationBuffer>();
   private subscriptionInterval: NodeJS.Timeout | null = null;
+  private stopping = false;
 
   constructor(
     private readonly store: AgentInboxStore,
@@ -81,6 +86,13 @@ export class AgentInboxService {
   }
 
   async stop(): Promise<void> {
+    this.stopping = true;
+    for (const buffer of this.activationBuffers.values()) {
+      if (buffer.timer) {
+        clearTimeout(buffer.timer);
+        buffer.timer = null;
+      }
+    }
     if (!this.subscriptionInterval) {
       await this.flushAllPendingActivations();
       return;
@@ -127,6 +139,7 @@ export class AgentInboxService {
       inboxId,
       matchRules: input.matchRules ?? {},
       activationTarget: input.activationTarget ?? null,
+      activationMode: input.activationMode ?? "activation_only",
       startPolicy: input.startPolicy ?? "latest",
       startOffset: input.startOffset ?? null,
       startTime: input.startTime ?? null,
@@ -253,11 +266,23 @@ export class AgentInboxService {
             agentId: subscription.agentId,
             inboxId: subscription.inboxId,
             activationTarget: subscription.activationTarget ?? null,
+            activationMode: subscription.activationMode,
             subscriptionId: subscription.subscriptionId,
             sourceId: source.sourceId,
             eventVariant: event.eventVariant,
             sourceType: source.sourceType,
             sourceKey: source.sourceKey,
+            item: {
+              itemId: item.itemId,
+              sourceId: item.sourceId,
+              sourceNativeId: item.sourceNativeId,
+              eventVariant: item.eventVariant,
+              inboxId: item.inboxId,
+              occurredAt: item.occurredAt,
+              metadata: item.metadata,
+              rawPayload: item.rawPayload,
+              deliveryHandle: item.deliveryHandle,
+            },
           });
         }
       } catch (error) {
@@ -366,35 +391,35 @@ export class AgentInboxService {
     agentId: string;
     inboxId: string;
     activationTarget: string | null;
+    activationMode: Subscription["activationMode"];
     subscriptionId: string;
     sourceId: string;
     eventVariant: string;
     sourceType: string;
     sourceKey: string;
+    item: ActivationItem;
   }): void {
-    const key = activationBufferKey(input.inboxId, input.activationTarget);
+    const key = activationBufferKey(input.inboxId, input.activationTarget, input.activationMode);
     let buffer = this.activationBuffers.get(key);
     if (!buffer) {
       buffer = {
         agentId: input.agentId,
         inboxId: input.inboxId,
         activationTarget: input.activationTarget,
-        newItemCount: 0,
-        subscriptionIds: new Set<string>(),
-        sourceIds: new Set<string>(),
-        firstSummary: null,
+        activationMode: input.activationMode,
+        pending: [],
         timer: null,
         inFlight: false,
       };
       this.activationBuffers.set(key, buffer);
     }
 
-    buffer.newItemCount += 1;
-    buffer.subscriptionIds.add(input.subscriptionId);
-    buffer.sourceIds.add(input.sourceId);
-    if (!buffer.firstSummary) {
-      buffer.firstSummary = `${input.sourceType}:${input.sourceKey}:${input.eventVariant}`;
-    }
+    buffer.pending.push({
+      subscriptionId: input.subscriptionId,
+      sourceId: input.sourceId,
+      summary: `${input.sourceType}:${input.sourceKey}:${input.eventVariant}`,
+      item: input.activationMode === "activation_with_items" ? input.item : undefined,
+    });
 
     if (!buffer.timer && !buffer.inFlight) {
       buffer.timer = setTimeout(() => {
@@ -402,7 +427,7 @@ export class AgentInboxService {
       }, this.activationWindowMs);
     }
 
-    if (buffer.newItemCount >= this.activationMaxItems) {
+    if (buffer.pending.length >= this.activationMaxItems) {
       if (buffer.timer) {
         clearTimeout(buffer.timer);
         buffer.timer = null;
@@ -420,7 +445,7 @@ export class AgentInboxService {
 
   private async flushActivationBuffer(key: string): Promise<void> {
     const buffer = this.activationBuffers.get(key);
-    if (!buffer || buffer.inFlight || buffer.newItemCount === 0) {
+    if (!buffer || buffer.inFlight || buffer.pending.length === 0) {
       return;
     }
     if (buffer.timer) {
@@ -429,11 +454,17 @@ export class AgentInboxService {
     }
 
     buffer.inFlight = true;
+    const dispatchedEntries = buffer.pending.splice(0, buffer.pending.length);
     try {
-      const dispatchedCount = buffer.newItemCount;
-      const dispatchedSubscriptionIds = Array.from(buffer.subscriptionIds).sort();
-      const dispatchedSourceIds = Array.from(buffer.sourceIds).sort();
-      const dispatchedSummary = buffer.firstSummary;
+      const dispatchedCount = dispatchedEntries.length;
+      const dispatchedSubscriptionIds = Array.from(new Set(dispatchedEntries.map((entry) => entry.subscriptionId))).sort();
+      const dispatchedSourceIds = Array.from(new Set(dispatchedEntries.map((entry) => entry.sourceId))).sort();
+      const dispatchedSummary = dispatchedEntries[0]?.summary ?? null;
+      const dispatchedItems = buffer.activationMode === "activation_with_items"
+        ? dispatchedEntries
+          .map((entry) => entry.item)
+          .filter((item): item is ActivationItem => Boolean(item))
+        : undefined;
       const activation: Activation = {
         kind: "agentinbox.activation",
         activationId: generateId("act"),
@@ -443,23 +474,14 @@ export class AgentInboxService {
         sourceIds: dispatchedSourceIds,
         newItemCount: dispatchedCount,
         summary: summarizeActivation(buffer.inboxId, dispatchedCount, dispatchedSummary),
+        items: dispatchedItems && dispatchedItems.length > 0 ? dispatchedItems : undefined,
         createdAt: nowIso(),
         deliveredAt: null,
       };
-      this.store.insertActivation(activation);
       await this.activationDispatcher.dispatch(buffer.activationTarget, activation);
+      this.store.insertActivation(activation);
 
-      const hasPendingDuringFlight = buffer.newItemCount > dispatchedCount;
-      buffer.newItemCount = Math.max(0, buffer.newItemCount - dispatchedCount);
-      for (const subscriptionId of dispatchedSubscriptionIds) {
-        buffer.subscriptionIds.delete(subscriptionId);
-      }
-      for (const sourceId of dispatchedSourceIds) {
-        buffer.sourceIds.delete(sourceId);
-      }
-      if (!hasPendingDuringFlight) {
-        buffer.firstSummary = null;
-      }
+      const hasPendingDuringFlight = buffer.pending.length > 0;
       buffer.inFlight = false;
 
       if (hasPendingDuringFlight) {
@@ -471,8 +493,9 @@ export class AgentInboxService {
 
       this.activationBuffers.delete(key);
     } catch (error) {
+      buffer.pending.unshift(...dispatchedEntries);
       buffer.inFlight = false;
-      if (!buffer.timer) {
+      if (!this.stopping && !buffer.timer) {
         buffer.timer = setTimeout(() => {
           void this.flushActivationBuffer(key);
         }, this.activationWindowMs);
@@ -518,8 +541,12 @@ export class ActivationDispatcher {
   }
 }
 
-function activationBufferKey(inboxId: string, activationTarget: string | null): string {
-  return `${inboxId}::${activationTarget ?? ""}`;
+function activationBufferKey(
+  inboxId: string,
+  activationTarget: string | null,
+  activationMode: Subscription["activationMode"],
+): string {
+  return `${inboxId}::${activationTarget ?? ""}::${activationMode}`;
 }
 
 function summarizeActivation(inboxId: string, newItemCount: number, firstSummary: string | null): string {

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,6 +9,7 @@ import type {
 } from "./backend";
 import {
   Activation,
+  ActivationItem,
   AppendSourceEventInput,
   AppendSourceEventResult,
   DeliveryAttempt,
@@ -20,7 +21,7 @@ import {
 } from "./model";
 import { generateId, nowIso } from "./util";
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 4;
 
 function parseJson<T>(value: string | null): T {
   if (!value) {
@@ -82,6 +83,14 @@ export class AgentInboxStore {
       this.upgradeActivationSchema();
     }
 
+    if (userVersion < 3 && this.needsSubscriptionActivationModeUpgrade()) {
+      this.upgradeSubscriptionActivationModeSchema();
+    }
+
+    if (userVersion < 4 && this.needsActivationItemsUpgrade()) {
+      this.upgradeActivationItemsSchema();
+    }
+
     this.setUserVersion(SCHEMA_VERSION);
   }
 
@@ -119,6 +128,7 @@ export class AgentInboxStore {
           source_ids_json text not null,
           new_item_count integer not null,
           summary text not null,
+          items_json text,
           created_at text not null,
           delivered_at text
         );
@@ -132,11 +142,11 @@ export class AgentInboxStore {
 
         insert or ignore into subscriptions (
           subscription_id, agent_id, source_id, inbox_id, match_rules_json,
-          activation_target, start_policy, start_offset, start_time, created_at
+          activation_target, activation_mode, start_policy, start_offset, start_time, created_at
         )
         select
           interest_id, agent_id, source_id, mailbox_id, match_rules_json,
-          activation_target, 'latest', null, null, created_at
+          activation_target, 'activation_only', 'latest', null, null, created_at
         from interests;
 
         insert or ignore into inbox_items_v2 (
@@ -149,10 +159,10 @@ export class AgentInboxStore {
         from inbox_items;
 
         insert or ignore into activations_v2 (
-          activation_id, kind, agent_id, inbox_id, subscription_ids_json, source_ids_json, new_item_count, summary, created_at, delivered_at
+          activation_id, kind, agent_id, inbox_id, subscription_ids_json, source_ids_json, new_item_count, summary, items_json, created_at, delivered_at
         )
         select
-          activation_id, 'agentinbox.activation', agent_id, mailbox_id, '[]', '[]', new_item_count, summary, created_at, delivered_at
+          activation_id, 'agentinbox.activation', agent_id, mailbox_id, '[]', '[]', new_item_count, summary, null, created_at, delivered_at
         from activations;
 
         insert or ignore into streams (stream_id, source_id, stream_key, backend, created_at)
@@ -207,6 +217,14 @@ export class AgentInboxStore {
       || !this.columnExists("activations", "source_ids_json");
   }
 
+  private needsSubscriptionActivationModeUpgrade(): boolean {
+    return !this.columnExists("subscriptions", "activation_mode");
+  }
+
+  private needsActivationItemsUpgrade(): boolean {
+    return !this.columnExists("activations", "items_json");
+  }
+
   private upgradeActivationSchema(): void {
     this.inTransaction(() => {
       this.db.exec(`
@@ -219,6 +237,7 @@ export class AgentInboxStore {
           source_ids_json text not null,
           new_item_count integer not null,
           summary text not null,
+          items_json text,
           created_at text not null,
           delivered_at text
         );
@@ -226,7 +245,7 @@ export class AgentInboxStore {
 
       this.db.exec(`
         insert or ignore into activations_v3 (
-          activation_id, kind, agent_id, inbox_id, subscription_ids_json, source_ids_json, new_item_count, summary, created_at, delivered_at
+          activation_id, kind, agent_id, inbox_id, subscription_ids_json, source_ids_json, new_item_count, summary, items_json, created_at, delivered_at
         )
         select
           activation_id,
@@ -237,6 +256,7 @@ export class AgentInboxStore {
           '[]',
           new_item_count,
           summary,
+          null,
           created_at,
           delivered_at
         from activations;
@@ -244,6 +264,18 @@ export class AgentInboxStore {
 
       this.db.exec("drop table activations;");
       this.db.exec("alter table activations_v3 rename to activations;");
+    });
+  }
+
+  private upgradeSubscriptionActivationModeSchema(): void {
+    this.inTransaction(() => {
+      this.db.exec("alter table subscriptions add column activation_mode text not null default 'activation_only';");
+    });
+  }
+
+  private upgradeActivationItemsSchema(): void {
+    this.inTransaction(() => {
+      this.db.exec("alter table activations add column items_json text;");
     });
   }
 
@@ -280,6 +312,7 @@ export class AgentInboxStore {
         inbox_id text not null,
         match_rules_json text not null,
         activation_target text,
+        activation_mode text not null,
         start_policy text not null,
         start_offset integer,
         start_time text,
@@ -309,6 +342,7 @@ export class AgentInboxStore {
         source_ids_json text not null,
         new_item_count integer not null,
         summary text not null,
+        items_json text,
         created_at text not null,
         delivered_at text
       );
@@ -528,8 +562,8 @@ export class AgentInboxStore {
       `
       insert into subscriptions (
         subscription_id, agent_id, source_id, inbox_id, match_rules_json,
-        activation_target, start_policy, start_offset, start_time, created_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        activation_target, activation_mode, start_policy, start_offset, start_time, created_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         subscription.subscriptionId,
@@ -538,6 +572,7 @@ export class AgentInboxStore {
         subscription.inboxId,
         JSON.stringify(subscription.matchRules),
         subscription.activationTarget ?? null,
+        subscription.activationMode,
         subscription.startPolicy,
         subscription.startOffset ?? null,
         subscription.startTime ?? null,
@@ -622,8 +657,8 @@ export class AgentInboxStore {
     this.db.run(
       `
       insert into activations (
-        activation_id, kind, agent_id, inbox_id, subscription_ids_json, source_ids_json, new_item_count, summary, created_at, delivered_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        activation_id, kind, agent_id, inbox_id, subscription_ids_json, source_ids_json, new_item_count, summary, items_json, created_at, delivered_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         activation.activationId,
@@ -634,6 +669,7 @@ export class AgentInboxStore {
         JSON.stringify(activation.sourceIds),
         activation.newItemCount,
         activation.summary,
+        activation.items ? JSON.stringify(activation.items) : null,
         activation.createdAt,
         activation.deliveredAt ?? null,
       ],
@@ -976,6 +1012,7 @@ export class AgentInboxStore {
       inboxId: String(row.inbox_id),
       matchRules: parseJson<Record<string, unknown>>(row.match_rules_json as string),
       activationTarget: row.activation_target ? String(row.activation_target) : null,
+      activationMode: (row.activation_mode ? String(row.activation_mode) : "activation_only") as Subscription["activationMode"],
       startPolicy: row.start_policy as SubscriptionStartPolicy,
       startOffset: row.start_offset != null ? Number(row.start_offset) : null,
       startTime: row.start_time ? String(row.start_time) : null,
@@ -1010,6 +1047,7 @@ export class AgentInboxStore {
       sourceIds: parseJson<string[]>(row.source_ids_json as string),
       newItemCount: Number(row.new_item_count),
       summary: String(row.summary),
+      items: row.items_json ? parseJson<ActivationItem[]>(row.items_json as string) : undefined,
       createdAt: String(row.created_at),
       deliveredAt: row.delivered_at ? String(row.delivered_at) : null,
     };

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -308,6 +308,7 @@ test("legacy interest/mailbox schema migrates to subscriptions/inboxes", async (
     assert.equal(subscriptions.length, 1);
     assert.equal(subscriptions[0].subscriptionId, "int_legacy");
     assert.equal(subscriptions[0].inboxId, "mbx_alpha");
+    assert.equal(subscriptions[0].activationMode, "activation_only");
     assert.equal(inboxes.length, 1);
     assert.equal(inboxes[0].inboxId, "mbx_alpha");
     assert.equal(inboxItems.length, 1);
@@ -371,6 +372,7 @@ test("activations are aggregated within the inbox window", async () => {
     assert.deepEqual(activation.subscriptionIds, [subscription.subscriptionId]);
     assert.deepEqual(activation.sourceIds, [source.sourceId]);
     assert.equal(activation.newItemCount, 2);
+    assert.equal(activation.items, undefined);
     assert.match(activation.summary, /2 new items in inbox_alpha/);
     assert.equal(store.listActivations().length, 1);
     assert.equal(store.listActivations()[0].newItemCount, 2);
@@ -424,6 +426,58 @@ test("activations flush immediately when the inbox count threshold is reached", 
 
     assert.equal(dispatcher.calls.length, 1);
     assert.equal(dispatcher.calls[0].activation.newItemCount, 2);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("activation_with_items includes inbox item snapshots in the webhook body", async () => {
+  const dispatcher = new RecordingActivationDispatcher();
+  const { store, service, dir } = await makeAsyncService({
+    dispatcher,
+    activationWindowMs: 40,
+    activationMaxItems: 20,
+  });
+  try {
+    const source = await service.registerSource({
+      sourceType: "fixture",
+      sourceKey: "demo",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: "alpha",
+      sourceId: source.sourceId,
+      matchRules: { channel: "engineering" },
+      activationTarget: "http://louke.local/activate?agent=alpha",
+      activationMode: "activation_with_items",
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "evt-1",
+      eventVariant: "message.created",
+      metadata: { channel: "engineering", priority: "high" },
+      rawPayload: { text: "hello" },
+    });
+
+    const poll = await service.pollSubscription(subscription.subscriptionId);
+    assert.equal(poll.inboxItemsCreated, 1);
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    assert.equal(dispatcher.calls.length, 1);
+    const activation = dispatcher.calls[0].activation;
+    assert.equal(activation.newItemCount, 1);
+    assert.ok(activation.items);
+    assert.equal(activation.items.length, 1);
+    assert.equal(activation.items[0].sourceNativeId, "evt-1");
+    assert.equal(activation.items[0].metadata.channel, "engineering");
+    assert.equal(activation.items[0].rawPayload.text, "hello");
+    assert.equal(store.listActivations().length, 1);
+    assert.equal(store.listActivations()[0].items?.length, 1);
   } finally {
     await service.stop();
     store.close();

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -196,6 +196,30 @@ test("delivery requests are recorded with provider metadata", async () => {
   }
 });
 
+test("registerSubscription rejects unsupported activation modes", async () => {
+  const { store, service, dir } = await makeAsyncService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "fixture",
+      sourceKey: "demo",
+      config: {},
+    });
+
+    await assert.rejects(
+      () => service.registerSubscription({
+        agentId: "alpha",
+        sourceId: source.sourceId,
+        activationMode: "push_everything" as never,
+      }),
+      /unsupported activation mode: push_everything/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("legacy interest/mailbox schema migrates to subscriptions/inboxes", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-migrate-test-"));
   const dbPath = path.join(dir, "agentinbox.sqlite");

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -76,8 +76,6 @@ test("unix socket control plane replaces stale socket files and serves requests"
   const server = createServer(service);
 
   try {
-    await adapters.start();
-    await service.start();
     const started = await startControlServer(server, {
       kind: "socket",
       socketPath,
@@ -96,7 +94,6 @@ test("unix socket control plane replaces stale socket files and serves requests"
     }
     assert.equal(fs.existsSync(socketPath), false);
   } finally {
-    await adapters.stop();
     await service.stop();
     store.close();
     fs.rmSync(homeDir, { recursive: true, force: true });
@@ -134,13 +131,13 @@ test("e2e control plane can register fixture source, consume a subscription, and
       chunks.push(Buffer.from(chunk));
     }
     const payload = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Activation;
-    resolveWebhook?.(payload);
     res.statusCode = 204;
-    res.end();
+    res.end(() => {
+      resolveWebhook?.(payload);
+    });
   });
 
   try {
-    await adapters.start();
     const started = await startControlServer(server, {
       kind: "socket",
       socketPath,
@@ -210,6 +207,7 @@ test("e2e control plane can register fixture source, consume a subscription, and
       assert.deepEqual(activation.subscriptionIds, [subscriptionResponse.data.subscriptionId]);
       assert.deepEqual(activation.sourceIds, [sourceResponse.data.sourceId]);
       assert.equal(activation.newItemCount, 1);
+      assert.equal(activation.items, undefined);
       assert.match(activation.summary, /1 new item/);
 
       const inboxResponse = await client.request<{ items: InboxItem[] }>(
@@ -227,7 +225,6 @@ test("e2e control plane can register fixture source, consume a subscription, and
       await started.close();
     }
   } finally {
-    await adapters.stop();
     await service.stop();
     store.close();
     fs.rmSync(homeDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add `activationMode` on subscriptions with `activation_only` as the default
- support `activation_with_items` so activation webhooks can carry newly created inbox item snapshots
- persist activation item snapshots and expose the new CLI flag `--activation-mode`

## Testing
- npm test