### PR TITLE
Add GitHub repo CI polling source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   node-tests:

--- a/README.md
+++ b/README.md
@@ -249,6 +249,15 @@ node dist/src/cli.js subscription add alpha <source_id> --match-json '{"mentions
 node dist/src/cli.js source poll <source_id>
 ```
 
+Register a GitHub repo CI source backed by GitHub Actions workflow run polling:
+
+```bash
+node dist/src/cli.js source add github_repo_ci holon-run/agentinbox \
+  --config-json '{"owner":"holon-run","repo":"agentinbox","uxcAuth":"github-default","pollIntervalSecs":30,"perPage":20}'
+node dist/src/cli.js subscription add alpha <source_id> --match-json '{"conclusion":"failure","headBranch":"main"}'
+node dist/src/cli.js source poll <source_id>
+```
+
 Register a Feishu bot source backed by `uxc` long-connection subscription:
 
 ```bash

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -9,6 +9,7 @@ import {
 import { AgentInboxStore } from "./store";
 import { FeishuDeliveryAdapter, FeishuSourceRuntime } from "./sources/feishu";
 import { GithubDeliveryAdapter, GithubSourceRuntime } from "./sources/github";
+import { GithubCiSourceRuntime } from "./sources/github_ci";
 
 export interface SourceAdapter {
   ensureSource(source: SubscriptionSource): Promise<void>;
@@ -52,6 +53,7 @@ export class AdapterRegistry {
   private readonly customSource = new NoopSourceAdapter("custom");
   private readonly feishuSource: FeishuSourceRuntime;
   private readonly githubSource: GithubSourceRuntime;
+  private readonly githubCiSource: GithubCiSourceRuntime;
   private readonly fixtureDelivery = new NoopDeliveryAdapter();
   private readonly feishuDelivery = new FeishuDeliveryAdapter();
   private readonly githubDelivery = new GithubDeliveryAdapter();
@@ -59,6 +61,7 @@ export class AdapterRegistry {
   constructor(store: AgentInboxStore, appendSourceEvent: (input: AppendSourceEventInput) => Promise<{ appended: number; deduped: number }>) {
     this.feishuSource = new FeishuSourceRuntime(store, appendSourceEvent);
     this.githubSource = new GithubSourceRuntime(store, appendSourceEvent);
+    this.githubCiSource = new GithubCiSourceRuntime(store, appendSourceEvent);
   }
 
   sourceAdapterFor(type: SourceType): SourceAdapter {
@@ -70,6 +73,9 @@ export class AdapterRegistry {
     }
     if (type === "github_repo") {
       return this.githubSource;
+    }
+    if (type === "github_repo_ci") {
+      return this.githubCiSource;
     }
     if (type === "feishu_bot") {
       return this.feishuSource;
@@ -93,11 +99,13 @@ export class AdapterRegistry {
   async start(): Promise<void> {
     await this.feishuSource.start?.();
     await this.githubSource.start?.();
+    await this.githubCiSource.start?.();
   }
 
   async stop(): Promise<void> {
     await this.feishuSource.stop?.();
     await this.githubSource.stop?.();
+    await this.githubCiSource.stop?.();
   }
 
   async pollSource(source: SubscriptionSource): Promise<SourcePollResult> {
@@ -119,6 +127,7 @@ export class AdapterRegistry {
     return {
       feishu: this.feishuSource.status?.() ?? {},
       github: this.githubSource.status?.() ?? {},
+      githubCi: this.githubCiSource.status?.() ?? {},
     };
   }
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,7 +1,7 @@
 import http from "node:http";
 import { AgentInboxService } from "./service";
 import { asObject, jsonResponse } from "./util";
-import { WatchInboxOptions } from "./model";
+import { DeliveryHandle, WatchInboxOptions } from "./model";
 
 async function readJson(req: http.IncomingMessage): Promise<Record<string, unknown>> {
   const chunks: Buffer[] = [];
@@ -66,8 +66,8 @@ export function createServer(service: AgentInboxService): http.Server {
       if (req.method === "POST" && sourceEventsMatch) {
         const sourceId = decodeURIComponent(sourceEventsMatch[1]);
         const body = await readJson(req);
-        const sourceNativeId = String(body.sourceNativeId ?? "");
-        const eventVariant = String(body.eventVariant ?? "");
+        const sourceNativeId = parseRequiredString(body.sourceNativeId, "sources/events requires sourceNativeId");
+        const eventVariant = parseRequiredString(body.eventVariant, "sources/events requires eventVariant");
         if (!sourceNativeId) {
           send(res, 400, { error: "sources/events requires sourceNativeId" });
           return;
@@ -79,12 +79,10 @@ export function createServer(service: AgentInboxService): http.Server {
         const result = await service.appendSourceEventByCaller(sourceId, {
           sourceNativeId,
           eventVariant,
-          occurredAt: body.occurredAt ? String(body.occurredAt) : undefined,
+          occurredAt: parseOptionalString(body.occurredAt),
           metadata: asObject(body.metadata),
           rawPayload: asObject(body.rawPayload),
-          deliveryHandle: body.deliveryHandle && typeof body.deliveryHandle === "object"
-            ? body.deliveryHandle as never
-            : undefined,
+          deliveryHandle: parseOptionalDeliveryHandle(body.deliveryHandle),
         });
         send(res, 200, result);
         return;
@@ -105,17 +103,17 @@ export function createServer(service: AgentInboxService): http.Server {
 
       if (req.method === "POST" && url.pathname === "/fixtures/emit") {
         const body = await readJson(req);
-        const sourceId = String(body.sourceId ?? "");
+        const sourceId = parseRequiredString(body.sourceId, "fixtures/emit requires sourceId");
         if (!sourceId) {
           send(res, 400, { error: "fixtures/emit requires sourceId" });
           return;
         }
-        const sourceNativeId = String(body.sourceNativeId ?? "");
+        const sourceNativeId = parseRequiredString(body.sourceNativeId, "fixtures/emit requires sourceNativeId");
         if (!sourceNativeId) {
           send(res, 400, { error: "fixtures/emit requires sourceNativeId" });
           return;
         }
-        const eventVariant = String(body.eventVariant ?? "");
+        const eventVariant = parseRequiredString(body.eventVariant, "fixtures/emit requires eventVariant");
         if (!eventVariant) {
           send(res, 400, { error: "fixtures/emit requires eventVariant" });
           return;
@@ -123,12 +121,10 @@ export function createServer(service: AgentInboxService): http.Server {
         const result = await service.appendFixtureEvent(sourceId, {
           sourceNativeId,
           eventVariant,
-          occurredAt: body.occurredAt ? String(body.occurredAt) : undefined,
+          occurredAt: parseOptionalString(body.occurredAt),
           metadata: asObject(body.metadata),
           rawPayload: asObject(body.rawPayload),
-          deliveryHandle: body.deliveryHandle && typeof body.deliveryHandle === "object"
-            ? body.deliveryHandle as never
-            : undefined,
+          deliveryHandle: parseOptionalDeliveryHandle(body.deliveryHandle),
         });
         send(res, 200, result);
         return;
@@ -218,7 +214,12 @@ export function createServer(service: AgentInboxService): http.Server {
         send(res, 404, { error: message });
         return;
       }
-      if (message.startsWith("manual append is not supported") || message.startsWith("fixtures/emit requires")) {
+      if (
+        message.startsWith("manual append is not supported") ||
+        message.startsWith("fixtures/emit requires") ||
+        message.startsWith("sources/events requires") ||
+        message.startsWith("deliveryHandle requires")
+      ) {
         send(res, 400, { error: message });
         return;
       }
@@ -240,4 +241,40 @@ function parsePositiveInteger(value: string | null): number | undefined {
     throw new Error(`expected positive integer, received ${value}`);
   }
   return parsed;
+}
+
+function parseRequiredString(value: unknown, _errorMessage: string): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : "";
+}
+
+function parseOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseOptionalDeliveryHandle(value: unknown): DeliveryHandle | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const provider = parseOptionalString(record.provider);
+  const surface = parseOptionalString(record.surface);
+  const targetRef = parseOptionalString(record.targetRef);
+  if (!provider || !surface || !targetRef) {
+    throw new Error("deliveryHandle requires provider, surface, and targetRef");
+  }
+  return {
+    provider,
+    surface,
+    targetRef,
+    threadRef: parseOptionalString(record.threadRef) ?? null,
+    replyMode: parseOptionalString(record.replyMode) ?? null,
+  };
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-export type SourceType = "fixture" | "custom" | "github_repo" | "feishu_bot";
+export type SourceType = "fixture" | "custom" | "github_repo" | "github_repo_ci" | "feishu_bot";
 
 export type SubscriptionStartPolicy = "latest" | "earliest" | "at_offset" | "at_time";
 export type ActivationMode = "activation_only" | "activation_with_items";

--- a/src/sources/github_ci.ts
+++ b/src/sources/github_ci.ts
@@ -1,0 +1,355 @@
+import { UxcDaemonClient } from "@holon-run/uxc-daemon-client";
+import { AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "../model";
+import { AgentInboxStore } from "../store";
+
+const GITHUB_ENDPOINT = "https://api.github.com";
+const DEFAULT_POLL_INTERVAL_SECS = 30;
+const DEFAULT_PER_PAGE = 20;
+const MAX_SEEN_KEYS = 512;
+
+export interface GithubCiSourceConfig {
+  owner: string;
+  repo: string;
+  uxcAuth?: string;
+  pollIntervalSecs?: number;
+  perPage?: number;
+  eventFilter?: string;
+  branch?: string;
+  statusFilter?: string;
+}
+
+interface GithubCiSourceCheckpoint {
+  lastSeenUpdatedAt?: string;
+  seenRunKeys?: string[];
+  lastEventAt?: string;
+  lastError?: string;
+}
+
+interface WorkflowRunListResponse {
+  workflow_runs?: unknown[];
+}
+
+interface GithubActionsLikeClient {
+  call(args: {
+    endpoint: string;
+    operation: string;
+    payload?: Record<string, unknown>;
+    options?: { auth?: string };
+  }): Promise<{ data: unknown }>;
+}
+
+export class GithubActionsUxcClient {
+  constructor(private readonly client: GithubActionsLikeClient = new UxcDaemonClient({ env: process.env })) {}
+
+  async listWorkflowRuns(config: GithubCiSourceConfig): Promise<Record<string, unknown>[]> {
+    const payload: Record<string, unknown> = {
+      owner: config.owner,
+      repo: config.repo,
+      per_page: config.perPage ?? DEFAULT_PER_PAGE,
+    };
+    if (config.eventFilter) {
+      payload.event = config.eventFilter;
+    }
+    if (config.branch) {
+      payload.branch = config.branch;
+    }
+    if (config.statusFilter) {
+      payload.status = config.statusFilter;
+    }
+    const response = await this.client.call({
+      endpoint: GITHUB_ENDPOINT,
+      operation: "get:/repos/{owner}/{repo}/actions/runs",
+      payload,
+      options: { auth: config.uxcAuth },
+    });
+    const data = asRecord(response.data) as WorkflowRunListResponse;
+    return Array.isArray(data.workflow_runs)
+      ? data.workflow_runs.map((value) => asRecord(value)).filter((value) => Object.keys(value).length > 0)
+      : [];
+  }
+}
+
+export class GithubCiSourceRuntime {
+  private readonly client: GithubActionsUxcClient;
+  private interval: NodeJS.Timeout | null = null;
+  private readonly inFlight = new Set<string>();
+  private readonly lastPollAt = new Map<string, number>();
+
+  constructor(
+    private readonly store: AgentInboxStore,
+    private readonly appendSourceEvent: (input: AppendSourceEventInput) => Promise<{ appended: number; deduped: number }>,
+    client?: GithubActionsUxcClient,
+  ) {
+    this.client = client ?? new GithubActionsUxcClient();
+  }
+
+  async ensureSource(source: SubscriptionSource): Promise<void> {
+    if (source.sourceType !== "github_repo_ci") {
+      return;
+    }
+    const checkpoint = parseGithubCiCheckpoint(source.checkpoint);
+    this.store.updateSourceRuntime(source.sourceId, {
+      status: "active",
+      checkpoint: JSON.stringify(checkpoint),
+    });
+  }
+
+  async start(): Promise<void> {
+    if (this.interval) {
+      return;
+    }
+    this.interval = setInterval(() => {
+      void this.syncAll();
+    }, 2_000);
+    await this.syncAll();
+  }
+
+  async stop(): Promise<void> {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  async pollSource(sourceId: string): Promise<SourcePollResult> {
+    return this.syncSource(sourceId, true);
+  }
+
+  status(): Record<string, unknown> {
+    return {
+      activeSourceIds: Array.from(this.inFlight.values()).sort(),
+    };
+  }
+
+  private async syncAll(): Promise<void> {
+    const sources = this.store.listSources().filter((source) => source.sourceType === "github_repo_ci" && source.status === "active");
+    for (const source of sources) {
+      await this.syncSource(source.sourceId, false);
+    }
+  }
+
+  private async syncSource(sourceId: string, force: boolean): Promise<SourcePollResult> {
+    if (this.inFlight.has(sourceId)) {
+      return {
+        sourceId,
+        sourceType: "github_repo_ci",
+        appended: 0,
+        deduped: 0,
+        eventsRead: 0,
+        note: "source sync already in flight",
+      };
+    }
+    this.inFlight.add(sourceId);
+    try {
+      const source = this.store.getSource(sourceId);
+      if (!source) {
+        throw new Error(`unknown source: ${sourceId}`);
+      }
+      const config = parseGithubCiSourceConfig(source);
+      if (!force) {
+        const lastPollAt = this.lastPollAt.get(sourceId) ?? 0;
+        const pollIntervalMs = (config.pollIntervalSecs ?? DEFAULT_POLL_INTERVAL_SECS) * 1000;
+        if (Date.now() - lastPollAt < pollIntervalMs) {
+          return {
+            sourceId,
+            sourceType: "github_repo_ci",
+            appended: 0,
+            deduped: 0,
+            eventsRead: 0,
+            note: "poll interval not elapsed",
+          };
+        }
+      }
+      this.lastPollAt.set(sourceId, Date.now());
+      const checkpoint = parseGithubCiCheckpoint(source.checkpoint);
+      const runs = await this.client.listWorkflowRuns(config);
+      let appended = 0;
+      let deduped = 0;
+      let lastSeenUpdatedAt: string | undefined = checkpoint.lastSeenUpdatedAt ?? undefined;
+      const seenKeys = new Set<string>(checkpoint.seenRunKeys ?? []);
+
+      for (const run of runs.slice().reverse()) {
+        const normalized = normalizeGithubWorkflowRunEvent(source, config, run);
+        if (!normalized) {
+          continue;
+        }
+        const eventUpdatedAt = normalized.metadata?.updatedAt;
+        const runKey = `${normalized.sourceNativeId}:${normalized.eventVariant}`;
+        const shouldProcess =
+          !lastSeenUpdatedAt ||
+          (typeof eventUpdatedAt === "string" && eventUpdatedAt > lastSeenUpdatedAt) ||
+          !seenKeys.has(runKey);
+        if (!shouldProcess) {
+          continue;
+        }
+        const result = await this.appendSourceEvent(normalized);
+        appended += result.appended;
+        deduped += result.deduped;
+        seenKeys.add(runKey);
+        if (typeof eventUpdatedAt === "string" && (!lastSeenUpdatedAt || eventUpdatedAt >= lastSeenUpdatedAt)) {
+          lastSeenUpdatedAt = eventUpdatedAt;
+        }
+      }
+
+      this.store.updateSourceRuntime(sourceId, {
+        status: "active",
+        checkpoint: JSON.stringify({
+          lastSeenUpdatedAt,
+          seenRunKeys: Array.from(seenKeys).slice(-MAX_SEEN_KEYS),
+          lastEventAt: new Date().toISOString(),
+          lastError: undefined,
+        } satisfies GithubCiSourceCheckpoint),
+      });
+
+      return {
+        sourceId,
+        sourceType: "github_repo_ci",
+        appended,
+        deduped,
+        eventsRead: runs.length,
+        note: `workflow runs fetched=${runs.length}`,
+      };
+    } catch (error) {
+      const source = this.store.getSource(sourceId);
+      if (source) {
+        const checkpoint = parseGithubCiCheckpoint(source.checkpoint);
+        this.store.updateSourceRuntime(sourceId, {
+          status: "error",
+          checkpoint: JSON.stringify({
+            ...checkpoint,
+            lastError: error instanceof Error ? error.message : String(error),
+          }),
+        });
+      }
+      throw error;
+    } finally {
+      this.inFlight.delete(sourceId);
+    }
+  }
+}
+
+export function normalizeGithubWorkflowRunEvent(
+  source: SubscriptionSource,
+  config: GithubCiSourceConfig,
+  raw: unknown,
+): AppendSourceEventInput | null {
+  const run = asRecord(raw);
+  const runId = asNumber(run.id);
+  if (!runId) {
+    return null;
+  }
+  const status = asString(run.status) ?? "unknown";
+  const conclusion = asString(run.conclusion);
+  const variant = conclusion && status === "completed"
+    ? `workflow_run.${status}.${conclusion}`
+    : `workflow_run.${status}`;
+  const actor = asRecord(run.actor);
+  const headCommit = asRecord(run.head_commit);
+
+  return {
+    sourceId: source.sourceId,
+    sourceNativeId: `workflow_run:${runId}`,
+    eventVariant: variant,
+    occurredAt: asString(run.updated_at) ?? asString(run.created_at) ?? new Date().toISOString(),
+    metadata: {
+      provider: "github",
+      owner: config.owner,
+      repo: config.repo,
+      repoFullName: `${config.owner}/${config.repo}`,
+      workflowRunId: runId,
+      workflowId: asNumber(run.workflow_id),
+      name: asString(run.name),
+      displayTitle: asString(run.display_title),
+      status,
+      conclusion,
+      event: asString(run.event),
+      headSha: asString(run.head_sha),
+      headBranch: asString(run.head_branch),
+      runNumber: asNumber(run.run_number),
+      runAttempt: asNumber(run.run_attempt),
+      actor: asString(actor.login),
+      htmlUrl: asString(run.html_url),
+      createdAt: asString(run.created_at),
+      updatedAt: asString(run.updated_at),
+      commitMessage: asString(headCommit.message),
+    },
+    rawPayload: {
+      id: runId,
+      workflow_id: asNumber(run.workflow_id),
+      name: asString(run.name),
+      display_title: asString(run.display_title),
+      status,
+      conclusion,
+      event: asString(run.event),
+      head_sha: asString(run.head_sha),
+      head_branch: asString(run.head_branch),
+      run_number: asNumber(run.run_number),
+      run_attempt: asNumber(run.run_attempt),
+      html_url: asString(run.html_url),
+      actor: asString(actor.login),
+      head_commit: {
+        id: asString(headCommit.id),
+        message: asString(headCommit.message),
+      },
+    },
+    deliveryHandle: null,
+  };
+}
+
+function parseGithubCiSourceConfig(source: SubscriptionSource): GithubCiSourceConfig {
+  const config = source.config ?? {};
+  const owner = asString(config.owner);
+  const repo = asString(config.repo);
+  if (!owner || !repo) {
+    const [fallbackOwner, fallbackRepo] = source.sourceKey.split("/", 2);
+    if (!fallbackOwner || !fallbackRepo) {
+      throw new Error(`github_repo_ci source requires config.owner and config.repo: ${source.sourceId}`);
+    }
+    return {
+      owner: fallbackOwner,
+      repo: fallbackRepo,
+      uxcAuth: asString(config.uxcAuth) ?? asString(config.credentialRef) ?? undefined,
+      pollIntervalSecs: asNumber(config.pollIntervalSecs) ?? DEFAULT_POLL_INTERVAL_SECS,
+      perPage: asNumber(config.perPage) ?? DEFAULT_PER_PAGE,
+      eventFilter: asString(config.eventFilter) ?? undefined,
+      branch: asString(config.branch) ?? undefined,
+      statusFilter: asString(config.statusFilter) ?? undefined,
+    };
+  }
+  return {
+    owner,
+    repo,
+    uxcAuth: asString(config.uxcAuth) ?? asString(config.credentialRef) ?? undefined,
+    pollIntervalSecs: asNumber(config.pollIntervalSecs) ?? DEFAULT_POLL_INTERVAL_SECS,
+    perPage: asNumber(config.perPage) ?? DEFAULT_PER_PAGE,
+    eventFilter: asString(config.eventFilter) ?? undefined,
+    branch: asString(config.branch) ?? undefined,
+    statusFilter: asString(config.statusFilter) ?? undefined,
+  };
+}
+
+function parseGithubCiCheckpoint(checkpoint: string | null | undefined): GithubCiSourceCheckpoint {
+  if (!checkpoint) {
+    return {};
+  }
+  try {
+    return JSON.parse(checkpoint) as GithubCiSourceCheckpoint;
+  } catch {
+    return {};
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -502,6 +502,58 @@ test("manual append endpoint rejects adapter-managed sources", async () => {
   }
 });
 
+test("sources/events validates string ids and delivery handle shape", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-sev-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const sourceResponse = await client.request<SubscriptionSource>("/sources/register", {
+        sourceType: "custom",
+        sourceKey: "validate-demo",
+      } satisfies RegisterSourceInput);
+      assert.equal(sourceResponse.statusCode, 200);
+
+      const invalidId = await client.request<{ error: string }>(`/sources/${sourceResponse.data.sourceId}/events`, {
+        sourceNativeId: { bad: true },
+        eventVariant: "message.created",
+      });
+      assert.equal(invalidId.statusCode, 400);
+      assert.match(invalidId.data.error, /sources\/events requires sourceNativeId/);
+
+      const invalidDeliveryHandle = await client.request<{ error: string }>(`/sources/${sourceResponse.data.sourceId}/events`, {
+        sourceNativeId: "evt-1",
+        eventVariant: "message.created",
+        deliveryHandle: { provider: "github" },
+      });
+      assert.equal(invalidDeliveryHandle.statusCode, 400);
+      assert.match(invalidDeliveryHandle.data.error, /deliveryHandle requires provider, surface, and targetRef/);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 async function waitFor<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: NodeJS.Timeout | null = null;
   try {

--- a/test/github_ci.test.ts
+++ b/test/github_ci.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { AgentInboxStore } from "../src/store";
+import { AgentInboxService } from "../src/service";
+import { AdapterRegistry } from "../src/adapters";
+import { AppendSourceEventInput, SubscriptionSource } from "../src/model";
+import { nowIso } from "../src/util";
+import { GithubActionsUxcClient, GithubCiSourceRuntime, normalizeGithubWorkflowRunEvent } from "../src/sources/github_ci";
+
+class FakeGithubActionsClient {
+  public calls: Array<Record<string, unknown>> = [];
+  public workflowRuns: unknown[] = [];
+
+  async call(args: Record<string, unknown>) {
+    this.calls.push(args);
+    return {
+      data: {
+        total_count: this.workflowRuns.length,
+        workflow_runs: this.workflowRuns,
+      },
+    };
+  }
+}
+
+async function makeService(): Promise<{ store: AgentInboxStore; service: AgentInboxService; adapters: AdapterRegistry; dir: string }> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-github-ci-test-"));
+  const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters);
+  return { store, service, adapters, dir };
+}
+
+test("normalizeGithubWorkflowRunEvent extracts workflow run metadata", () => {
+  const source: SubscriptionSource = {
+    sourceId: "src_ci",
+    sourceType: "github_repo_ci",
+    sourceKey: "holon-run/agentinbox",
+    config: { owner: "holon-run", repo: "agentinbox" },
+    configRef: null,
+    status: "active",
+    checkpoint: null,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  };
+
+  const normalized = normalizeGithubWorkflowRunEvent(source, { owner: "holon-run", repo: "agentinbox" }, {
+    id: 987,
+    workflow_id: 321,
+    name: "CI",
+    display_title: "ci / test",
+    status: "completed",
+    conclusion: "failure",
+    event: "pull_request",
+    head_sha: "abc123",
+    head_branch: "main",
+    run_number: 14,
+    run_attempt: 2,
+    html_url: "https://github.com/holon-run/agentinbox/actions/runs/987",
+    created_at: "2026-04-06T10:00:00Z",
+    updated_at: "2026-04-06T10:05:00Z",
+    actor: { login: "jolestar" },
+    head_commit: { id: "abc123", message: "fix ci" },
+  });
+
+  assert.ok(normalized);
+  assert.equal(normalized?.sourceNativeId, "workflow_run:987");
+  assert.equal(normalized?.eventVariant, "workflow_run.completed.failure");
+  assert.equal(normalized?.metadata?.headBranch, "main");
+  assert.equal(normalized?.metadata?.conclusion, "failure");
+  assert.equal(normalized?.deliveryHandle, null);
+});
+
+test("github_repo_ci source runtime appends workflow run events and subscriptions materialize inbox items", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const fake = new FakeGithubActionsClient();
+    const runtime = new GithubCiSourceRuntime(store, async (input) => service.appendSourceEvent(input), new GithubActionsUxcClient(fake));
+    const source: SubscriptionSource = {
+      sourceId: "src_ci",
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      configRef: null,
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default", perPage: 10 },
+      status: "active",
+      checkpoint: null,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    store.insertSource(source);
+    const subscription = await service.registerSubscription({
+      agentId: "alpha",
+      sourceId: source.sourceId,
+      matchRules: { conclusion: "failure", headBranch: "main" },
+      startPolicy: "earliest",
+    });
+
+    fake.workflowRuns = [
+      {
+        id: 1001,
+        workflow_id: 10,
+        name: "ci",
+        display_title: "ci / test",
+        status: "completed",
+        conclusion: "success",
+        event: "push",
+        head_sha: "sha-success",
+        head_branch: "main",
+        run_number: 1,
+        run_attempt: 1,
+        html_url: "https://github.com/holon-run/agentinbox/actions/runs/1001",
+        created_at: "2026-04-06T10:00:00Z",
+        updated_at: "2026-04-06T10:00:10Z",
+        actor: { login: "jolestar" },
+      },
+      {
+        id: 1002,
+        workflow_id: 10,
+        name: "ci",
+        display_title: "ci / test",
+        status: "completed",
+        conclusion: "failure",
+        event: "pull_request",
+        head_sha: "sha-failure",
+        head_branch: "main",
+        run_number: 2,
+        run_attempt: 1,
+        html_url: "https://github.com/holon-run/agentinbox/actions/runs/1002",
+        created_at: "2026-04-06T10:01:00Z",
+        updated_at: "2026-04-06T10:01:30Z",
+        actor: { login: "jolestar" },
+      },
+    ];
+
+    await runtime.ensureSource(source);
+    const sourceResult = await runtime.pollSource(source.sourceId);
+    const subscriptionResult = await service.pollSubscription(subscription.subscriptionId);
+    const items = service.listInboxItems(subscription.inboxId);
+
+    assert.equal(fake.calls[0]?.operation, "get:/repos/{owner}/{repo}/actions/runs");
+    assert.equal(sourceResult.appended, 2);
+    assert.equal(subscriptionResult.inboxItemsCreated, 1);
+    assert.equal(items.length, 1);
+    assert.equal(items[0]?.metadata?.conclusion, "failure");
+    assert.equal(items[0]?.eventVariant, "workflow_run.completed.failure");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a dedicated `github_repo_ci` source backed by GitHub Actions workflow run polling
- normalize workflow run state into `StreamEvent` metadata for subscription matching
- document the new source type and add source/runtime tests

## Testing
- npm test
