### PR TITLE
Add programmable custom sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,20 @@ node dist/src/cli.js source add fixture demo
 node dist/src/cli.js subscription add alpha <source_id> --match-json '{"channel":"engineering"}'
 ```
 
+Create a programmable local event bus source and publish events into it:
+
+```bash
+node dist/src/cli.js source add custom project-alpha
+node dist/src/cli.js subscription add alpha <source_id> --match-json '{"channel":"engineering"}'
+node dist/src/cli.js source event <source_id> \
+  --native-id evt-1 \
+  --event message.created \
+  --metadata-json '{"channel":"engineering"}' \
+  --payload-json '{"text":"hello from a local producer"}'
+node dist/src/cli.js subscription poll <subscription_id>
+node dist/src/cli.js inbox read inbox_alpha
+```
+
 Subscriptions default to `activation_only`. For low-frequency flows, you can push the newly created inbox items directly in the activation webhook body:
 
 ```bash
@@ -244,7 +258,7 @@ node dist/src/cli.js subscription add alpha <source_id> --match-json '{"mentions
 node dist/src/cli.js source poll <source_id>
 ```
 
-Emit a fixture event, materialize it into an inbox, and inspect the result:
+Emit a fixture event for tests and local demos:
 
 ```bash
 node dist/src/cli.js fixture emit <source_id> --metadata-json '{"channel":"engineering"}' --payload-json '{"text":"hello"}'

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -49,6 +49,7 @@ class NoopDeliveryAdapter implements DeliveryAdapter {
 
 export class AdapterRegistry {
   private readonly fixtureSource = new NoopSourceAdapter("fixture");
+  private readonly customSource = new NoopSourceAdapter("custom");
   private readonly feishuSource: FeishuSourceRuntime;
   private readonly githubSource: GithubSourceRuntime;
   private readonly fixtureDelivery = new NoopDeliveryAdapter();
@@ -63,6 +64,9 @@ export class AdapterRegistry {
   sourceAdapterFor(type: SourceType): SourceAdapter {
     if (type === "fixture") {
       return this.fixtureSource;
+    }
+    if (type === "custom") {
+      return this.customSource;
     }
     if (type === "github_repo") {
       return this.githubSource;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,23 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "source" && args[1] === "event") {
+    const sourceId = args[2];
+    const sourceNativeId = takeFlagValue(args, "--native-id");
+    const eventVariant = takeFlagValue(args, "--event");
+    if (!sourceId || !sourceNativeId || !eventVariant) {
+      throw new Error("usage: agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]");
+    }
+    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}/events`, {
+      sourceNativeId,
+      eventVariant,
+      occurredAt: takeFlagValue(args, "--occurred-at") ?? undefined,
+      metadata: parseJsonArg(takeFlagValue(args, "--metadata-json")),
+      rawPayload: parseJsonArg(takeFlagValue(args, "--payload-json")),
+    });
+    return;
+  }
+
   if (command === "subscription" && args[1] === "add") {
     const [agentId, sourceId] = args.slice(2, 4);
     if (!agentId || !sourceId) {
@@ -255,6 +272,7 @@ Commands:
   agentinbox serve --port 4747 [--state ~/.agentinbox/agentinbox.sqlite]
   agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]
   agentinbox source poll <sourceId>
+  agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]
   agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
   agentinbox subscription poll <subscriptionId>
   agentinbox inbox list

--- a/src/http.ts
+++ b/src/http.ts
@@ -66,7 +66,26 @@ export function createServer(service: AgentInboxService): http.Server {
       if (req.method === "POST" && sourceEventsMatch) {
         const sourceId = decodeURIComponent(sourceEventsMatch[1]);
         const body = await readJson(req);
-        const result = await service.appendSourceEventByCaller(sourceId, body as never);
+        const sourceNativeId = String(body.sourceNativeId ?? "");
+        const eventVariant = String(body.eventVariant ?? "");
+        if (!sourceNativeId) {
+          send(res, 400, { error: "sources/events requires sourceNativeId" });
+          return;
+        }
+        if (!eventVariant) {
+          send(res, 400, { error: "sources/events requires eventVariant" });
+          return;
+        }
+        const result = await service.appendSourceEventByCaller(sourceId, {
+          sourceNativeId,
+          eventVariant,
+          occurredAt: body.occurredAt ? String(body.occurredAt) : undefined,
+          metadata: asObject(body.metadata),
+          rawPayload: asObject(body.rawPayload),
+          deliveryHandle: body.deliveryHandle && typeof body.deliveryHandle === "object"
+            ? body.deliveryHandle as never
+            : undefined,
+        });
         send(res, 200, result);
         return;
       }
@@ -88,11 +107,22 @@ export function createServer(service: AgentInboxService): http.Server {
         const body = await readJson(req);
         const sourceId = String(body.sourceId ?? "");
         if (!sourceId) {
-          throw new Error("fixtures/emit requires sourceId");
+          send(res, 400, { error: "fixtures/emit requires sourceId" });
+          return;
+        }
+        const sourceNativeId = String(body.sourceNativeId ?? "");
+        if (!sourceNativeId) {
+          send(res, 400, { error: "fixtures/emit requires sourceNativeId" });
+          return;
+        }
+        const eventVariant = String(body.eventVariant ?? "");
+        if (!eventVariant) {
+          send(res, 400, { error: "fixtures/emit requires eventVariant" });
+          return;
         }
         const result = await service.appendFixtureEvent(sourceId, {
-          sourceNativeId: String(body.sourceNativeId ?? ""),
-          eventVariant: String(body.eventVariant ?? ""),
+          sourceNativeId,
+          eventVariant,
           occurredAt: body.occurredAt ? String(body.occurredAt) : undefined,
           metadata: asObject(body.metadata),
           rawPayload: asObject(body.rawPayload),

--- a/src/http.ts
+++ b/src/http.ts
@@ -62,6 +62,15 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
+      const sourceEventsMatch = url.pathname.match(/^\/sources\/([^/]+)\/events$/);
+      if (req.method === "POST" && sourceEventsMatch) {
+        const sourceId = decodeURIComponent(sourceEventsMatch[1]);
+        const body = await readJson(req);
+        const result = await service.appendSourceEventByCaller(sourceId, body as never);
+        send(res, 200, result);
+        return;
+      }
+
       if (req.method === "POST" && url.pathname === "/subscriptions/register") {
         const subscription = await service.registerSubscription(await readJson(req) as never);
         send(res, 200, subscription);
@@ -76,7 +85,21 @@ export function createServer(service: AgentInboxService): http.Server {
       }
 
       if (req.method === "POST" && url.pathname === "/fixtures/emit") {
-        const result = await service.appendSourceEvent(await readJson(req) as never);
+        const body = await readJson(req);
+        const sourceId = String(body.sourceId ?? "");
+        if (!sourceId) {
+          throw new Error("fixtures/emit requires sourceId");
+        }
+        const result = await service.appendFixtureEvent(sourceId, {
+          sourceNativeId: String(body.sourceNativeId ?? ""),
+          eventVariant: String(body.eventVariant ?? ""),
+          occurredAt: body.occurredAt ? String(body.occurredAt) : undefined,
+          metadata: asObject(body.metadata),
+          rawPayload: asObject(body.rawPayload),
+          deliveryHandle: body.deliveryHandle && typeof body.deliveryHandle === "object"
+            ? body.deliveryHandle as never
+            : undefined,
+        });
         send(res, 200, result);
         return;
       }
@@ -163,6 +186,10 @@ export function createServer(service: AgentInboxService): http.Server {
       const message = error instanceof Error ? error.message : String(error);
       if (message.startsWith("unknown ")) {
         send(res, 404, { error: message });
+        return;
+      }
+      if (message.startsWith("manual append is not supported") || message.startsWith("fixtures/emit requires")) {
+        send(res, 400, { error: message });
         return;
       }
       if (message.startsWith("expected positive integer")) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-export type SourceType = "fixture" | "github_repo" | "feishu_bot";
+export type SourceType = "fixture" | "custom" | "github_repo" | "feishu_bot";
 
 export type SubscriptionStartPolicy = "latest" | "earliest" | "at_offset" | "at_time";
 export type ActivationMode = "activation_only" | "activation_with_items";

--- a/src/service.ts
+++ b/src/service.ts
@@ -196,7 +196,7 @@ export class AgentInboxService {
     if (!source) {
       throw new Error(`unknown source: ${sourceId}`);
     }
-    if (source.sourceType !== "custom" && source.sourceType !== "fixture") {
+    if (source.sourceType !== "custom") {
       throw new Error(`manual append is not supported for source type: ${source.sourceType}`);
     }
     return this.appendSourceEvent({

--- a/src/service.ts
+++ b/src/service.ts
@@ -188,6 +188,50 @@ export class AgentInboxService {
     return toAppendResult(result);
   }
 
+  async appendSourceEventByCaller(
+    sourceId: string,
+    input: Omit<AppendSourceEventInput, "sourceId">,
+  ): Promise<AppendSourceEventResult> {
+    const source = this.store.getSource(sourceId);
+    if (!source) {
+      throw new Error(`unknown source: ${sourceId}`);
+    }
+    if (source.sourceType !== "custom" && source.sourceType !== "fixture") {
+      throw new Error(`manual append is not supported for source type: ${source.sourceType}`);
+    }
+    return this.appendSourceEvent({
+      sourceId,
+      sourceNativeId: input.sourceNativeId,
+      eventVariant: input.eventVariant,
+      occurredAt: input.occurredAt,
+      metadata: input.metadata,
+      rawPayload: input.rawPayload,
+      deliveryHandle: input.deliveryHandle,
+    });
+  }
+
+  async appendFixtureEvent(
+    sourceId: string,
+    input: Omit<AppendSourceEventInput, "sourceId">,
+  ): Promise<AppendSourceEventResult> {
+    const source = this.store.getSource(sourceId);
+    if (!source) {
+      throw new Error(`unknown source: ${sourceId}`);
+    }
+    if (source.sourceType !== "fixture") {
+      throw new Error(`fixtures/emit requires fixture source, received: ${source.sourceType}`);
+    }
+    return this.appendSourceEvent({
+      sourceId,
+      sourceNativeId: input.sourceNativeId,
+      eventVariant: input.eventVariant,
+      occurredAt: input.occurredAt,
+      metadata: input.metadata,
+      rawPayload: input.rawPayload,
+      deliveryHandle: input.deliveryHandle,
+    });
+  }
+
   listInboxIds(): string[] {
     return this.store.listInboxes().map((inbox) => inbox.inboxId);
   }

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -8,7 +8,8 @@ import { AgentInboxStore } from "../src/store";
 import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { AdapterRegistry } from "../src/adapters";
 import { SqliteEventBusBackend } from "../src/backend";
-import { Activation, InboxWatchEvent } from "../src/model";
+import { Activation, InboxWatchEvent, SubscriptionSource } from "../src/model";
+import { nowIso } from "../src/util";
 
 class RecordingActivationDispatcher extends ActivationDispatcher {
   public readonly calls: Array<{ target: string | null | undefined; activation: Activation }> = [];
@@ -303,11 +304,18 @@ test("registerSubscription rejects unsupported activation modes", async () => {
 test("manual append is rejected for adapter-managed sources", async () => {
   const { store, service, dir } = await makeAsyncService();
   try {
-    const githubSource = await service.registerSource({
+    const githubSource: SubscriptionSource = {
+      sourceId: "src_github_manual_append",
       sourceType: "github_repo",
       sourceKey: "holon-run/agentinbox",
+      configRef: null,
       config: { owner: "holon-run", repo: "agentinbox" },
-    });
+      status: "active",
+      checkpoint: null,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    store.insertSource(githubSource);
 
     await assert.rejects(
       () => service.appendSourceEventByCaller(githubSource.sourceId, {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -85,6 +85,40 @@ test("shared source can route one stream event to multiple agent inboxes", async
   }
 });
 
+test("custom source can act as a programmable event bus source", async () => {
+  const { store, service, dir } = await makeAsyncService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "custom",
+      sourceKey: "project-alpha",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: "alpha",
+      sourceId: source.sourceId,
+      matchRules: { channel: "engineering" },
+      startPolicy: "earliest",
+    });
+
+    const appendResult = await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "custom-evt-1",
+      eventVariant: "message.created",
+      metadata: { channel: "engineering" },
+      rawPayload: { text: "hello from custom source" },
+    });
+    assert.equal(appendResult.appended, 1);
+
+    const pollResult = await service.pollSubscription(subscription.subscriptionId);
+    assert.equal(pollResult.inboxItemsCreated, 1);
+    assert.equal(service.listInboxItems(subscription.inboxId).length, 1);
+    assert.equal(service.listInboxItems(subscription.inboxId)[0].sourceNativeId, "custom-evt-1");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("watchInbox receives inserted items without auto-acking them", async () => {
   const { store, service, dir } = await makeAsyncService();
   try {
@@ -258,6 +292,31 @@ test("registerSubscription rejects unsupported activation modes", async () => {
         activationMode: "push_everything" as never,
       }),
       /unsupported activation mode: push_everything/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("manual append is rejected for adapter-managed sources", async () => {
+  const { store, service, dir } = await makeAsyncService();
+  try {
+    const githubSource = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox" },
+    });
+
+    await assert.rejects(
+      () => service.appendSourceEventByCaller(githubSource.sourceId, {
+        sourceNativeId: "evt-1",
+        eventVariant: "message.created",
+        metadata: {},
+        rawPayload: {},
+      }),
+      /manual append is not supported for source type: github_repo/,
     );
   } finally {
     await service.stop();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -11,7 +11,8 @@ import { createServer } from "../src/http";
 import { AgentInboxClient } from "../src/client";
 import { startControlServer } from "../src/control_server";
 import { DEFAULT_AGENTINBOX_PORT, resolveClientTransport, resolveServeConfig } from "../src/paths";
-import { Activation, InboxItem, RegisterSourceInput, RegisterSubscriptionInput, SubscriptionPollResult } from "../src/model";
+import { Activation, InboxItem, RegisterSourceInput, RegisterSubscriptionInput, SubscriptionPollResult, SubscriptionSource } from "../src/model";
+import { nowIso } from "../src/util";
 
 test("resolveServeConfig derives home, db, and socket defaults from AGENTINBOX_HOME", () => {
   const homeDir = path.join(os.tmpdir(), `agentinbox-home-${Date.now()}`);
@@ -452,6 +453,18 @@ test("manual append endpoint rejects adapter-managed sources", async () => {
   const dbPath = path.join(homeDir, "agentinbox.sqlite");
 
   const store = await AgentInboxStore.open(dbPath);
+  const githubSource: SubscriptionSource = {
+    sourceId: "src_github_manual_append",
+    sourceType: "github_repo",
+    sourceKey: "holon-run/agentinbox",
+    configRef: null,
+    config: { owner: "holon-run", repo: "agentinbox" },
+    status: "active",
+    checkpoint: null,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  };
+  store.insertSource(githubSource);
   let service: AgentInboxService;
   const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
   service = new AgentInboxService(store, adapters);
@@ -468,14 +481,8 @@ test("manual append endpoint rejects adapter-managed sources", async () => {
         socketPath,
         source: "flag",
       });
-      const sourceResponse = await client.request<{ sourceId: string }>("/sources/register", {
-        sourceType: "github_repo",
-        sourceKey: "holon-run/agentinbox",
-        config: { owner: "holon-run", repo: "agentinbox" },
-      } satisfies RegisterSourceInput);
-
       const response = await client.request<{ error: string }>(
-        `/sources/${encodeURIComponent(sourceResponse.data.sourceId)}/events`,
+        `/sources/${encodeURIComponent(githubSource.sourceId)}/events`,
         {
           sourceNativeId: "evt-1",
           eventVariant: "message.created",

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -231,6 +231,85 @@ test("e2e control plane can register fixture source, consume a subscription, and
   }
 });
 
+test("e2e control plane can append events through a custom source", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-custom-source-home-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+
+      const sourceResponse = await client.request<{ sourceId: string; sourceType: string }>("/sources/register", {
+        sourceType: "custom",
+        sourceKey: "project-alpha",
+        config: {},
+      } satisfies RegisterSourceInput);
+      assert.equal(sourceResponse.statusCode, 200);
+      assert.equal(sourceResponse.data.sourceType, "custom");
+
+      const subscriptionResponse = await client.request<{ subscriptionId: string; inboxId: string }>(
+        "/subscriptions/register",
+        {
+          agentId: "alpha",
+          sourceId: sourceResponse.data.sourceId,
+          matchRules: { channel: "engineering" },
+          startPolicy: "earliest",
+        } satisfies RegisterSubscriptionInput,
+      );
+      assert.equal(subscriptionResponse.statusCode, 200);
+
+      const appendResponse = await client.request<{ appended: number; deduped: number }>(
+        `/sources/${encodeURIComponent(sourceResponse.data.sourceId)}/events`,
+        {
+          sourceNativeId: "custom-evt-1",
+          eventVariant: "message.created",
+          metadata: { channel: "engineering" },
+          rawPayload: { text: "hello from custom source" },
+        },
+      );
+      assert.equal(appendResponse.statusCode, 200);
+      assert.equal(appendResponse.data.appended, 1);
+
+      const pollResponse = await client.request<SubscriptionPollResult>(
+        `/subscriptions/${subscriptionResponse.data.subscriptionId}/poll`,
+        {},
+      );
+      assert.equal(pollResponse.statusCode, 200);
+      assert.equal(pollResponse.data.inboxItemsCreated, 1);
+
+      const inboxResponse = await client.request<{ items: InboxItem[] }>(
+        `/inboxes/${subscriptionResponse.data.inboxId}/items`,
+        undefined,
+        "GET",
+      );
+      assert.equal(inboxResponse.statusCode, 200);
+      assert.equal(inboxResponse.data.items.length, 1);
+      assert.equal(inboxResponse.data.items[0].sourceNativeId, "custom-evt-1");
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("e2e control plane watch streams backlog and future inbox items over socket SSE", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-watch-home-"));
   const socketPath = path.join(homeDir, "agentinbox.sock");
@@ -357,6 +436,55 @@ test("inbox reads return 404 when after_item_id is unknown", async () => {
       );
       assert.equal(response.statusCode, 404);
       assert.match(response.data.error, /unknown inbox item/);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("manual append endpoint rejects adapter-managed sources", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-manual-append-home-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const sourceResponse = await client.request<{ sourceId: string }>("/sources/register", {
+        sourceType: "github_repo",
+        sourceKey: "holon-run/agentinbox",
+        config: { owner: "holon-run", repo: "agentinbox" },
+      } satisfies RegisterSourceInput);
+
+      const response = await client.request<{ error: string }>(
+        `/sources/${encodeURIComponent(sourceResponse.data.sourceId)}/events`,
+        {
+          sourceNativeId: "evt-1",
+          eventVariant: "message.created",
+          metadata: {},
+          rawPayload: {},
+        },
+      );
+      assert.equal(response.statusCode, 400);
+      assert.match(response.data.error, /manual append is not supported for source type: github_repo/);
     } finally {
       await started.close();
     }


### PR DESCRIPTION
## Summary
- add a formal `custom` source type so local agents can use AgentInbox as a programmable event bus
- add `POST /sources/:id/events` and `agentinbox source event` for appending events to custom sources
- keep `fixture` as a test-only path and reject manual appends to adapter-managed sources like GitHub and Feishu

## Testing
- npm test