### PR TITLE
Normalize CLI help and version commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import pkg from "../package.json";
+import fs from "node:fs";
+import path from "node:path";
 import { AgentInboxStore } from "./store";
 import { AgentInboxService } from "./service";
 import { createServer } from "./http";
@@ -20,6 +21,10 @@ async function main(): Promise<void> {
   }
 
   if (command === "version" || command === "--version" || command === "-v") {
+    if (hasHelpFlag(normalized.slice(1))) {
+      printHelp(["version"]);
+      return;
+    }
     printVersion();
     return;
   }
@@ -416,8 +421,8 @@ function printHelp(path: string[] = []): void {
 Usage:
   agentinbox <command> [options]
   agentinbox help [command]
-  agentinbox --help
-  agentinbox --version
+  agentinbox --help, -h
+  agentinbox --version, -v
 
 Commands:
   serve
@@ -486,14 +491,35 @@ Usage:
 
 Usage:
   agentinbox version
-  agentinbox --version
+  agentinbox --version, -v
 `,
   };
   console.log(helpByKey[key] ?? helpByKey.root);
 }
 
 function printVersion(): void {
-  console.log(`agentinbox ${pkg.version}`);
+  console.log(`agentinbox ${readPackageVersion()}`);
+}
+
+function readPackageVersion(): string {
+  const packageJsonPath = findPackageJsonPath(__dirname);
+  const parsed = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as { version?: unknown };
+  return typeof parsed.version === "string" ? parsed.version : "0.0.0";
+}
+
+function findPackageJsonPath(startDir: string): string {
+  let currentDir = startDir;
+  while (true) {
+    const candidate = path.join(currentDir, "package.json");
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      throw new Error(`could not locate package.json from ${startDir}`);
+    }
+    currentDir = parentDir;
+  }
 }
 
 main().catch((error) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import pkg from "../package.json";
 import { AgentInboxStore } from "./store";
 import { AgentInboxService } from "./service";
 import { createServer } from "./http";
@@ -10,27 +11,42 @@ import { resolveClientTransport, resolveServeConfig } from "./paths";
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
-  const command = args[0];
+  const normalized = normalizeHelpArgs(args);
+  const command = normalized[0];
 
   if (!command || command === "help" || command === "--help" || command === "-h") {
-    printHelp();
+    printHelp(normalized.slice(1));
+    return;
+  }
+
+  if (command === "version" || command === "--version" || command === "-v") {
+    printVersion();
     return;
   }
 
   if (command === "serve") {
-    await runServe(args.slice(1));
+    if (hasHelpFlag(normalized.slice(1))) {
+      printHelp(["serve"]);
+      return;
+    }
+    await runServe(normalized.slice(1));
     return;
   }
 
-  const client = createClient(args);
+  const client = createClient(normalized);
 
-  if (command === "source" && args[1] === "add") {
-    const [type, sourceKey] = args.slice(2, 4);
+  if (command === "source" && hasHelpFlag(normalized.slice(1))) {
+    printHelp(["source"]);
+    return;
+  }
+
+  if (command === "source" && normalized[1] === "add") {
+    const [type, sourceKey] = normalized.slice(2, 4);
     if (!type || !sourceKey) {
       throw new Error("usage: agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]");
     }
-    const configJson = takeFlagValue(args, "--config-json");
-    const configRef = takeFlagValue(args, "--config-ref");
+    const configJson = takeFlagValue(normalized, "--config-json");
+    const configRef = takeFlagValue(normalized, "--config-ref");
     await printRemote(client, "/sources/register", {
       sourceType: type,
       sourceKey,
@@ -40,13 +56,13 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "source" && args[1] === "list") {
+  if (command === "source" && normalized[1] === "list") {
     await printRemote(client, "/sources", undefined, "GET");
     return;
   }
 
-  if (command === "source" && args[1] === "show") {
-    const sourceId = args[2];
+  if (command === "source" && normalized[1] === "show") {
+    const sourceId = normalized[2];
     if (!sourceId) {
       throw new Error("usage: agentinbox source show <sourceId>");
     }
@@ -54,8 +70,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "source" && args[1] === "poll") {
-    const sourceId = args[2];
+  if (command === "source" && normalized[1] === "poll") {
+    const sourceId = normalized[2];
     if (!sourceId) {
       throw new Error("usage: agentinbox source poll <sourceId>");
     }
@@ -63,54 +79,59 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "source" && args[1] === "event") {
-    const sourceId = args[2];
-    const sourceNativeId = takeFlagValue(args, "--native-id");
-    const eventVariant = takeFlagValue(args, "--event");
+  if (command === "source" && normalized[1] === "event") {
+    const sourceId = normalized[2];
+    const sourceNativeId = takeFlagValue(normalized, "--native-id");
+    const eventVariant = takeFlagValue(normalized, "--event");
     if (!sourceId || !sourceNativeId || !eventVariant) {
       throw new Error("usage: agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]");
     }
     await printRemote(client, `/sources/${encodeURIComponent(sourceId)}/events`, {
       sourceNativeId,
       eventVariant,
-      occurredAt: takeFlagValue(args, "--occurred-at") ?? undefined,
-      metadata: parseJsonArg(takeFlagValue(args, "--metadata-json")),
-      rawPayload: parseJsonArg(takeFlagValue(args, "--payload-json")),
+      occurredAt: takeFlagValue(normalized, "--occurred-at") ?? undefined,
+      metadata: parseJsonArg(takeFlagValue(normalized, "--metadata-json")),
+      rawPayload: parseJsonArg(takeFlagValue(normalized, "--payload-json")),
     });
     return;
   }
 
-  if (command === "subscription" && args[1] === "add") {
-    const [agentId, sourceId] = args.slice(2, 4);
+  if (command === "subscription" && hasHelpFlag(normalized.slice(1))) {
+    printHelp(["subscription"]);
+    return;
+  }
+
+  if (command === "subscription" && normalized[1] === "add") {
+    const [agentId, sourceId] = normalized.slice(2, 4);
     if (!agentId || !sourceId) {
       throw new Error("usage: agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
     }
     await printRemote(client, "/subscriptions/register", {
       agentId,
       sourceId,
-      inboxId: takeFlagValue(args, "--inbox-id") ?? undefined,
-      matchRules: parseJsonArg(takeFlagValue(args, "--match-json")),
-      activationTarget: takeFlagValue(args, "--activation-target") ?? null,
-      activationMode: takeFlagValue(args, "--activation-mode") ?? undefined,
-      startPolicy: takeFlagValue(args, "--start-policy") ?? undefined,
-      startOffset: parseOptionalNumber(takeFlagValue(args, "--start-offset")),
-      startTime: takeFlagValue(args, "--start-time") ?? undefined,
+      inboxId: takeFlagValue(normalized, "--inbox-id") ?? undefined,
+      matchRules: parseJsonArg(takeFlagValue(normalized, "--match-json")),
+      activationTarget: takeFlagValue(normalized, "--activation-target") ?? null,
+      activationMode: takeFlagValue(normalized, "--activation-mode") ?? undefined,
+      startPolicy: takeFlagValue(normalized, "--start-policy") ?? undefined,
+      startOffset: parseOptionalNumber(takeFlagValue(normalized, "--start-offset")),
+      startTime: takeFlagValue(normalized, "--start-time") ?? undefined,
     });
     return;
   }
 
-  if (command === "subscription" && args[1] === "list") {
+  if (command === "subscription" && normalized[1] === "list") {
     const query = buildQuery({
-      source_id: takeFlagValue(args, "--source-id"),
-      agent_id: takeFlagValue(args, "--agent-id"),
-      inbox_id: takeFlagValue(args, "--inbox-id"),
+      source_id: takeFlagValue(normalized, "--source-id"),
+      agent_id: takeFlagValue(normalized, "--agent-id"),
+      inbox_id: takeFlagValue(normalized, "--inbox-id"),
     });
     await printRemote(client, `/subscriptions${query}`, undefined, "GET");
     return;
   }
 
-  if (command === "subscription" && args[1] === "show") {
-    const subscriptionId = args[2];
+  if (command === "subscription" && normalized[1] === "show") {
+    const subscriptionId = normalized[2];
     if (!subscriptionId) {
       throw new Error("usage: agentinbox subscription show <subscriptionId>");
     }
@@ -118,8 +139,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "subscription" && args[1] === "poll") {
-    const subscriptionId = args[2];
+  if (command === "subscription" && normalized[1] === "poll") {
+    const subscriptionId = normalized[2];
     if (!subscriptionId) {
       throw new Error("usage: agentinbox subscription poll <subscriptionId>");
     }
@@ -127,8 +148,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "subscription" && args[1] === "lag") {
-    const subscriptionId = args[2];
+  if (command === "subscription" && normalized[1] === "lag") {
+    const subscriptionId = normalized[2];
     if (!subscriptionId) {
       throw new Error("usage: agentinbox subscription lag <subscriptionId>");
     }
@@ -136,28 +157,33 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "subscription" && args[1] === "reset") {
-    const subscriptionId = args[2];
-    const startPolicy = takeFlagValue(args, "--start-policy");
+  if (command === "subscription" && normalized[1] === "reset") {
+    const subscriptionId = normalized[2];
+    const startPolicy = takeFlagValue(normalized, "--start-policy");
     if (!subscriptionId || !startPolicy) {
       throw new Error("usage: agentinbox subscription reset <subscriptionId> --start-policy latest|earliest|at_offset|at_time [--start-offset N] [--start-time ISO8601]");
     }
     await printRemote(client, `/subscriptions/${encodeURIComponent(subscriptionId)}/reset`, {
       startPolicy,
-      startOffset: parseOptionalNumber(takeFlagValue(args, "--start-offset")),
-      startTime: takeFlagValue(args, "--start-time") ?? undefined,
+      startOffset: parseOptionalNumber(takeFlagValue(normalized, "--start-offset")),
+      startTime: takeFlagValue(normalized, "--start-time") ?? undefined,
     });
     return;
   }
 
-  if (command === "inbox" && args[1] === "list") {
+  if (command === "inbox" && hasHelpFlag(normalized.slice(1))) {
+    printHelp(["inbox"]);
+    return;
+  }
+
+  if (command === "inbox" && normalized[1] === "list") {
     await printRemote(client, "/inboxes", undefined, "GET");
     return;
   }
 
-  if (command === "inbox" && args[1] === "ensure") {
-    const inboxId = args[2];
-    const agentId = takeFlagValue(args, "--agent-id");
+  if (command === "inbox" && normalized[1] === "ensure") {
+    const inboxId = normalized[2];
+    const agentId = takeFlagValue(normalized, "--agent-id");
     if (!inboxId || !agentId) {
       throw new Error("usage: agentinbox inbox ensure <inboxId> --agent-id <agentId>");
     }
@@ -165,8 +191,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "inbox" && args[1] === "show") {
-    const inboxId = args[2];
+  if (command === "inbox" && normalized[1] === "show") {
+    const inboxId = normalized[2];
     if (!inboxId) {
       throw new Error("usage: agentinbox inbox show <inboxId>");
     }
@@ -174,8 +200,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "inbox" && args[1] === "read") {
-    const inboxId = args[2];
+  if (command === "inbox" && normalized[1] === "read") {
+    const inboxId = normalized[2];
     if (!inboxId) {
       throw new Error("usage: agentinbox inbox read <inboxId>");
     }
@@ -183,15 +209,15 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "inbox" && args[1] === "watch") {
-    const inboxId = args[2];
+  if (command === "inbox" && normalized[1] === "watch") {
+    const inboxId = normalized[2];
     if (!inboxId) {
       throw new Error("usage: agentinbox inbox watch <inboxId> [--after-item ID] [--include-acked] [--heartbeat-ms N]");
     }
     for await (const event of client.watchInbox(inboxId, {
-      afterItemId: takeFlagValue(args, "--after-item"),
-      includeAcked: hasFlag(args, "--include-acked"),
-      heartbeatMs: parseOptionalNumber(takeFlagValue(args, "--heartbeat-ms")),
+      afterItemId: takeFlagValue(normalized, "--after-item"),
+      includeAcked: hasFlag(normalized, "--include-acked"),
+      heartbeatMs: parseOptionalNumber(takeFlagValue(normalized, "--heartbeat-ms")),
     })) {
       if (event.event !== "items") {
         continue;
@@ -201,10 +227,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "inbox" && args[1] === "ack") {
-    const inboxId = args[2];
-    const itemId = takeFlagValue(args, "--item");
-    const ackAll = hasFlag(args, "--all");
+  if (command === "inbox" && normalized[1] === "ack") {
+    const inboxId = normalized[2];
+    const itemId = takeFlagValue(normalized, "--item");
+    const ackAll = hasFlag(normalized, "--all");
     if (ackAll && itemId) {
       throw new Error("usage: agentinbox inbox ack <inboxId> (--item <itemId> | --all)");
     }
@@ -219,10 +245,15 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "fixture" && args[1] === "emit") {
-    const sourceId = args[2];
-    const sourceNativeId = takeFlagValue(args, "--native-id") ?? `fixture-${Date.now()}`;
-    const eventVariant = takeFlagValue(args, "--event") ?? "message";
+  if (command === "fixture" && hasHelpFlag(normalized.slice(1))) {
+    printHelp(["fixture"]);
+    return;
+  }
+
+  if (command === "fixture" && normalized[1] === "emit") {
+    const sourceId = normalized[2];
+    const sourceNativeId = takeFlagValue(normalized, "--native-id") ?? `fixture-${Date.now()}`;
+    const eventVariant = takeFlagValue(normalized, "--event") ?? "message";
     if (!sourceId) {
       throw new Error("usage: agentinbox fixture emit <sourceId> [--native-id ID] [--event EVENT] [--metadata-json JSON] [--payload-json JSON]");
     }
@@ -230,17 +261,22 @@ async function main(): Promise<void> {
       sourceId,
       sourceNativeId,
       eventVariant,
-      metadata: parseJsonArg(takeFlagValue(args, "--metadata-json")),
-      rawPayload: parseJsonArg(takeFlagValue(args, "--payload-json")),
+      metadata: parseJsonArg(takeFlagValue(normalized, "--metadata-json")),
+      rawPayload: parseJsonArg(takeFlagValue(normalized, "--payload-json")),
     });
     return;
   }
 
-  if (command === "deliver" && args[1] === "send") {
-    const provider = takeFlagValue(args, "--provider");
-    const surface = takeFlagValue(args, "--surface");
-    const targetRef = takeFlagValue(args, "--target");
-    const kind = takeFlagValue(args, "--kind") ?? "reply";
+  if (command === "deliver" && hasHelpFlag(normalized.slice(1))) {
+    printHelp(["deliver"]);
+    return;
+  }
+
+  if (command === "deliver" && normalized[1] === "send") {
+    const provider = takeFlagValue(normalized, "--provider");
+    const surface = takeFlagValue(normalized, "--surface");
+    const targetRef = takeFlagValue(normalized, "--target");
+    const kind = takeFlagValue(normalized, "--kind") ?? "reply";
     if (!provider || !surface || !targetRef) {
       throw new Error("usage: agentinbox deliver send --provider PROVIDER --surface SURFACE --target TARGET [--kind KIND] [--payload-json JSON]");
     }
@@ -248,10 +284,10 @@ async function main(): Promise<void> {
       provider,
       surface,
       targetRef,
-      threadRef: takeFlagValue(args, "--thread") ?? null,
-      replyMode: takeFlagValue(args, "--reply-mode") ?? null,
+      threadRef: takeFlagValue(normalized, "--thread") ?? null,
+      replyMode: takeFlagValue(normalized, "--reply-mode") ?? null,
       kind,
-      payload: parseJsonArg(takeFlagValue(args, "--payload-json")),
+      payload: parseJsonArg(takeFlagValue(normalized, "--payload-json")),
     });
     return;
   }
@@ -347,6 +383,20 @@ function parseOptionalNumber(value: string | undefined): number | undefined {
   return parsed;
 }
 
+function normalizeHelpArgs(args: string[]): string[] {
+  if (args[0] !== "help") {
+    return args;
+  }
+  if (!args[1]) {
+    return ["help"];
+  }
+  return [args[1], "--help"];
+}
+
+function hasHelpFlag(args: string[]): boolean {
+  return args.includes("--help") || args.includes("-h");
+}
+
 function buildQuery(params: Record<string, string | undefined>): string {
   const search = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
@@ -358,38 +408,92 @@ function buildQuery(params: Record<string, string | undefined>): string {
   return query ? `?${query}` : "";
 }
 
-function printHelp(): void {
-  console.log(`agentinbox
+function printHelp(path: string[] = []): void {
+  const key = path[0] ?? "root";
+  const helpByKey: Record<string, string> = {
+    root: `agentinbox
+
+Usage:
+  agentinbox <command> [options]
+  agentinbox help [command]
+  agentinbox --help
+  agentinbox --version
 
 Commands:
+  serve
+  source
+  subscription
+  inbox
+  fixture
+  deliver
+  status
+  version
+
+Try:
+  agentinbox <command> --help
+`,
+    serve: `agentinbox serve
+
+Usage:
   agentinbox serve [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
   agentinbox serve --port 4747 [--state ~/.agentinbox/agentinbox.sqlite]
+`,
+    source: `agentinbox source
+
+Usage:
   agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]
   agentinbox source list
   agentinbox source show <sourceId>
   agentinbox source poll <sourceId>
   agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]
+`,
+    subscription: `agentinbox subscription
+
+Usage:
   agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
   agentinbox subscription list [--source-id ID] [--agent-id ID] [--inbox-id ID]
   agentinbox subscription show <subscriptionId>
   agentinbox subscription poll <subscriptionId>
   agentinbox subscription lag <subscriptionId>
   agentinbox subscription reset <subscriptionId> --start-policy latest|earliest|at_offset|at_time [--start-offset N] [--start-time ISO8601]
+`,
+    inbox: `agentinbox inbox
+
+Usage:
   agentinbox inbox list
   agentinbox inbox ensure <inboxId> --agent-id <agentId>
   agentinbox inbox show <inboxId>
   agentinbox inbox read <inboxId>
   agentinbox inbox watch <inboxId> [--after-item ID] [--include-acked] [--heartbeat-ms N]
   agentinbox inbox ack <inboxId> (--item <itemId> | --all)
-  agentinbox fixture emit <sourceId> [--native-id ID] [--event EVENT] [--metadata-json JSON] [--payload-json JSON]
-  agentinbox deliver send --provider PROVIDER --surface SURFACE --target TARGET [--kind KIND] [--payload-json JSON]
-  agentinbox status
+`,
+    fixture: `agentinbox fixture
 
-Global client flags:
-  --home PATH
-  --socket PATH
-  --url URL
-`);
+Usage:
+  agentinbox fixture emit <sourceId> [--native-id ID] [--event EVENT] [--metadata-json JSON] [--payload-json JSON]
+`,
+    deliver: `agentinbox deliver
+
+Usage:
+  agentinbox deliver send --provider PROVIDER --surface SURFACE --target TARGET [--kind KIND] [--payload-json JSON]
+`,
+    status: `agentinbox status
+
+Usage:
+  agentinbox status
+`,
+    version: `agentinbox version
+
+Usage:
+  agentinbox version
+  agentinbox --version
+`,
+  };
+  console.log(helpByKey[key] ?? helpByKey.root);
+}
+
+function printVersion(): void {
+  console.log(`agentinbox ${pkg.version}`);
 }
 
 main().catch((error) => {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
+import { spawnSync } from "node:child_process";
 import { AgentInboxStore } from "../src/store";
 import { AgentInboxService } from "../src/service";
 import { AdapterRegistry } from "../src/adapters";
@@ -13,6 +14,29 @@ import { startControlServer } from "../src/control_server";
 import { DEFAULT_AGENTINBOX_PORT, resolveClientTransport, resolveServeConfig } from "../src/paths";
 import { Activation, InboxItem, RegisterSourceInput, RegisterSubscriptionInput, SubscriptionPollResult, SubscriptionSource } from "../src/model";
 import { nowIso } from "../src/util";
+
+test("cli version and help subcommands print text output", () => {
+  const repoDir = "/Users/jolestar/opensource/src/github.com/holon-run/agentinbox";
+  const version = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "--version"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  });
+  assert.equal(version.status, 0);
+  assert.match(version.stdout, /^agentinbox 0\.1\.0/m);
+
+  const helpInbox = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "help", "inbox"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  });
+  const inboxHelp = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "inbox", "--help"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  });
+  assert.equal(helpInbox.status, 0);
+  assert.equal(inboxHelp.status, 0);
+  assert.match(helpInbox.stdout, /agentinbox inbox/);
+  assert.equal(helpInbox.stdout, inboxHelp.stdout);
+});
 
 test("resolveServeConfig derives home, db, and socket defaults from AGENTINBOX_HOME", () => {
   const homeDir = path.join(os.tmpdir(), `agentinbox-home-${Date.now()}`);

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -16,13 +16,13 @@ import { Activation, InboxItem, RegisterSourceInput, RegisterSubscriptionInput, 
 import { nowIso } from "../src/util";
 
 test("cli version and help subcommands print text output", () => {
-  const repoDir = "/Users/jolestar/opensource/src/github.com/holon-run/agentinbox";
+  const repoDir = path.resolve(__dirname, "..");
   const version = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "--version"], {
     cwd: repoDir,
     encoding: "utf8",
   });
   assert.equal(version.status, 0);
-  assert.match(version.stdout, /^agentinbox 0\.1\.0/m);
+  assert.match(version.stdout, /^agentinbox \d+\.\d+\.\d+/m);
 
   const helpInbox = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "help", "inbox"], {
     cwd: repoDir,
@@ -36,6 +36,20 @@ test("cli version and help subcommands print text output", () => {
   assert.equal(inboxHelp.status, 0);
   assert.match(helpInbox.stdout, /agentinbox inbox/);
   assert.equal(helpInbox.stdout, inboxHelp.stdout);
+
+  const helpVersion = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "help", "version"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  });
+  const versionHelp = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "version", "--help"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  });
+  assert.equal(helpVersion.status, 0);
+  assert.equal(versionHelp.status, 0);
+  assert.match(helpVersion.stdout, /agentinbox version/);
+  assert.match(helpVersion.stdout, /--version, -v/);
+  assert.equal(helpVersion.stdout, versionHelp.stdout);
 });
 
 test("resolveServeConfig derives home, db, and socket defaults from AGENTINBOX_HOME", () => {


### PR DESCRIPTION
## Summary
- normalize root and subcommand help flows around `help`, `--help`, and `-h`
- add `version`, `--version`, and `-v` text output
- keep resource commands JSON while making meta commands text-oriented

## Testing
- npm test
