### PR TITLE
Add CLI management commands for inbox relations

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -204,10 +204,14 @@ async function main(): Promise<void> {
   if (command === "inbox" && args[1] === "ack") {
     const inboxId = args[2];
     const itemId = takeFlagValue(args, "--item");
-    if (!inboxId || (!itemId && !hasFlag(args, "--all"))) {
+    const ackAll = hasFlag(args, "--all");
+    if (ackAll && itemId) {
       throw new Error("usage: agentinbox inbox ack <inboxId> (--item <itemId> | --all)");
     }
-    if (hasFlag(args, "--all")) {
+    if (!inboxId || (!itemId && !ackAll)) {
+      throw new Error("usage: agentinbox inbox ack <inboxId> (--item <itemId> | --all)");
+    }
+    if (ackAll) {
       await printRemote(client, `/inboxes/${encodeURIComponent(inboxId)}/ack-all`, {});
       return;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,20 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "source" && args[1] === "list") {
+    await printRemote(client, "/sources", undefined, "GET");
+    return;
+  }
+
+  if (command === "source" && args[1] === "show") {
+    const sourceId = args[2];
+    if (!sourceId) {
+      throw new Error("usage: agentinbox source show <sourceId>");
+    }
+    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}`, undefined, "GET");
+    return;
+  }
+
   if (command === "source" && args[1] === "poll") {
     const sourceId = args[2];
     if (!sourceId) {
@@ -85,6 +99,25 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "subscription" && args[1] === "list") {
+    const query = buildQuery({
+      source_id: takeFlagValue(args, "--source-id"),
+      agent_id: takeFlagValue(args, "--agent-id"),
+      inbox_id: takeFlagValue(args, "--inbox-id"),
+    });
+    await printRemote(client, `/subscriptions${query}`, undefined, "GET");
+    return;
+  }
+
+  if (command === "subscription" && args[1] === "show") {
+    const subscriptionId = args[2];
+    if (!subscriptionId) {
+      throw new Error("usage: agentinbox subscription show <subscriptionId>");
+    }
+    await printRemote(client, `/subscriptions/${encodeURIComponent(subscriptionId)}`, undefined, "GET");
+    return;
+  }
+
   if (command === "subscription" && args[1] === "poll") {
     const subscriptionId = args[2];
     if (!subscriptionId) {
@@ -94,8 +127,50 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "subscription" && args[1] === "lag") {
+    const subscriptionId = args[2];
+    if (!subscriptionId) {
+      throw new Error("usage: agentinbox subscription lag <subscriptionId>");
+    }
+    await printRemote(client, `/subscriptions/${encodeURIComponent(subscriptionId)}/lag`, undefined, "GET");
+    return;
+  }
+
+  if (command === "subscription" && args[1] === "reset") {
+    const subscriptionId = args[2];
+    const startPolicy = takeFlagValue(args, "--start-policy");
+    if (!subscriptionId || !startPolicy) {
+      throw new Error("usage: agentinbox subscription reset <subscriptionId> --start-policy latest|earliest|at_offset|at_time [--start-offset N] [--start-time ISO8601]");
+    }
+    await printRemote(client, `/subscriptions/${encodeURIComponent(subscriptionId)}/reset`, {
+      startPolicy,
+      startOffset: parseOptionalNumber(takeFlagValue(args, "--start-offset")),
+      startTime: takeFlagValue(args, "--start-time") ?? undefined,
+    });
+    return;
+  }
+
   if (command === "inbox" && args[1] === "list") {
     await printRemote(client, "/inboxes", undefined, "GET");
+    return;
+  }
+
+  if (command === "inbox" && args[1] === "ensure") {
+    const inboxId = args[2];
+    const agentId = takeFlagValue(args, "--agent-id");
+    if (!inboxId || !agentId) {
+      throw new Error("usage: agentinbox inbox ensure <inboxId> --agent-id <agentId>");
+    }
+    await printRemote(client, "/inboxes/ensure", { inboxId, agentId });
+    return;
+  }
+
+  if (command === "inbox" && args[1] === "show") {
+    const inboxId = args[2];
+    if (!inboxId) {
+      throw new Error("usage: agentinbox inbox show <inboxId>");
+    }
+    await printRemote(client, `/inboxes/${encodeURIComponent(inboxId)}`, undefined, "GET");
     return;
   }
 
@@ -129,8 +204,12 @@ async function main(): Promise<void> {
   if (command === "inbox" && args[1] === "ack") {
     const inboxId = args[2];
     const itemId = takeFlagValue(args, "--item");
-    if (!inboxId || !itemId) {
-      throw new Error("usage: agentinbox inbox ack <inboxId> --item <itemId>");
+    if (!inboxId || (!itemId && !hasFlag(args, "--all"))) {
+      throw new Error("usage: agentinbox inbox ack <inboxId> (--item <itemId> | --all)");
+    }
+    if (hasFlag(args, "--all")) {
+      await printRemote(client, `/inboxes/${encodeURIComponent(inboxId)}/ack-all`, {});
+      return;
     }
     await printRemote(client, `/inboxes/${encodeURIComponent(inboxId)}/ack`, { itemIds: [itemId] });
     return;
@@ -264,6 +343,17 @@ function parseOptionalNumber(value: string | undefined): number | undefined {
   return parsed;
 }
 
+function buildQuery(params: Record<string, string | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      search.set(key, value);
+    }
+  }
+  const query = search.toString();
+  return query ? `?${query}` : "";
+}
+
 function printHelp(): void {
   console.log(`agentinbox
 
@@ -271,14 +361,22 @@ Commands:
   agentinbox serve [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
   agentinbox serve --port 4747 [--state ~/.agentinbox/agentinbox.sqlite]
   agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]
+  agentinbox source list
+  agentinbox source show <sourceId>
   agentinbox source poll <sourceId>
   agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]
   agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
+  agentinbox subscription list [--source-id ID] [--agent-id ID] [--inbox-id ID]
+  agentinbox subscription show <subscriptionId>
   agentinbox subscription poll <subscriptionId>
+  agentinbox subscription lag <subscriptionId>
+  agentinbox subscription reset <subscriptionId> --start-policy latest|earliest|at_offset|at_time [--start-offset N] [--start-time ISO8601]
   agentinbox inbox list
+  agentinbox inbox ensure <inboxId> --agent-id <agentId>
+  agentinbox inbox show <inboxId>
   agentinbox inbox read <inboxId>
   agentinbox inbox watch <inboxId> [--after-item ID] [--include-acked] [--heartbeat-ms N]
-  agentinbox inbox ack <inboxId> --item <itemId>
+  agentinbox inbox ack <inboxId> (--item <itemId> | --all)
   agentinbox fixture emit <sourceId> [--native-id ID] [--event EVENT] [--metadata-json JSON] [--payload-json JSON]
   agentinbox deliver send --provider PROVIDER --surface SURFACE --target TARGET [--kind KIND] [--payload-json JSON]
   agentinbox status

--- a/src/http.ts
+++ b/src/http.ts
@@ -139,6 +139,10 @@ export function createServer(service: AgentInboxService): http.Server {
       if (req.method === "POST" && subscriptionResetMatch) {
         const body = await readJson(req);
         const startPolicy = parseRequiredString(body.startPolicy, "subscriptions/reset requires startPolicy");
+        if (!startPolicy) {
+          send(res, 400, { error: "subscriptions/reset requires startPolicy" });
+          return;
+        }
         send(res, 200, await service.resetSubscription({
           subscriptionId: decodeURIComponent(subscriptionResetMatch[1]),
           startPolicy: startPolicy as never,

--- a/src/http.ts
+++ b/src/http.ts
@@ -49,9 +49,20 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
+      if (req.method === "GET" && url.pathname === "/sources") {
+        send(res, 200, { sources: service.listSources() });
+        return;
+      }
+
       if (req.method === "POST" && url.pathname === "/sources/register") {
         const source = await service.registerSource(await readJson(req) as never);
         send(res, 200, source);
+        return;
+      }
+
+      const sourceMatch = url.pathname.match(/^\/sources\/([^/]+)$/);
+      if (req.method === "GET" && sourceMatch) {
+        send(res, 200, service.getSourceDetails(decodeURIComponent(sourceMatch[1])));
         return;
       }
 
@@ -88,9 +99,26 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
+      if (req.method === "GET" && url.pathname === "/subscriptions") {
+        send(res, 200, {
+          subscriptions: service.listSubscriptions({
+            sourceId: url.searchParams.get("source_id") ?? undefined,
+            agentId: url.searchParams.get("agent_id") ?? undefined,
+            inboxId: url.searchParams.get("inbox_id") ?? undefined,
+          }),
+        });
+        return;
+      }
+
       if (req.method === "POST" && url.pathname === "/subscriptions/register") {
         const subscription = await service.registerSubscription(await readJson(req) as never);
         send(res, 200, subscription);
+        return;
+      }
+
+      const subscriptionMatch = url.pathname.match(/^\/subscriptions\/([^/]+)$/);
+      if (req.method === "GET" && subscriptionMatch) {
+        send(res, 200, await service.getSubscriptionDetails(decodeURIComponent(subscriptionMatch[1])));
         return;
       }
 
@@ -98,6 +126,25 @@ export function createServer(service: AgentInboxService): http.Server {
       if (req.method === "POST" && subscriptionPollMatch) {
         const result = await service.pollSubscription(decodeURIComponent(subscriptionPollMatch[1]));
         send(res, 200, result);
+        return;
+      }
+
+      const subscriptionLagMatch = url.pathname.match(/^\/subscriptions\/([^/]+)\/lag$/);
+      if (req.method === "GET" && subscriptionLagMatch) {
+        send(res, 200, await service.getSubscriptionLag(decodeURIComponent(subscriptionLagMatch[1])));
+        return;
+      }
+
+      const subscriptionResetMatch = url.pathname.match(/^\/subscriptions\/([^/]+)\/reset$/);
+      if (req.method === "POST" && subscriptionResetMatch) {
+        const body = await readJson(req);
+        const startPolicy = parseRequiredString(body.startPolicy, "subscriptions/reset requires startPolicy");
+        send(res, 200, await service.resetSubscription({
+          subscriptionId: decodeURIComponent(subscriptionResetMatch[1]),
+          startPolicy: startPolicy as never,
+          startOffset: parseOptionalInteger(body.startOffset),
+          startTime: parseOptionalString(body.startTime) ?? null,
+        }));
         return;
       }
 
@@ -131,7 +178,29 @@ export function createServer(service: AgentInboxService): http.Server {
       }
 
       if (req.method === "GET" && url.pathname === "/inboxes") {
-        send(res, 200, { inboxes: service.listInboxIds() });
+        send(res, 200, { inboxes: service.listInboxes() });
+        return;
+      }
+
+      if (req.method === "POST" && url.pathname === "/inboxes/ensure") {
+        const body = await readJson(req);
+        const inboxId = parseRequiredString(body.inboxId, "inboxes/ensure requires inboxId");
+        const agentId = parseRequiredString(body.agentId, "inboxes/ensure requires agentId");
+        if (!inboxId) {
+          send(res, 400, { error: "inboxes/ensure requires inboxId" });
+          return;
+        }
+        if (!agentId) {
+          send(res, 400, { error: "inboxes/ensure requires agentId" });
+          return;
+        }
+        send(res, 200, service.ensureInboxByCaller(inboxId, agentId));
+        return;
+      }
+
+      const inboxShowMatch = url.pathname.match(/^\/inboxes\/([^/]+)$/);
+      if (req.method === "GET" && inboxShowMatch) {
+        send(res, 200, service.getInboxDetails(decodeURIComponent(inboxShowMatch[1])));
         return;
       }
 
@@ -201,6 +270,12 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
+      const inboxAckAllMatch = url.pathname.match(/^\/inboxes\/([^/]+)\/ack-all$/);
+      if (req.method === "POST" && inboxAckAllMatch) {
+        send(res, 200, service.ackAllInboxItems(decodeURIComponent(inboxAckAllMatch[1])));
+        return;
+      }
+
       if (req.method === "POST" && url.pathname === "/deliveries/send") {
         const result = await service.sendDelivery(await readJson(req) as never);
         send(res, 200, result);
@@ -218,12 +293,16 @@ export function createServer(service: AgentInboxService): http.Server {
         message.startsWith("manual append is not supported") ||
         message.startsWith("fixtures/emit requires") ||
         message.startsWith("sources/events requires") ||
-        message.startsWith("deliveryHandle requires")
+        message.startsWith("deliveryHandle requires") ||
+        message.startsWith("subscriptions/reset requires") ||
+        message.startsWith("inboxes/ensure requires") ||
+        message.startsWith("inbox ") ||
+        message.startsWith("unsupported start policy")
       ) {
         send(res, 400, { error: message });
         return;
       }
-      if (message.startsWith("expected positive integer")) {
+      if (message.startsWith("expected positive integer") || message.startsWith("expected integer")) {
         send(res, 400, { error: message });
         return;
       }
@@ -241,6 +320,16 @@ function parsePositiveInteger(value: string | null): number | undefined {
     throw new Error(`expected positive integer, received ${value}`);
   }
   return parsed;
+}
+
+function parseOptionalInteger(value: unknown): number | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`expected integer, received ${String(value)}`);
+  }
+  return value;
 }
 
 function parseRequiredString(value: unknown, _errorMessage: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -227,12 +227,16 @@ export class AgentInboxService {
 
   async getSubscriptionDetails(subscriptionId: string): Promise<Record<string, unknown>> {
     const subscription = this.getSubscription(subscriptionId);
+    const consumer = await this.backend.getConsumer({ subscriptionId });
+    if (!consumer) {
+      throw new Error(`unknown consumer for subscription: ${subscriptionId}`);
+    }
     return {
       subscription,
       source: this.getSource(subscription.sourceId),
       inbox: this.getInbox(subscription.inboxId),
-      consumer: await this.backend.getConsumer({ subscriptionId }),
-      lag: await this.backend.getConsumerLag({ subscriptionId }),
+      consumer,
+      lag: await this.backend.getConsumerLag({ consumerId: consumer.consumerId }),
     };
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -21,6 +21,7 @@ import { AgentInboxStore } from "./store";
 import { AdapterRegistry } from "./adapters";
 import {
   defaultInboxIdForAgent,
+  ConsumerLag,
   EventBusBackend,
   SqliteEventBusBackend,
   streamKeyForSource,
@@ -33,6 +34,7 @@ const DEFAULT_SUBSCRIPTION_POLL_LIMIT = 100;
 const DEFAULT_ACTIVATION_WINDOW_MS = 3_000;
 const DEFAULT_ACTIVATION_MAX_ITEMS = 20;
 const ACTIVATION_MODES = new Set<Subscription["activationMode"]>(["activation_only", "activation_with_items"]);
+const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
 
 interface ActivationBuffer {
   agentId: string;
@@ -139,6 +141,27 @@ export class AgentInboxService {
     return source;
   }
 
+  listSources(): SubscriptionSource[] {
+    return this.store.listSources();
+  }
+
+  getSource(sourceId: string): SubscriptionSource {
+    const source = this.store.getSource(sourceId);
+    if (!source) {
+      throw new Error(`unknown source: ${sourceId}`);
+    }
+    return source;
+  }
+
+  getSourceDetails(sourceId: string): Record<string, unknown> {
+    const source = this.getSource(sourceId);
+    return {
+      source,
+      stream: this.store.getStreamBySourceId(sourceId),
+      subscriptions: this.store.listSubscriptionsForSource(sourceId),
+    };
+  }
+
   async registerSubscription(input: RegisterSubscriptionInput): Promise<Subscription> {
     const source = this.store.getSource(input.sourceId);
     if (!source) {
@@ -173,6 +196,76 @@ export class AgentInboxService {
       startTime: subscription.startTime ?? null,
     });
     return subscription;
+  }
+
+  listSubscriptions(filters?: {
+    sourceId?: string;
+    agentId?: string;
+    inboxId?: string;
+  }): Subscription[] {
+    return this.store.listSubscriptions().filter((subscription) => {
+      if (filters?.sourceId && subscription.sourceId !== filters.sourceId) {
+        return false;
+      }
+      if (filters?.agentId && subscription.agentId !== filters.agentId) {
+        return false;
+      }
+      if (filters?.inboxId && subscription.inboxId !== filters.inboxId) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  getSubscription(subscriptionId: string): Subscription {
+    const subscription = this.store.getSubscription(subscriptionId);
+    if (!subscription) {
+      throw new Error(`unknown subscription: ${subscriptionId}`);
+    }
+    return subscription;
+  }
+
+  async getSubscriptionDetails(subscriptionId: string): Promise<Record<string, unknown>> {
+    const subscription = this.getSubscription(subscriptionId);
+    return {
+      subscription,
+      source: this.getSource(subscription.sourceId),
+      inbox: this.getInbox(subscription.inboxId),
+      consumer: await this.backend.getConsumer({ subscriptionId }),
+      lag: await this.backend.getConsumerLag({ subscriptionId }),
+    };
+  }
+
+  async getSubscriptionLag(subscriptionId: string): Promise<ConsumerLag> {
+    this.getSubscription(subscriptionId);
+    return this.backend.getConsumerLag({ subscriptionId });
+  }
+
+  async resetSubscription(input: {
+    subscriptionId: string;
+    startPolicy: Subscription["startPolicy"];
+    startOffset?: number | null;
+    startTime?: string | null;
+  }): Promise<Record<string, unknown>> {
+    this.getSubscription(input.subscriptionId);
+    if (!SUBSCRIPTION_START_POLICIES.has(input.startPolicy)) {
+      throw new Error(`unsupported start policy: ${input.startPolicy}`);
+    }
+    const consumer = await this.backend.getConsumer({ subscriptionId: input.subscriptionId });
+    if (!consumer) {
+      throw new Error(`unknown consumer for subscription: ${input.subscriptionId}`);
+    }
+    const reset = await this.backend.reset({
+      consumerId: consumer.consumerId,
+      startPolicy: input.startPolicy,
+      startOffset: input.startOffset ?? null,
+      startTime: input.startTime ?? null,
+    });
+    return {
+      subscription: this.getSubscription(input.subscriptionId),
+      consumer: reset,
+      lag: await this.backend.getConsumerLag({ consumerId: reset.consumerId }),
+    };
   }
 
   async appendSourceEvent(input: AppendSourceEventInput): Promise<AppendSourceEventResult> {
@@ -234,6 +327,36 @@ export class AgentInboxService {
 
   listInboxIds(): string[] {
     return this.store.listInboxes().map((inbox) => inbox.inboxId);
+  }
+
+  listInboxes(): Inbox[] {
+    return this.store.listInboxes();
+  }
+
+  ensureInboxByCaller(inboxId: string, ownerAgentId: string): Inbox {
+    return this.ensureInbox(inboxId, ownerAgentId);
+  }
+
+  getInbox(inboxId: string): Inbox {
+    const inbox = this.store.getInbox(inboxId);
+    if (!inbox) {
+      throw new Error(`unknown inbox: ${inboxId}`);
+    }
+    return inbox;
+  }
+
+  getInboxDetails(inboxId: string): Record<string, unknown> {
+    const inbox = this.getInbox(inboxId);
+    const subscriptions = this.listSubscriptions({ inboxId });
+    return {
+      inbox,
+      subscriptions,
+      itemCounts: {
+        total: this.store.listInboxItems(inboxId).length,
+        unacked: this.store.listInboxItems(inboxId, { includeAcked: false }).length,
+        acked: this.store.listInboxItems(inboxId).filter((item) => item.ackedAt != null).length,
+      },
+    };
   }
 
   listInboxItems(inboxId: string, options?: WatchInboxOptions): InboxItem[] {
@@ -321,6 +444,11 @@ export class AgentInboxService {
   }
 
   ackInboxItems(inboxId: string, itemIds: string[]): { acked: number } {
+    return { acked: this.store.ackItems(inboxId, itemIds, nowIso()) };
+  }
+
+  ackAllInboxItems(inboxId: string): { acked: number } {
+    const itemIds = this.store.listInboxItems(inboxId, { includeAcked: false }).map((item) => item.itemId);
     return { acked: this.store.ackItems(inboxId, itemIds, nowIso()) };
   }
 

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -301,6 +301,66 @@ test("registerSubscription rejects unsupported activation modes", async () => {
   }
 });
 
+test("service can list relationships and reset subscription lag", async () => {
+  const { store, service, dir } = await makeAsyncService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "custom",
+      sourceKey: "project-alpha",
+      config: {},
+    });
+    const inbox = service.ensureInboxByCaller("shared_alpha", "alpha");
+    const subscription = await service.registerSubscription({
+      agentId: "alpha",
+      sourceId: source.sourceId,
+      inboxId: inbox.inboxId,
+      matchRules: { channel: "engineering" },
+      startPolicy: "latest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-1",
+      eventVariant: "message.created",
+      metadata: { channel: "engineering" },
+      rawPayload: { text: "hello" },
+    });
+
+    const listed = service.listSubscriptions({ sourceId: source.sourceId, agentId: "alpha", inboxId: inbox.inboxId });
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].subscriptionId, subscription.subscriptionId);
+
+    const lagBefore = await service.getSubscriptionLag(subscription.subscriptionId) as { pendingEvents: number };
+    assert.equal(lagBefore.pendingEvents, 1);
+
+    const reset = await service.resetSubscription({
+      subscriptionId: subscription.subscriptionId,
+      startPolicy: "earliest",
+    });
+    assert.equal((reset.consumer as { nextOffset: number }).nextOffset, 1);
+
+    const lagAfter = await service.getSubscriptionLag(subscription.subscriptionId) as { pendingEvents: number };
+    assert.equal(lagAfter.pendingEvents, 1);
+
+    const inboxDetails = service.getInboxDetails(inbox.inboxId);
+    assert.equal((inboxDetails.itemCounts as { total: number }).total, 0);
+
+    const poll = await service.pollSubscription(subscription.subscriptionId);
+    assert.equal(poll.inboxItemsCreated, 1);
+
+    const shown = await service.getSubscriptionDetails(subscription.subscriptionId);
+    assert.equal((shown.source as SubscriptionSource).sourceId, source.sourceId);
+    assert.equal((shown.inbox as { inboxId: string }).inboxId, inbox.inboxId);
+
+    const acked = service.ackAllInboxItems(inbox.inboxId);
+    assert.equal(acked.acked, 1);
+    assert.equal(service.listInboxItems(inbox.inboxId, { includeAcked: false }).length, 0);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("manual append is rejected for adapter-managed sources", async () => {
   const { store, service, dir } = await makeAsyncService();
   try {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -554,6 +554,130 @@ test("sources/events validates string ids and delivery handle shape", async () =
   }
 });
 
+test("control plane exposes source, subscription, and inbox management endpoints", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-mgmt-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const source = await client.request<SubscriptionSource>("/sources/register", {
+        sourceType: "custom",
+        sourceKey: "mgmt-demo",
+      } satisfies RegisterSourceInput);
+      assert.equal(source.statusCode, 200);
+
+      const ensured = await client.request<{ inboxId: string; ownerAgentId: string }>("/inboxes/ensure", {
+        inboxId: "shared_alpha",
+        agentId: "alpha",
+      });
+      assert.equal(ensured.statusCode, 200);
+      assert.equal(ensured.data.inboxId, "shared_alpha");
+
+      const subscription = await client.request<{ subscriptionId: string; inboxId: string }>("/subscriptions/register", {
+        agentId: "alpha",
+        sourceId: source.data.sourceId,
+        inboxId: "shared_alpha",
+        matchRules: { channel: "engineering" },
+        startPolicy: "latest",
+      } satisfies RegisterSubscriptionInput);
+      assert.equal(subscription.statusCode, 200);
+
+      const sources = await client.request<{ sources: SubscriptionSource[] }>("/sources", undefined, "GET");
+      assert.equal(sources.statusCode, 200);
+      assert.equal(sources.data.sources.length, 1);
+
+      const sourceDetails = await client.request<{ source: SubscriptionSource; subscriptions: Array<{ subscriptionId: string }> }>(
+        `/sources/${source.data.sourceId}`,
+        undefined,
+        "GET",
+      );
+      assert.equal(sourceDetails.statusCode, 200);
+      assert.equal(sourceDetails.data.subscriptions.length, 1);
+
+      await client.request(`/sources/${source.data.sourceId}/events`, {
+        sourceNativeId: "evt-1",
+        eventVariant: "message.created",
+        metadata: { channel: "engineering" },
+      });
+
+      const lagBefore = await client.request<{ pendingEvents: number }>(
+        `/subscriptions/${subscription.data.subscriptionId}/lag`,
+        undefined,
+        "GET",
+      );
+      assert.equal(lagBefore.statusCode, 200);
+      assert.equal(lagBefore.data.pendingEvents, 1);
+
+      const listed = await client.request<{ subscriptions: Array<{ subscriptionId: string }> }>(
+        `/subscriptions?source_id=${encodeURIComponent(source.data.sourceId)}&agent_id=alpha&inbox_id=shared_alpha`,
+        undefined,
+        "GET",
+      );
+      assert.equal(listed.statusCode, 200);
+      assert.equal(listed.data.subscriptions.length, 1);
+
+      const reset = await client.request<{ consumer: { nextOffset: number } }>(
+        `/subscriptions/${subscription.data.subscriptionId}/reset`,
+        { startPolicy: "earliest" },
+      );
+      assert.equal(reset.statusCode, 200);
+      assert.equal(reset.data.consumer.nextOffset, 1);
+
+      const poll = await client.request<SubscriptionPollResult>(
+        `/subscriptions/${subscription.data.subscriptionId}/poll`,
+        {},
+      );
+      assert.equal(poll.statusCode, 200);
+      assert.equal(poll.data.inboxItemsCreated, 1);
+
+      const subShow = await client.request<{ subscription: { inboxId: string }; lag: { pendingEvents: number } }>(
+        `/subscriptions/${subscription.data.subscriptionId}`,
+        undefined,
+        "GET",
+      );
+      assert.equal(subShow.statusCode, 200);
+      assert.equal(subShow.data.subscription.inboxId, "shared_alpha");
+      assert.equal(subShow.data.lag.pendingEvents, 0);
+
+      const inboxShow = await client.request<{
+        inbox: { inboxId: string; ownerAgentId: string };
+        subscriptions: Array<{ subscriptionId: string }>;
+        itemCounts: { total: number; unacked: number; acked: number };
+      }>(`/inboxes/shared_alpha`, undefined, "GET");
+      assert.equal(inboxShow.statusCode, 200);
+      assert.equal(inboxShow.data.inbox.ownerAgentId, "alpha");
+      assert.equal(inboxShow.data.subscriptions.length, 1);
+      assert.equal(inboxShow.data.itemCounts.unacked, 1);
+
+      const ackAll = await client.request<{ acked: number }>(`/inboxes/shared_alpha/ack-all`, {});
+      assert.equal(ackAll.statusCode, 200);
+      assert.equal(ackAll.data.acked, 1);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 async function waitFor<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: NodeJS.Timeout | null = null;
   try {


### PR DESCRIPTION
## Summary
- add list/show commands for sources, subscriptions, and inboxes
- expose explicit inbox ensure plus subscription lag/reset and inbox ack-all
- add service/control-plane tests for the new management surface

## Testing
- npm test
