### PR TITLE
Add inbox watch over SSE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  node-tests:
+    name: Node Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ node dist/src/cli.js fixture emit <source_id> --metadata-json '{"channel":"engin
 node dist/src/cli.js subscription poll <subscription_id>
 node dist/src/cli.js inbox list
 node dist/src/cli.js inbox read inbox_alpha
+node dist/src/cli.js inbox watch inbox_alpha
 ```
 
 Record a delivery attempt:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@holon-run/uxc-daemon-client": "file:../uxc/packages/uxc-daemon-client",
+        "@holon-run/uxc-daemon-client": "^0.13.1",
         "sql.js": "^1.13.0"
       },
       "bin": {
@@ -20,21 +20,6 @@
         "@types/sql.js": "^1.4.9",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
-      }
-    },
-    "../uxc/packages/uxc-daemon-client": {
-      "name": "@holon-run/uxc-daemon-client",
-      "version": "0.13.0",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/node": "^24.5.0",
-        "tsup": "^8.3.5",
-        "typescript": "^5.9.2",
-        "vitest": "^3.2.4",
-        "ws": "^8.18.3"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -51,8 +36,13 @@
       }
     },
     "node_modules/@holon-run/uxc-daemon-client": {
-      "resolved": "../uxc/packages/uxc-daemon-client",
-      "link": true
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.13.1.tgz",
+      "integrity": "sha512-OuCwQJGLdjlMXIYRehY0EDVZCkifep8UpsqHDht1IS3DKbeUDN5aE0IRZpU0HjLSUNX7IA3qxnTA21TD7mXT6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "node --watch --loader ts-node/esm src/cli.ts",
-    "test": "npm run build && node --test dist/test/**/*.test.js"
+    "test": "node --require ts-node/register --test test/**/*.test.ts"
   },
   "dependencies": {
     "@holon-run/uxc-daemon-client": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run build && node --test dist/test/**/*.test.js"
   },
   "dependencies": {
-    "@holon-run/uxc-daemon-client": "file:../uxc/packages/uxc-daemon-client",
+    "@holon-run/uxc-daemon-client": "^0.13.1",
     "sql.js": "^1.13.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "node --watch --loader ts-node/esm src/cli.ts",
-    "test": "node --require ts-node/register --test test/**/*.test.ts"
+    "test": "node --require ts-node/register --test test/*.test.ts"
   },
   "dependencies": {
     "@holon-run/uxc-daemon-client": "^0.13.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,6 +91,24 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "inbox" && args[1] === "watch") {
+    const inboxId = args[2];
+    if (!inboxId) {
+      throw new Error("usage: agentinbox inbox watch <inboxId> [--after-item ID] [--include-acked] [--heartbeat-ms N]");
+    }
+    for await (const event of client.watchInbox(inboxId, {
+      afterItemId: takeFlagValue(args, "--after-item"),
+      includeAcked: hasFlag(args, "--include-acked"),
+      heartbeatMs: parseOptionalNumber(takeFlagValue(args, "--heartbeat-ms")),
+    })) {
+      if (event.event !== "items") {
+        continue;
+      }
+      console.log(jsonResponse(event));
+    }
+    return;
+  }
+
   if (command === "inbox" && args[1] === "ack") {
     const inboxId = args[2];
     const itemId = takeFlagValue(args, "--item");
@@ -214,6 +232,10 @@ function takeFlagValue(args: string[], flag: string): string | undefined {
   return args[index + 1];
 }
 
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
 function parseOptionalNumber(value: string | undefined): number | undefined {
   if (value == null) {
     return undefined;
@@ -237,6 +259,7 @@ Commands:
   agentinbox subscription poll <subscriptionId>
   agentinbox inbox list
   agentinbox inbox read <inboxId>
+  agentinbox inbox watch <inboxId> [--after-item ID] [--include-acked] [--heartbeat-ms N]
   agentinbox inbox ack <inboxId> --item <itemId>
   agentinbox fixture emit <sourceId> [--native-id ID] [--event EVENT] [--metadata-json JSON] [--payload-json JSON]
   agentinbox deliver send --provider PROVIDER --surface SURFACE --target TARGET [--kind KIND] [--payload-json JSON]

--- a/src/client.ts
+++ b/src/client.ts
@@ -232,16 +232,20 @@ function createSseStream(
     let buffer = "";
     res.setEncoding("utf8");
     res.on("data", (chunk: string) => {
-      buffer += chunk;
-      let separatorIndex = buffer.indexOf("\n\n");
-      while (separatorIndex >= 0) {
-        const frame = buffer.slice(0, separatorIndex);
-        buffer = buffer.slice(separatorIndex + 2);
-        const event = parseSseFrame(frame);
-        if (event) {
-          push(event);
+      try {
+        buffer += chunk;
+        let separatorIndex = buffer.indexOf("\n\n");
+        while (separatorIndex >= 0) {
+          const frame = buffer.slice(0, separatorIndex);
+          buffer = buffer.slice(separatorIndex + 2);
+          const event = parseSseFrame(frame);
+          if (event) {
+            push(event);
+          }
+          separatorIndex = buffer.indexOf("\n\n");
         }
-        separatorIndex = buffer.indexOf("\n\n");
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)));
       }
     });
     res.on("end", () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 import https from "node:https";
 import { ClientTransport } from "./paths";
+import { InboxWatchEvent, WatchInboxOptions } from "./model";
 
 export interface AgentInboxResponse<T = unknown> {
   statusCode: number;
@@ -19,6 +20,25 @@ export class AgentInboxClient {
       return requestViaSocket<T>(this.transport.socketPath, endpoint, body, method);
     }
     return requestViaUrl<T>(this.transport.baseUrl, endpoint, body, method);
+  }
+
+  watchInbox(inboxId: string, options: WatchInboxOptions = {}): AsyncIterable<InboxWatchEvent> {
+    const query = new URLSearchParams();
+    if (options.afterItemId) {
+      query.set("after_item_id", options.afterItemId);
+    }
+    if (options.includeAcked) {
+      query.set("include_acked", "true");
+    }
+    if (options.heartbeatMs) {
+      query.set("heartbeat_ms", String(options.heartbeatMs));
+    }
+    const endpoint = `/inboxes/${encodeURIComponent(inboxId)}/watch${query.size > 0 ? `?${query.toString()}` : ""}`;
+
+    if (this.transport.kind === "socket") {
+      return watchViaSocket(this.transport.socketPath, endpoint);
+    }
+    return watchViaUrl(this.transport.baseUrl, endpoint);
   }
 }
 
@@ -90,6 +110,46 @@ function requestViaUrl<T>(
   });
 }
 
+function watchViaSocket(socketPath: string, endpoint: string): AsyncIterable<InboxWatchEvent> {
+  return createSseStream((handleResponse) => {
+    const req = http.request(
+      {
+        socketPath,
+        path: normalizeEndpoint(endpoint),
+        method: "GET",
+        headers: {
+          accept: "text/event-stream",
+        },
+      },
+      handleResponse,
+    );
+    req.end();
+    return req;
+  });
+}
+
+function watchViaUrl(baseUrl: string, endpoint: string): AsyncIterable<InboxWatchEvent> {
+  return createSseStream((handleResponse) => {
+    const url = new URL(normalizeEndpoint(endpoint), baseUrl);
+    const transport = url.protocol === "https:" ? https : http;
+    const req = transport.request(
+      {
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        method: "GET",
+        headers: {
+          accept: "text/event-stream",
+        },
+      },
+      handleResponse,
+    );
+    req.end();
+    return req;
+  });
+}
+
 function collectResponse<T>(res: http.IncomingMessage): Promise<AgentInboxResponse<T>> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -114,4 +174,146 @@ function collectResponse<T>(res: http.IncomingMessage): Promise<AgentInboxRespon
 
 function normalizeEndpoint(endpoint: string): string {
   return endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
+}
+
+function createSseStream(
+  openRequest: (handleResponse: (res: http.IncomingMessage) => void) => http.ClientRequest,
+): AsyncIterable<InboxWatchEvent> {
+  const queue: InboxWatchEvent[] = [];
+  const waiters: Array<(result: IteratorResult<InboxWatchEvent>) => void> = [];
+  let done = false;
+  let failure: Error | null = null;
+  let request: http.ClientRequest | null = null;
+  let response: http.IncomingMessage | null = null;
+
+  const push = (event: InboxWatchEvent) => {
+    if (done) {
+      return;
+    }
+    const waiter = waiters.shift();
+    if (waiter) {
+      waiter({ value: event, done: false });
+      return;
+    }
+    queue.push(event);
+  };
+
+  const finish = (error?: Error) => {
+    if (done) {
+      return;
+    }
+    done = true;
+    failure = error ?? null;
+    request?.destroy();
+    response?.destroy();
+    while (waiters.length > 0) {
+      const waiter = waiters.shift();
+      if (!waiter) {
+        continue;
+      }
+      waiter({ value: undefined, done: true });
+    }
+  };
+
+  request = openRequest((res) => {
+    response = res;
+    if ((res.statusCode ?? 500) < 200 || (res.statusCode ?? 500) >= 300) {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      res.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8");
+        finish(new Error(body || `watch failed with status ${res.statusCode ?? 500}`));
+      });
+      return;
+    }
+
+    let buffer = "";
+    res.setEncoding("utf8");
+    res.on("data", (chunk: string) => {
+      buffer += chunk;
+      let separatorIndex = buffer.indexOf("\n\n");
+      while (separatorIndex >= 0) {
+        const frame = buffer.slice(0, separatorIndex);
+        buffer = buffer.slice(separatorIndex + 2);
+        const event = parseSseFrame(frame);
+        if (event) {
+          push(event);
+        }
+        separatorIndex = buffer.indexOf("\n\n");
+      }
+    });
+    res.on("end", () => {
+      finish();
+    });
+    res.on("error", (error) => {
+      finish(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+
+  request.on("error", (error) => {
+    finish(error instanceof Error ? error : new Error(String(error)));
+  });
+
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<InboxWatchEvent> {
+      return {
+        next(): Promise<IteratorResult<InboxWatchEvent>> {
+          if (queue.length > 0) {
+            return Promise.resolve({ value: queue.shift() as InboxWatchEvent, done: false });
+          }
+          if (done) {
+            if (failure) {
+              return Promise.reject(failure);
+            }
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          return new Promise<IteratorResult<InboxWatchEvent>>((resolve) => {
+            waiters.push(resolve);
+          }).then((result) => {
+            if (result.done && failure) {
+              throw failure;
+            }
+            return result;
+          });
+        },
+        return(): Promise<IteratorResult<InboxWatchEvent>> {
+          finish();
+          return Promise.resolve({ value: undefined, done: true });
+        },
+      };
+    },
+  };
+}
+
+function parseSseFrame(frame: string): InboxWatchEvent | null {
+  const lines = frame
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0 && !line.startsWith(":"));
+  if (lines.length === 0) {
+    return null;
+  }
+
+  let eventName = "message";
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith("event:")) {
+      eventName = line.slice("event:".length).trim();
+      continue;
+    }
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trim());
+    }
+  }
+
+  if (dataLines.length === 0) {
+    return null;
+  }
+
+  const payload = JSON.parse(dataLines.join("\n")) as InboxWatchEvent;
+  if (eventName !== payload.event) {
+    throw new Error(`unexpected SSE event name ${eventName} for payload event ${payload.event}`);
+  }
+  return payload;
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 import { AgentInboxService } from "./service";
 import { asObject, jsonResponse } from "./util";
+import { WatchInboxOptions } from "./model";
 
 async function readJson(req: http.IncomingMessage): Promise<Record<string, unknown>> {
   const chunks: Buffer[] = [];
@@ -18,6 +19,15 @@ function send(res: http.ServerResponse, statusCode: number, data: unknown): void
   res.statusCode = statusCode;
   res.setHeader("content-type", "application/json; charset=utf-8");
   res.end(jsonResponse(data));
+}
+
+function sendSse(res: http.ServerResponse, event: string, data: unknown): void {
+  res.write(`event: ${event}\n`);
+  const payload = jsonResponse(data)
+    .split("\n")
+    .map((line) => `data: ${line}`)
+    .join("\n");
+  res.write(`${payload}\n\n`);
 }
 
 export function createServer(service: AgentInboxService): http.Server {
@@ -78,7 +88,59 @@ export function createServer(service: AgentInboxService): http.Server {
 
       const inboxMatch = url.pathname.match(/^\/inboxes\/([^/]+)\/items$/);
       if (req.method === "GET" && inboxMatch) {
-        send(res, 200, { items: service.listInboxItems(decodeURIComponent(inboxMatch[1])) });
+        send(res, 200, {
+          items: service.listInboxItems(decodeURIComponent(inboxMatch[1]), {
+            afterItemId: url.searchParams.get("after_item_id") ?? undefined,
+            includeAcked: url.searchParams.has("include_acked")
+              ? url.searchParams.get("include_acked") === "true"
+              : undefined,
+          }),
+        });
+        return;
+      }
+
+      const inboxWatchMatch = url.pathname.match(/^\/inboxes\/([^/]+)\/watch$/);
+      if (req.method === "GET" && inboxWatchMatch) {
+        const inboxId = decodeURIComponent(inboxWatchMatch[1]);
+        const watchOptions: WatchInboxOptions = {
+          afterItemId: url.searchParams.get("after_item_id") ?? undefined,
+          includeAcked: url.searchParams.get("include_acked") === "true",
+          heartbeatMs: parsePositiveInteger(url.searchParams.get("heartbeat_ms")) ?? 15_000,
+        };
+        const session = service.watchInbox(inboxId, watchOptions, (event) => {
+          sendSse(res, event.event, event);
+        });
+
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache, no-transform",
+          connection: "keep-alive",
+        });
+        res.flushHeaders?.();
+
+        if (session.initialItems.length > 0) {
+          sendSse(res, "items", {
+            event: "items",
+            inboxId,
+            items: session.initialItems,
+          });
+        }
+        session.start();
+
+        const heartbeat = setInterval(() => {
+          sendSse(res, "heartbeat", {
+            event: "heartbeat",
+            inboxId,
+            timestamp: new Date().toISOString(),
+          });
+        }, watchOptions.heartbeatMs ?? 15_000);
+
+        const cleanup = () => {
+          clearInterval(heartbeat);
+          session.close();
+        };
+        req.on("close", cleanup);
+        req.on("error", cleanup);
         return;
       }
 
@@ -99,7 +161,26 @@ export function createServer(service: AgentInboxService): http.Server {
       send(res, 404, { error: "not found" });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      if (message.startsWith("unknown ")) {
+        send(res, 404, { error: message });
+        return;
+      }
+      if (message.startsWith("expected positive integer")) {
+        send(res, 400, { error: message });
+        return;
+      }
       send(res, 500, { error: message });
     }
   });
+}
+
+function parsePositiveInteger(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`expected positive integer, received ${value}`);
+  }
+  return parsed;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -165,3 +165,26 @@ export interface SubscriptionPollResult {
   committedOffset: number | null;
   note: string;
 }
+
+export interface ListInboxItemsOptions {
+  afterItemId?: string;
+  includeAcked?: boolean;
+}
+
+export interface WatchInboxOptions extends ListInboxItemsOptions {
+  heartbeatMs?: number;
+}
+
+export interface InboxWatchItemsEvent {
+  event: "items";
+  inboxId: string;
+  items: InboxItem[];
+}
+
+export interface InboxWatchHeartbeatEvent {
+  event: "heartbeat";
+  inboxId: string;
+  timestamp: string;
+}
+
+export type InboxWatchEvent = InboxWatchItemsEvent | InboxWatchHeartbeatEvent;

--- a/src/service.ts
+++ b/src/service.ts
@@ -236,10 +236,20 @@ export class AgentInboxService {
     }
     watchers.add(watcher);
 
-    const initialItems = this.store.listInboxItems(inbox.inboxId, {
-      afterItemId: options.afterItemId,
-      includeAcked: options.includeAcked ?? false,
-    });
+    let initialItems: InboxItem[];
+    try {
+      initialItems = this.store.listInboxItems(inbox.inboxId, {
+        afterItemId: options.afterItemId,
+        includeAcked: options.includeAcked ?? false,
+      });
+    } catch (error) {
+      watchers.delete(watcher);
+      if (watchers.size === 0) {
+        this.inboxWatchers.delete(inboxId);
+      }
+      throw error;
+    }
+
     const initialItemIds = new Set(initialItems.map((item) => item.itemId));
 
     return {

--- a/src/service.ts
+++ b/src/service.ts
@@ -8,12 +8,14 @@ import {
   DeliveryRequest,
   Inbox,
   InboxItem,
+  InboxWatchEvent,
   RegisterSourceInput,
   RegisterSubscriptionInput,
   SourcePollResult,
   Subscription,
   SubscriptionPollResult,
   SubscriptionSource,
+  WatchInboxOptions,
 } from "./model";
 import { AgentInboxStore } from "./store";
 import { AdapterRegistry } from "./adapters";
@@ -52,12 +54,23 @@ interface ActivationPolicy {
   maxItems?: number;
 }
 
+interface InboxWatcher {
+  onItems(items: InboxItem[]): void;
+}
+
+export interface InboxWatchSession {
+  initialItems: InboxItem[];
+  start(): void;
+  close(): void;
+}
+
 export class AgentInboxService {
   private readonly backend: EventBusBackend;
   private readonly inFlightSubscriptions = new Set<string>();
   private readonly activationWindowMs: number;
   private readonly activationMaxItems: number;
   private readonly activationBuffers = new Map<string, ActivationBuffer>();
+  private readonly inboxWatchers = new Map<string, Set<InboxWatcher>>();
   private subscriptionInterval: NodeJS.Timeout | null = null;
   private stopping = false;
 
@@ -179,8 +192,78 @@ export class AgentInboxService {
     return this.store.listInboxes().map((inbox) => inbox.inboxId);
   }
 
-  listInboxItems(inboxId: string): InboxItem[] {
-    return this.store.listInboxItems(inboxId);
+  listInboxItems(inboxId: string, options?: WatchInboxOptions): InboxItem[] {
+    return this.store.listInboxItems(inboxId, options);
+  }
+
+  watchInbox(
+    inboxId: string,
+    options: WatchInboxOptions,
+    onEvent: (event: InboxWatchEvent) => void,
+  ): InboxWatchSession {
+    const inbox = this.store.getInbox(inboxId);
+    if (!inbox) {
+      throw new Error(`unknown inbox: ${inboxId}`);
+    }
+
+    const pendingItems: InboxItem[] = [];
+    let started = false;
+    const emitItems = (items: InboxItem[]) => {
+      if (items.length === 0) {
+        return;
+      }
+      onEvent({
+        event: "items",
+        inboxId,
+        items,
+      });
+    };
+
+    const watcher: InboxWatcher = {
+      onItems: (items) => {
+        if (!started) {
+          pendingItems.push(...items);
+          return;
+        }
+        emitItems(items);
+      },
+    };
+
+    let watchers = this.inboxWatchers.get(inboxId);
+    if (!watchers) {
+      watchers = new Set();
+      this.inboxWatchers.set(inboxId, watchers);
+    }
+    watchers.add(watcher);
+
+    const initialItems = this.store.listInboxItems(inbox.inboxId, {
+      afterItemId: options.afterItemId,
+      includeAcked: options.includeAcked ?? false,
+    });
+    const initialItemIds = new Set(initialItems.map((item) => item.itemId));
+
+    return {
+      initialItems,
+      start: () => {
+        if (started) {
+          return;
+        }
+        started = true;
+        const replayItems = pendingItems.filter((item) => !initialItemIds.has(item.itemId));
+        pendingItems.length = 0;
+        emitItems(replayItems);
+      },
+      close: () => {
+        const activeWatchers = this.inboxWatchers.get(inboxId);
+        if (!activeWatchers) {
+          return;
+        }
+        activeWatchers.delete(watcher);
+        if (activeWatchers.size === 0) {
+          this.inboxWatchers.delete(inboxId);
+        }
+      },
+    };
   }
 
   ackInboxItems(inboxId: string, itemIds: string[]): { acked: number } {
@@ -240,6 +323,7 @@ export class AgentInboxService {
       let matched = 0;
       let inboxItemsCreated = 0;
       let lastProcessedOffset: number | null = null;
+      const insertedItems: InboxItem[] = [];
       try {
         for (const event of batch.events) {
           lastProcessedOffset = event.offset;
@@ -265,6 +349,7 @@ export class AgentInboxService {
             continue;
           }
           inboxItemsCreated += 1;
+          insertedItems.push(item);
           this.enqueueActivation({
             agentId: subscription.agentId,
             inboxId: subscription.inboxId,
@@ -289,6 +374,9 @@ export class AgentInboxService {
           });
         }
       } catch (error) {
+        if (insertedItems.length > 0) {
+          this.notifyInboxWatchers(subscription.inboxId, insertedItems);
+        }
         if (lastProcessedOffset != null) {
           await this.backend.commit({
             consumerId: consumer.consumerId,
@@ -296,6 +384,10 @@ export class AgentInboxService {
           });
         }
         throw error;
+      }
+
+      if (insertedItems.length > 0) {
+        this.notifyInboxWatchers(subscription.inboxId, insertedItems);
       }
 
       if (lastProcessedOffset != null) {
@@ -387,6 +479,16 @@ export class AgentInboxService {
       } catch (error) {
         console.warn(`subscription poll failed for ${subscription.subscriptionId}:`, error);
       }
+    }
+  }
+
+  private notifyInboxWatchers(inboxId: string, items: InboxItem[]): void {
+    const watchers = this.inboxWatchers.get(inboxId);
+    if (!watchers || watchers.size === 0) {
+      return;
+    }
+    for (const watcher of watchers) {
+      watcher.onItems(items);
     }
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,6 +15,7 @@ import {
   DeliveryAttempt,
   Inbox,
   InboxItem,
+  ListInboxItemsOptions,
   Subscription,
   SubscriptionSource,
   SubscriptionStartPolicy,
@@ -624,10 +625,30 @@ export class AgentInboxStore {
     return inserted;
   }
 
-  listInboxItems(inboxId: string): InboxItem[] {
+  listInboxItems(inboxId: string, options?: ListInboxItemsOptions): InboxItem[] {
+    const includeAcked = options?.includeAcked ?? true;
+    const filters = ["inbox_id = ?"];
+    const params: Array<string | number | null> = [inboxId];
+
+    if (!includeAcked) {
+      filters.push("acked_at is null");
+    }
+
+    if (options?.afterItemId) {
+      const anchor = this.getOne(
+        "select occurred_at, item_id from inbox_items where inbox_id = ? and item_id = ?",
+        [inboxId, options.afterItemId],
+      );
+      if (!anchor) {
+        throw new Error(`unknown inbox item: ${options.afterItemId}`);
+      }
+      filters.push("((occurred_at > ?) or (occurred_at = ? and item_id > ?))");
+      params.push(String(anchor.occurred_at), String(anchor.occurred_at), String(anchor.item_id));
+    }
+
     const rows = this.getAll(
-      "select * from inbox_items where inbox_id = ? order by occurred_at asc, item_id asc",
-      [inboxId],
+      `select * from inbox_items where ${filters.join(" and ")} order by occurred_at asc, item_id asc`,
+      params,
     );
     return rows.map((row) => this.mapInboxItem(row));
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import initSqlJs, { Database, SqlJsStatic } from "sql.js";
+import initSqlJs, { type BindParams, Database, SqlJsStatic } from "sql.js";
 import type {
   ConsumerRecord,
   StreamEventRecord,
@@ -976,7 +976,7 @@ export class AgentInboxStore {
     return Number(row?.rowid ?? 0);
   }
 
-  private getOne(sql: string, params: unknown[] = []): Record<string, unknown> | undefined {
+  private getOne(sql: string, params: BindParams = []): Record<string, unknown> | undefined {
     const statement = this.db.prepare(sql);
     try {
       statement.bind(params);
@@ -989,7 +989,7 @@ export class AgentInboxStore {
     }
   }
 
-  private getAll(sql: string, params: unknown[] = []): Record<string, unknown>[] {
+  private getAll(sql: string, params: BindParams = []): Record<string, unknown>[] {
     const statement = this.db.prepare(sql);
     try {
       statement.bind(params);

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -8,7 +8,7 @@ import { AgentInboxStore } from "../src/store";
 import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { AdapterRegistry } from "../src/adapters";
 import { SqliteEventBusBackend } from "../src/backend";
-import { Activation } from "../src/model";
+import { Activation, InboxWatchEvent } from "../src/model";
 
 class RecordingActivationDispatcher extends ActivationDispatcher {
   public readonly calls: Array<{ target: string | null | undefined; activation: Activation }> = [];
@@ -78,6 +78,52 @@ test("shared source can route one stream event to multiple agent inboxes", async
     await service.stop();
     assert.equal(store.listActivations().length, 2);
     assert.equal(store.listSources().length, 1);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("watchInbox receives inserted items without auto-acking them", async () => {
+  const { store, service, dir } = await makeAsyncService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "fixture",
+      sourceKey: "watch-demo",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: "alpha",
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    const seenEvents: InboxWatchEvent[] = [];
+    const session = service.watchInbox(subscription.inboxId, {}, (event) => {
+      seenEvents.push(event);
+    });
+
+    assert.equal(session.initialItems.length, 0);
+    session.start();
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "evt-watch-1",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: { text: "watch me" },
+    });
+    const poll = await service.pollSubscription(subscription.subscriptionId);
+    assert.equal(poll.inboxItemsCreated, 1);
+    assert.equal(seenEvents.length, 1);
+    assert.equal(seenEvents[0].event, "items");
+
+    const items = service.listInboxItems(subscription.inboxId);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].ackedAt, null);
+
+    session.close();
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -231,6 +231,142 @@ test("e2e control plane can register fixture source, consume a subscription, and
   }
 });
 
+test("e2e control plane watch streams backlog and future inbox items over socket SSE", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-watch-home-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+
+      const sourceResponse = await client.request<{ sourceId: string }>("/sources/register", {
+        sourceType: "fixture",
+        sourceKey: "watch-demo",
+        config: {},
+      } satisfies RegisterSourceInput);
+      assert.equal(sourceResponse.statusCode, 200);
+
+      const subscriptionResponse = await client.request<{ subscriptionId: string; inboxId: string }>(
+        "/subscriptions/register",
+        {
+          agentId: "alpha",
+          sourceId: sourceResponse.data.sourceId,
+          startPolicy: "earliest",
+        } satisfies RegisterSubscriptionInput,
+      );
+      assert.equal(subscriptionResponse.statusCode, 200);
+
+      await client.request("/fixtures/emit", {
+        sourceId: sourceResponse.data.sourceId,
+        sourceNativeId: "evt-watch-1",
+        eventVariant: "message.created",
+        metadata: { channel: "engineering" },
+        rawPayload: { text: "first" },
+      });
+      await client.request<SubscriptionPollResult>(
+        `/subscriptions/${subscriptionResponse.data.subscriptionId}/poll`,
+        {},
+      );
+
+      const watch = client.watchInbox(subscriptionResponse.data.inboxId, {
+        heartbeatMs: 25,
+      })[Symbol.asyncIterator]();
+
+      const firstEvent = await waitForWatchItems(watch, 1_000, "timed out waiting for backlog watch event");
+      assert.equal(firstEvent.items.length, 1);
+      assert.equal(firstEvent.items[0].sourceNativeId, "evt-watch-1");
+      assert.equal(firstEvent.items[0].ackedAt, null);
+
+      await client.request("/fixtures/emit", {
+        sourceId: sourceResponse.data.sourceId,
+        sourceNativeId: "evt-watch-2",
+        eventVariant: "message.created",
+        metadata: { channel: "engineering" },
+        rawPayload: { text: "second" },
+      });
+      await client.request<SubscriptionPollResult>(
+        `/subscriptions/${subscriptionResponse.data.subscriptionId}/poll`,
+        {},
+      );
+
+      const secondEvent = await waitForWatchItems(watch, 1_000, "timed out waiting for future watch event");
+      assert.equal(secondEvent.items.length, 1);
+      assert.equal(secondEvent.items[0].sourceNativeId, "evt-watch-2");
+
+      await watch.return?.();
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("inbox reads return 404 when after_item_id is unknown", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-watch-invalid-home-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const sourceResponse = await client.request<{ sourceId: string }>("/sources/register", {
+        sourceType: "fixture",
+        sourceKey: "watch-invalid",
+        config: {},
+      } satisfies RegisterSourceInput);
+      const subscriptionResponse = await client.request<{ inboxId: string }>("/subscriptions/register", {
+        agentId: "alpha",
+        sourceId: sourceResponse.data.sourceId,
+      } satisfies RegisterSubscriptionInput);
+      const response = await client.request<{ error: string }>(
+        `/inboxes/${encodeURIComponent(subscriptionResponse.data.inboxId)}/items?after_item_id=missing`,
+        undefined,
+        "GET",
+      );
+      assert.equal(response.statusCode, 404);
+      assert.match(response.data.error, /unknown inbox item/);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 async function waitFor<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: NodeJS.Timeout | null = null;
   try {
@@ -243,6 +379,21 @@ async function waitFor<T>(promise: Promise<T>, timeoutMs: number, message: strin
   } finally {
     if (timer) {
       clearTimeout(timer);
+    }
+  }
+}
+
+async function waitForWatchItems(
+  iterator: AsyncIterator<unknown>,
+  timeoutMs: number,
+  message: string,
+): Promise<{ event: "items"; inboxId: string; items: InboxItem[] }> {
+  while (true) {
+    const next = await waitFor(iterator.next(), timeoutMs, message);
+    assert.equal(next.done, false);
+    const value = next.value as { event: string; inboxId: string; items?: InboxItem[] };
+    if (value.event === "items") {
+      return value as { event: "items"; inboxId: string; items: InboxItem[] };
     }
   }
 }


### PR DESCRIPTION
## Summary
- add an SSE-based `GET /inboxes/:id/watch` endpoint for long-lived inbox reads
- add socket/url watch support in `AgentInboxClient` and `agentinbox inbox watch` CLI
- push backlog first, then stream future inbox items without auto-acking them

## Testing
- npm test