### PR TITLE
Add runtime-aware terminal registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,43 @@ agentinbox subscription add alpha <source_id> \
   --activation-mode activation_with_items
 ```
 
+## Terminal Targets
+
+For local agent sessions that do not expose a notification API, `AgentInbox`
+can register the current terminal session and inject an `agent_prompt` back
+into it when new inbox items arrive.
+
+Register the current session:
+
+```bash
+agentinbox terminal register
+```
+
+The response includes an assigned `agentId` and a `targetId`. Use the returned
+`agentId` for later subscription and inbox commands, and use the returned
+`targetId` when you want a subscription to notify this terminal session.
+
+Attach that terminal target to a subscription:
+
+```bash
+agentinbox subscription add <agent_id> <source_id> \
+  --terminal-target <target_id>
+```
+
+`AgentInbox` detects the current terminal context automatically. `tmux` targets
+are injected with `send-keys ... Enter`. `iTerm2` targets are injected through
+AppleScript using the current session identity. When available, runtime session
+identities such as `CODEX_THREAD_ID` are recorded and used to derive a stable
+assigned `agentId`.
+
+Terminal notifications are gated by inbox acknowledgement:
+
+- the first batch of new inbox items triggers one injected prompt
+- no further prompt is injected until the inbox is acknowledged
+- if more items arrive before acknowledgement, they are coalesced
+- if the session never acknowledges, the prompt is retried after the target's
+  notify lease expires
+
 ## CLI
 
 `help` and `version` are text-first:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { AdapterRegistry } from "./adapters";
 import { AgentInboxClient } from "./client";
 import { startControlServer } from "./control_server";
 import { resolveClientTransport, resolveServeConfig } from "./paths";
+import { detectTerminalContext } from "./terminal";
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -109,7 +110,7 @@ async function main(): Promise<void> {
   if (command === "subscription" && normalized[1] === "add") {
     const [agentId, sourceId] = normalized.slice(2, 4);
     if (!agentId || !sourceId) {
-      throw new Error("usage: agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
+      throw new Error("usage: agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--terminal-target ID] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
     }
     await printRemote(client, "/subscriptions/register", {
       agentId,
@@ -117,6 +118,7 @@ async function main(): Promise<void> {
       inboxId: takeFlagValue(normalized, "--inbox-id") ?? undefined,
       matchRules: parseJsonArg(takeFlagValue(normalized, "--match-json")),
       activationTarget: takeFlagValue(normalized, "--activation-target") ?? null,
+      terminalTargetId: takeFlagValue(normalized, "--terminal-target") ?? null,
       activationMode: takeFlagValue(normalized, "--activation-mode") ?? undefined,
       startPolicy: takeFlagValue(normalized, "--start-policy") ?? undefined,
       startOffset: parseOptionalNumber(takeFlagValue(normalized, "--start-offset")),
@@ -247,6 +249,41 @@ async function main(): Promise<void> {
       return;
     }
     await printRemote(client, `/inboxes/${encodeURIComponent(inboxId)}/ack`, { itemIds: [itemId] });
+    return;
+  }
+
+  if (command === "terminal" && hasHelpFlag(normalized.slice(1))) {
+    printHelp(["terminal"]);
+    return;
+  }
+
+  if (command === "terminal" && normalized[1] === "register") {
+    const detected = detectTerminalContext(process.env);
+    await printRemote(client, "/terminals/register", {
+      backend: detected.backend,
+      runtimeKind: detected.runtimeKind,
+      runtimeSessionId: detected.runtimeSessionId ?? null,
+      mode: "agent_prompt",
+      tmuxPaneId: detected.tmuxPaneId ?? null,
+      tty: detected.tty ?? null,
+      termProgram: detected.termProgram ?? null,
+      itermSessionId: detected.itermSessionId ?? null,
+      notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? null,
+    });
+    return;
+  }
+
+  if (command === "terminal" && normalized[1] === "list") {
+    await printRemote(client, "/terminals", undefined, "GET");
+    return;
+  }
+
+  if (command === "terminal" && normalized[1] === "show") {
+    const targetId = normalized[2];
+    if (!targetId) {
+      throw new Error("usage: agentinbox terminal show <targetId>");
+    }
+    await printRemote(client, `/terminals/${encodeURIComponent(targetId)}`, undefined, "GET");
     return;
   }
 
@@ -429,6 +466,7 @@ Commands:
   source
   subscription
   inbox
+  terminal
   fixture
   deliver
   status
@@ -455,7 +493,7 @@ Usage:
     subscription: `agentinbox subscription
 
 Usage:
-  agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
+  agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--terminal-target ID] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
   agentinbox subscription list [--source-id ID] [--agent-id ID] [--inbox-id ID]
   agentinbox subscription show <subscriptionId>
   agentinbox subscription poll <subscriptionId>
@@ -471,6 +509,13 @@ Usage:
   agentinbox inbox read <inboxId>
   agentinbox inbox watch <inboxId> [--after-item ID] [--include-acked] [--heartbeat-ms N]
   agentinbox inbox ack <inboxId> (--item <itemId> | --all)
+`,
+    terminal: `agentinbox terminal
+
+Usage:
+  agentinbox terminal register [--notify-lease-ms N]
+  agentinbox terminal list
+  agentinbox terminal show <targetId>
 `,
     fixture: `agentinbox fixture
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -116,6 +116,38 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
+      if (req.method === "GET" && url.pathname === "/terminals") {
+        send(res, 200, { terminals: service.listTerminalTargets() });
+        return;
+      }
+
+      if (req.method === "POST" && url.pathname === "/terminals/register") {
+        const body = await readJson(req);
+        const backend = parseRequiredString(body.backend, "terminals/register requires backend");
+        if (!backend) {
+          send(res, 400, { error: "terminals/register requires backend" });
+          return;
+        }
+        send(res, 200, service.registerTerminalTarget({
+          backend: backend as never,
+          runtimeKind: parseOptionalString(body.runtimeKind) as never,
+          runtimeSessionId: parseOptionalString(body.runtimeSessionId),
+          mode: parseOptionalString(body.mode) as never,
+          tmuxPaneId: parseOptionalString(body.tmuxPaneId),
+          tty: parseOptionalString(body.tty),
+          termProgram: parseOptionalString(body.termProgram),
+          itermSessionId: parseOptionalString(body.itermSessionId),
+          notifyLeaseMs: parseOptionalInteger(body.notifyLeaseMs) ?? null,
+        }));
+        return;
+      }
+
+      const terminalMatch = url.pathname.match(/^\/terminals\/([^/]+)$/);
+      if (req.method === "GET" && terminalMatch) {
+        send(res, 200, service.getTerminalTarget(decodeURIComponent(terminalMatch[1])));
+        return;
+      }
+
       const subscriptionMatch = url.pathname.match(/^\/subscriptions\/([^/]+)$/);
       if (req.method === "GET" && subscriptionMatch) {
         send(res, 200, await service.getSubscriptionDetails(decodeURIComponent(subscriptionMatch[1])));
@@ -299,9 +331,15 @@ export function createServer(service: AgentInboxService): http.Server {
         message.startsWith("sources/events requires") ||
         message.startsWith("deliveryHandle requires") ||
         message.startsWith("subscriptions/reset requires") ||
+        message.startsWith("terminals/register requires") ||
         message.startsWith("inboxes/ensure requires") ||
         message.startsWith("inbox ") ||
-        message.startsWith("unsupported start policy")
+        message.startsWith("unsupported start policy") ||
+        message.startsWith("unsupported terminal") ||
+        message.includes("requires tmuxPaneId") ||
+        message.includes("requires itermSessionId") ||
+        message.includes("already belongs to agent") ||
+        message.includes("belongs to agent")
       ) {
         send(res, 400, { error: message });
         return;

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,6 +2,9 @@ export type SourceType = "fixture" | "custom" | "github_repo" | "github_repo_ci"
 
 export type SubscriptionStartPolicy = "latest" | "earliest" | "at_offset" | "at_time";
 export type ActivationMode = "activation_only" | "activation_with_items";
+export type TerminalBackend = "tmux" | "iterm2";
+export type TerminalMode = "agent_prompt";
+export type RuntimeKind = "codex" | "claude_code" | "unknown";
 
 export interface DeliveryHandle {
   provider: string;
@@ -36,11 +39,41 @@ export interface Subscription {
   inboxId: string;
   matchRules: Record<string, unknown>;
   activationTarget?: string | null;
+  terminalTargetId?: string | null;
   activationMode: ActivationMode;
   startPolicy: SubscriptionStartPolicy;
   startOffset?: number | null;
   startTime?: string | null;
   createdAt: string;
+}
+
+export interface TerminalTarget {
+  targetId: string;
+  agentId: string;
+  runtimeKind: RuntimeKind;
+  runtimeSessionId?: string | null;
+  backend: TerminalBackend;
+  mode: TerminalMode;
+  tmuxPaneId?: string | null;
+  tty?: string | null;
+  termProgram?: string | null;
+  itermSessionId?: string | null;
+  notifyLeaseMs: number;
+  createdAt: string;
+  updatedAt: string;
+  lastSeenAt: string;
+}
+
+export interface TerminalDispatchState {
+  inboxId: string;
+  targetId: string;
+  status: "notified" | "dirty";
+  leaseExpiresAt: string | null;
+  pendingNewItemCount: number;
+  pendingSummary: string | null;
+  pendingSubscriptionIds: string[];
+  pendingSourceIds: string[];
+  updatedAt: string;
 }
 
 export interface InboxItem {
@@ -108,10 +141,23 @@ export interface RegisterSubscriptionInput {
   inboxId?: string;
   matchRules?: Record<string, unknown>;
   activationTarget?: string | null;
+  terminalTargetId?: string | null;
   activationMode?: ActivationMode;
   startPolicy?: SubscriptionStartPolicy;
   startOffset?: number | null;
   startTime?: string | null;
+}
+
+export interface RegisterTerminalTargetInput {
+  backend: TerminalBackend;
+  runtimeKind?: RuntimeKind | null;
+  runtimeSessionId?: string | null;
+  mode?: TerminalMode;
+  tmuxPaneId?: string | null;
+  tty?: string | null;
+  termProgram?: string | null;
+  itermSessionId?: string | null;
+  notifyLeaseMs?: number | null;
 }
 
 export interface AppendSourceEventInput {

--- a/src/service.ts
+++ b/src/service.ts
@@ -11,10 +11,13 @@ import {
   InboxWatchEvent,
   RegisterSourceInput,
   RegisterSubscriptionInput,
+  RegisterTerminalTargetInput,
   SourcePollResult,
   Subscription,
   SubscriptionPollResult,
   SubscriptionSource,
+  TerminalDispatchState,
+  TerminalTarget,
   WatchInboxOptions,
 } from "./model";
 import { AgentInboxStore } from "./store";
@@ -29,12 +32,16 @@ import {
 } from "./backend";
 import { generateId, nowIso } from "./util";
 import { matchSubscription } from "./matcher";
+import { assignedAgentIdFromContext, detectTerminalContext, renderAgentPrompt, TerminalDispatcher } from "./terminal";
 
 const DEFAULT_SUBSCRIPTION_POLL_LIMIT = 100;
 const DEFAULT_ACTIVATION_WINDOW_MS = 3_000;
 const DEFAULT_ACTIVATION_MAX_ITEMS = 20;
+const DEFAULT_TERMINAL_NOTIFY_LEASE_MS = 10 * 60 * 1000;
+const DEFAULT_TERMINAL_RETRY_MS = 5_000;
 const ACTIVATION_MODES = new Set<Subscription["activationMode"]>(["activation_only", "activation_with_items"]);
 const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
+const TERMINAL_MODES = new Set<TerminalTarget["mode"]>(["agent_prompt"]);
 
 interface ActivationBuffer {
   agentId: string;
@@ -56,6 +63,19 @@ interface ActivationPolicy {
   maxItems?: number;
 }
 
+interface BufferedTerminalNotification {
+  inboxId: string;
+  terminalTargetId: string;
+  agentId: string;
+  pending: Array<{
+    subscriptionId: string;
+    sourceId: string;
+    summary: string;
+  }>;
+  timer: NodeJS.Timeout | null;
+  inFlight: boolean;
+}
+
 interface InboxWatcher {
   onItems(items: InboxItem[]): void;
 }
@@ -72,6 +92,7 @@ export class AgentInboxService {
   private readonly activationWindowMs: number;
   private readonly activationMaxItems: number;
   private readonly activationBuffers = new Map<string, ActivationBuffer>();
+  private readonly terminalBuffers = new Map<string, BufferedTerminalNotification>();
   private readonly inboxWatchers = new Map<string, Set<InboxWatcher>>();
   private subscriptionInterval: NodeJS.Timeout | null = null;
   private stopping = false;
@@ -82,14 +103,17 @@ export class AgentInboxService {
     activationDispatcher: ActivationDispatcher = new ActivationDispatcher(),
     backend?: EventBusBackend,
     activationPolicy?: ActivationPolicy,
+    terminalDispatcher: TerminalDispatcher = new TerminalDispatcher(),
   ) {
     this.activationDispatcher = activationDispatcher;
     this.backend = backend ?? new SqliteEventBusBackend(store);
     this.activationWindowMs = activationPolicy?.windowMs ?? DEFAULT_ACTIVATION_WINDOW_MS;
     this.activationMaxItems = activationPolicy?.maxItems ?? DEFAULT_ACTIVATION_MAX_ITEMS;
+    this.terminalDispatcher = terminalDispatcher;
   }
 
   private readonly activationDispatcher: ActivationDispatcher;
+  private readonly terminalDispatcher: TerminalDispatcher;
 
   async start(): Promise<void> {
     if (this.subscriptionInterval) {
@@ -98,13 +122,21 @@ export class AgentInboxService {
     this.stopping = false;
     this.subscriptionInterval = setInterval(() => {
       void this.syncAllSubscriptions();
+      void this.syncTerminalDispatchStates();
     }, 2_000);
     await this.syncAllSubscriptions();
+    await this.syncTerminalDispatchStates();
   }
 
   async stop(): Promise<void> {
     this.stopping = true;
     for (const buffer of this.activationBuffers.values()) {
+      if (buffer.timer) {
+        clearTimeout(buffer.timer);
+        buffer.timer = null;
+      }
+    }
+    for (const buffer of this.terminalBuffers.values()) {
       if (buffer.timer) {
         clearTimeout(buffer.timer);
         buffer.timer = null;
@@ -168,6 +200,9 @@ export class AgentInboxService {
       throw new Error(`unknown source: ${input.sourceId}`);
     }
     const activationMode = normalizeActivationMode(input.activationMode);
+    const terminalTarget = input.terminalTargetId
+      ? this.getTerminalTarget(input.terminalTargetId)
+      : null;
 
     const inboxId = input.inboxId ?? defaultInboxIdForAgent(input.agentId);
     this.ensureInbox(inboxId, input.agentId);
@@ -178,6 +213,7 @@ export class AgentInboxService {
       inboxId,
       matchRules: input.matchRules ?? {},
       activationTarget: input.activationTarget ?? null,
+      terminalTargetId: terminalTarget?.targetId ?? null,
       activationMode,
       startPolicy: input.startPolicy ?? "latest",
       startOffset: input.startOffset ?? null,
@@ -196,6 +232,75 @@ export class AgentInboxService {
       startTime: subscription.startTime ?? null,
     });
     return subscription;
+  }
+
+  registerTerminalTarget(input: RegisterTerminalTargetInput): TerminalTarget {
+    const mode = normalizeTerminalMode(input.mode);
+    validateTerminalIdentity(input);
+    const runtimeKind = input.runtimeKind ?? "unknown";
+    const agentId = assignedAgentIdFromContext({
+      runtimeKind,
+      runtimeSessionId: input.runtimeSessionId ?? null,
+      backend: input.backend,
+      tmuxPaneId: input.tmuxPaneId ?? null,
+      itermSessionId: input.itermSessionId ?? null,
+      tty: input.tty ?? null,
+    });
+
+    const now = nowIso();
+    const existing = findExistingTerminalTarget(this.store, input);
+    if (existing) {
+      return this.store.updateTerminalTargetHeartbeat(existing.targetId, {
+        updatedAt: now,
+        lastSeenAt: now,
+      });
+    }
+
+    const target: TerminalTarget = {
+      targetId: generateId("term"),
+      agentId,
+      runtimeKind,
+      runtimeSessionId: input.runtimeSessionId ?? null,
+      backend: input.backend,
+      mode,
+      tmuxPaneId: input.tmuxPaneId ?? null,
+      tty: input.tty ?? null,
+      termProgram: input.termProgram ?? null,
+      itermSessionId: input.itermSessionId ?? null,
+      notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_TERMINAL_NOTIFY_LEASE_MS,
+      createdAt: now,
+      updatedAt: now,
+      lastSeenAt: now,
+    };
+    this.store.insertTerminalTarget(target);
+    return target;
+  }
+
+  detectAndRegisterTerminalTarget(notifyLeaseMs?: number | null, env: NodeJS.ProcessEnv = process.env): TerminalTarget {
+    const detected = detectTerminalContext(env);
+    return this.registerTerminalTarget({
+      runtimeKind: detected.runtimeKind,
+      runtimeSessionId: detected.runtimeSessionId ?? null,
+      backend: detected.backend,
+      mode: "agent_prompt",
+      tmuxPaneId: detected.tmuxPaneId ?? null,
+      tty: detected.tty ?? null,
+      termProgram: detected.termProgram ?? null,
+      itermSessionId: detected.itermSessionId ?? null,
+      notifyLeaseMs: notifyLeaseMs ?? null,
+    });
+  }
+
+  listTerminalTargets(): TerminalTarget[] {
+    return this.store.listTerminalTargets();
+  }
+
+  getTerminalTarget(targetId: string): TerminalTarget {
+    const target = this.store.getTerminalTarget(targetId);
+    if (!target) {
+      throw new Error(`unknown terminal target: ${targetId}`);
+    }
+    return target;
   }
 
   listSubscriptions(filters?: {
@@ -235,6 +340,7 @@ export class AgentInboxService {
       subscription,
       source: this.getSource(subscription.sourceId),
       inbox: this.getInbox(subscription.inboxId),
+      terminalTarget: subscription.terminalTargetId ? this.getTerminalTarget(subscription.terminalTargetId) : null,
       consumer,
       lag: await this.backend.getConsumerLag({ consumerId: consumer.consumerId }),
     };
@@ -355,10 +461,11 @@ export class AgentInboxService {
     return {
       inbox,
       subscriptions,
+      terminalDispatchStates: this.store.listTerminalDispatchStatesForInbox(inboxId),
       itemCounts: {
-        total: this.store.listInboxItems(inboxId).length,
-        unacked: this.store.listInboxItems(inboxId, { includeAcked: false }).length,
-        acked: this.store.listInboxItems(inboxId).filter((item) => item.ackedAt != null).length,
+        total: this.store.countInboxItems(inboxId, true),
+        unacked: this.store.countInboxItems(inboxId, false),
+        acked: this.store.countInboxItems(inboxId, true) - this.store.countInboxItems(inboxId, false),
       },
     };
   }
@@ -448,12 +555,20 @@ export class AgentInboxService {
   }
 
   ackInboxItems(inboxId: string, itemIds: string[]): { acked: number } {
-    return { acked: this.store.ackItems(inboxId, itemIds, nowIso()) };
+    const acked = this.store.ackItems(inboxId, itemIds, nowIso());
+    if (acked > 0) {
+      void this.handleInboxAckEffects(inboxId);
+    }
+    return { acked };
   }
 
   ackAllInboxItems(inboxId: string): { acked: number } {
     const itemIds = this.store.listInboxItems(inboxId, { includeAcked: false }).map((item) => item.itemId);
-    return { acked: this.store.ackItems(inboxId, itemIds, nowIso()) };
+    const acked = this.store.ackItems(inboxId, itemIds, nowIso());
+    if (acked > 0) {
+      void this.handleInboxAckEffects(inboxId);
+    }
+    return { acked };
   }
 
   async pollSource(sourceId: string): Promise<SourcePollResult> {
@@ -558,6 +673,18 @@ export class AgentInboxService {
               deliveryHandle: item.deliveryHandle,
             },
           });
+          if (subscription.terminalTargetId) {
+            this.enqueueTerminalNotification({
+              agentId: subscription.agentId,
+              inboxId: subscription.inboxId,
+              terminalTargetId: subscription.terminalTargetId,
+              subscriptionId: subscription.subscriptionId,
+              sourceId: source.sourceId,
+              eventVariant: event.eventVariant,
+              sourceType: source.sourceType,
+              sourceKey: source.sourceKey,
+            });
+          }
         }
       } catch (error) {
         if (insertedItems.length > 0) {
@@ -629,6 +756,8 @@ export class AgentInboxService {
       adapters: this.adapters.status(),
       recentActivations: this.store.listActivations().slice(0, 10),
       recentDeliveries: this.store.listDeliveries().slice(0, 10),
+      terminalTargets: this.store.listTerminalTargets(),
+      terminalDispatchStates: this.store.listTerminalDispatchStates(),
     };
   }
 
@@ -668,6 +797,25 @@ export class AgentInboxService {
     }
   }
 
+  private async syncTerminalDispatchStates(): Promise<void> {
+    const now = Date.now();
+    const states = this.store.listTerminalDispatchStates();
+    for (const state of states) {
+      if (!state.leaseExpiresAt) {
+        continue;
+      }
+      const expiresAt = Date.parse(state.leaseExpiresAt);
+      if (Number.isNaN(expiresAt) || expiresAt > now) {
+        continue;
+      }
+      try {
+        await this.maybeDispatchTerminalNotification(state.inboxId, state.targetId, "lease");
+      } catch (error) {
+        console.warn(`terminal notify lease sync failed for ${state.targetId}/${state.inboxId}:`, error);
+      }
+    }
+  }
+
   private notifyInboxWatchers(inboxId: string, items: InboxItem[]): void {
     const watchers = this.inboxWatchers.get(inboxId);
     if (!watchers || watchers.size === 0) {
@@ -675,6 +823,51 @@ export class AgentInboxService {
     }
     for (const watcher of watchers) {
       watcher.onItems(items);
+    }
+  }
+
+  private enqueueTerminalNotification(input: {
+    agentId: string;
+    inboxId: string;
+    terminalTargetId: string;
+    subscriptionId: string;
+    sourceId: string;
+    eventVariant: string;
+    sourceType: string;
+    sourceKey: string;
+  }): void {
+    const key = terminalBufferKey(input.inboxId, input.terminalTargetId);
+    let buffer = this.terminalBuffers.get(key);
+    if (!buffer) {
+      buffer = {
+        inboxId: input.inboxId,
+        terminalTargetId: input.terminalTargetId,
+        agentId: input.agentId,
+        pending: [],
+        timer: null,
+        inFlight: false,
+      };
+      this.terminalBuffers.set(key, buffer);
+    }
+
+    buffer.pending.push({
+      subscriptionId: input.subscriptionId,
+      sourceId: input.sourceId,
+      summary: `${input.sourceType}:${input.sourceKey}:${input.eventVariant}`,
+    });
+
+    if (!buffer.timer && !buffer.inFlight) {
+      buffer.timer = setTimeout(() => {
+        void this.flushTerminalBuffer(key);
+      }, this.activationWindowMs);
+    }
+
+    if (buffer.pending.length >= this.activationMaxItems) {
+      if (buffer.timer) {
+        clearTimeout(buffer.timer);
+        buffer.timer = null;
+      }
+      void this.flushTerminalBuffer(key);
     }
   }
 
@@ -794,6 +987,168 @@ export class AgentInboxService {
       throw error;
     }
   }
+
+  private async flushTerminalBuffer(key: string): Promise<void> {
+    const buffer = this.terminalBuffers.get(key);
+    if (!buffer || buffer.inFlight || buffer.pending.length === 0) {
+      return;
+    }
+    if (buffer.timer) {
+      clearTimeout(buffer.timer);
+      buffer.timer = null;
+    }
+
+    buffer.inFlight = true;
+    const entries = buffer.pending.splice(0, buffer.pending.length);
+    try {
+      const summary = entries[0]?.summary ?? null;
+      const state = this.store.getTerminalDispatchState(buffer.inboxId, buffer.terminalTargetId);
+      if (!state) {
+        const dispatched = await this.dispatchTerminalNotification({
+          inboxId: buffer.inboxId,
+          targetId: buffer.terminalTargetId,
+          agentId: buffer.agentId,
+          newItemCount: entries.length,
+          summary,
+          subscriptionIds: uniqueSorted(entries.map((entry) => entry.subscriptionId)),
+          sourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
+        });
+        if (!dispatched) {
+          this.upsertDirtyTerminalState(buffer.inboxId, buffer.terminalTargetId, entries);
+        }
+      } else {
+        this.store.upsertTerminalDispatchState({
+          inboxId: buffer.inboxId,
+          targetId: buffer.terminalTargetId,
+          status: "dirty",
+          leaseExpiresAt: state.leaseExpiresAt,
+          pendingNewItemCount: state.pendingNewItemCount + entries.length,
+          pendingSummary: state.pendingSummary ?? summary,
+          pendingSubscriptionIds: uniqueSorted([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)]),
+          pendingSourceIds: uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)]),
+          updatedAt: nowIso(),
+        });
+      }
+
+      const hasPendingDuringFlight = buffer.pending.length > 0;
+      buffer.inFlight = false;
+      if (hasPendingDuringFlight) {
+        buffer.timer = setTimeout(() => {
+          void this.flushTerminalBuffer(key);
+        }, this.activationWindowMs);
+        return;
+      }
+      this.terminalBuffers.delete(key);
+    } catch (error) {
+      buffer.pending.unshift(...entries);
+      buffer.inFlight = false;
+      if (!this.stopping && !buffer.timer) {
+        buffer.timer = setTimeout(() => {
+          void this.flushTerminalBuffer(key);
+        }, this.activationWindowMs);
+      }
+      throw error;
+    }
+  }
+
+  private async handleInboxAckEffects(inboxId: string): Promise<void> {
+    const states = this.store.listTerminalDispatchStatesForInbox(inboxId);
+    for (const state of states) {
+      await this.maybeDispatchTerminalNotification(inboxId, state.targetId, "ack");
+    }
+  }
+
+  private async maybeDispatchTerminalNotification(
+    inboxId: string,
+    targetId: string,
+    reason: "ack" | "lease",
+  ): Promise<void> {
+    const state = this.store.getTerminalDispatchState(inboxId, targetId);
+    if (!state) {
+      return;
+    }
+    const unacked = this.store.countInboxItems(inboxId, false);
+    if (unacked === 0) {
+      this.store.deleteTerminalDispatchState(inboxId, targetId);
+      return;
+    }
+
+    if (reason === "ack" && state.status !== "dirty") {
+      return;
+    }
+
+    const dispatched = await this.dispatchTerminalNotification({
+      inboxId,
+      targetId,
+      agentId: this.getTerminalTarget(targetId).agentId,
+      newItemCount: state.pendingNewItemCount > 0 ? state.pendingNewItemCount : unacked,
+      summary: state.pendingSummary,
+      subscriptionIds: state.pendingSubscriptionIds,
+      sourceIds: state.pendingSourceIds,
+    });
+
+    if (!dispatched) {
+      this.store.upsertTerminalDispatchState({
+        ...state,
+        status: "dirty",
+        leaseExpiresAt: new Date(Date.now() + DEFAULT_TERMINAL_RETRY_MS).toISOString(),
+        updatedAt: nowIso(),
+      });
+    }
+  }
+
+  private async dispatchTerminalNotification(input: {
+    inboxId: string;
+    targetId: string;
+    agentId: string;
+    newItemCount: number;
+    summary: string | null;
+    subscriptionIds: string[];
+    sourceIds: string[];
+  }): Promise<boolean> {
+    const target = this.getTerminalTarget(input.targetId);
+    const prompt = renderAgentPrompt({
+      inboxId: input.inboxId,
+      newItemCount: input.newItemCount,
+      summary: input.summary,
+    });
+    try {
+      await this.terminalDispatcher.dispatch(target, prompt);
+      this.store.upsertTerminalDispatchState({
+        inboxId: input.inboxId,
+        targetId: input.targetId,
+        status: "notified",
+        leaseExpiresAt: new Date(Date.now() + target.notifyLeaseMs).toISOString(),
+        pendingNewItemCount: 0,
+        pendingSummary: null,
+        pendingSubscriptionIds: [],
+        pendingSourceIds: [],
+        updatedAt: nowIso(),
+      });
+      return true;
+    } catch (error) {
+      console.warn(`terminal dispatch failed for ${target.targetId}:`, error);
+      return false;
+    }
+  }
+
+  private upsertDirtyTerminalState(
+    inboxId: string,
+    targetId: string,
+    entries: Array<{ subscriptionId: string; sourceId: string; summary: string }>,
+  ): void {
+    this.store.upsertTerminalDispatchState({
+      inboxId,
+      targetId,
+      status: "dirty",
+      leaseExpiresAt: new Date(Date.now() + DEFAULT_TERMINAL_RETRY_MS).toISOString(),
+      pendingNewItemCount: entries.length,
+      pendingSummary: entries[0]?.summary ?? null,
+      pendingSubscriptionIds: uniqueSorted(entries.map((entry) => entry.subscriptionId)),
+      pendingSourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
+      updatedAt: nowIso(),
+    });
+  }
 }
 
 function resolveDeliveryHandle(request: DeliveryRequest): DeliveryHandle {
@@ -854,4 +1209,54 @@ function normalizeActivationMode(mode: RegisterSubscriptionInput["activationMode
     throw new Error(`unsupported activation mode: ${String(mode)}`);
   }
   return resolved;
+}
+
+function normalizeTerminalMode(mode: RegisterTerminalTargetInput["mode"]): TerminalTarget["mode"] {
+  const resolved = mode ?? "agent_prompt";
+  if (!TERMINAL_MODES.has(resolved)) {
+    throw new Error(`unsupported terminal mode: ${String(mode)}`);
+  }
+  return resolved;
+}
+
+function validateTerminalIdentity(input: RegisterTerminalTargetInput): void {
+  if (input.backend === "tmux") {
+    if (!input.tmuxPaneId) {
+      throw new Error("tmux terminal target requires tmuxPaneId");
+    }
+    return;
+  }
+  if (input.backend === "iterm2") {
+    if (!input.itermSessionId && !input.tty) {
+      throw new Error("iterm2 terminal target requires itermSessionId or tty");
+    }
+    return;
+  }
+  throw new Error(`unsupported terminal backend: ${String(input.backend)}`);
+}
+
+function findExistingTerminalTarget(store: AgentInboxStore, input: RegisterTerminalTargetInput): TerminalTarget | null {
+  if (input.runtimeSessionId) {
+    return store.getTerminalTargetByRuntimeSession(input.runtimeKind ?? "unknown", input.runtimeSessionId);
+  }
+  if (input.backend === "tmux" && input.tmuxPaneId) {
+    return store.getTerminalTargetByTmuxPaneId(input.tmuxPaneId);
+  }
+  if (input.backend === "iterm2") {
+    if (input.itermSessionId) {
+      return store.getTerminalTargetByItermSessionId(input.itermSessionId);
+    }
+    if (input.tty) {
+      return store.getTerminalTargetByTty(input.tty);
+    }
+  }
+  return null;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+function terminalBufferKey(inboxId: string, terminalTargetId: string): string {
+  return `${inboxId}::${terminalTargetId}`;
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -203,6 +203,9 @@ export class AgentInboxService {
     const terminalTarget = input.terminalTargetId
       ? this.getTerminalTarget(input.terminalTargetId)
       : null;
+    if (terminalTarget && terminalTarget.agentId !== input.agentId) {
+      throw new Error(`terminal target ${terminalTarget.targetId} does not belong to agent ${input.agentId}`);
+    }
 
     const inboxId = input.inboxId ?? defaultInboxIdForAgent(input.agentId);
     this.ensureInbox(inboxId, input.agentId);
@@ -237,6 +240,7 @@ export class AgentInboxService {
   registerTerminalTarget(input: RegisterTerminalTargetInput): TerminalTarget {
     const mode = normalizeTerminalMode(input.mode);
     validateTerminalIdentity(input);
+    validateNotifyLeaseMs(input.notifyLeaseMs);
     const runtimeKind = input.runtimeKind ?? "unknown";
     const agentId = assignedAgentIdFromContext({
       runtimeKind,
@@ -251,6 +255,12 @@ export class AgentInboxService {
     const existing = findExistingTerminalTarget(this.store, input);
     if (existing) {
       return this.store.updateTerminalTargetHeartbeat(existing.targetId, {
+        runtimeKind,
+        runtimeSessionId: input.runtimeSessionId ?? null,
+        tmuxPaneId: input.tmuxPaneId ?? null,
+        tty: input.tty ?? null,
+        termProgram: input.termProgram ?? null,
+        itermSessionId: input.itermSessionId ?? null,
         updatedAt: now,
         lastSeenAt: now,
       });
@@ -1235,9 +1245,21 @@ function validateTerminalIdentity(input: RegisterTerminalTargetInput): void {
   throw new Error(`unsupported terminal backend: ${String(input.backend)}`);
 }
 
+function validateNotifyLeaseMs(value: number | null | undefined): void {
+  if (value == null) {
+    return;
+  }
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error("notifyLeaseMs must be a positive integer");
+  }
+}
+
 function findExistingTerminalTarget(store: AgentInboxStore, input: RegisterTerminalTargetInput): TerminalTarget | null {
   if (input.runtimeSessionId) {
-    return store.getTerminalTargetByRuntimeSession(input.runtimeKind ?? "unknown", input.runtimeSessionId);
+    const target = store.getTerminalTargetByRuntimeSession(input.runtimeKind ?? "unknown", input.runtimeSessionId);
+    if (target) {
+      return target;
+    }
   }
   if (input.backend === "tmux" && input.tmuxPaneId) {
     return store.getTerminalTargetByTmuxPaneId(input.tmuxPaneId);

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,10 +19,12 @@ import {
   Subscription,
   SubscriptionSource,
   SubscriptionStartPolicy,
+  TerminalDispatchState,
+  TerminalTarget,
 } from "./model";
 import { generateId, nowIso } from "./util";
 
-const SCHEMA_VERSION = 4;
+const SCHEMA_VERSION = 7;
 type SqlBindParams = unknown[];
 
 function parseJson<T>(value: string | null): T {
@@ -91,6 +93,18 @@ export class AgentInboxStore {
 
     if (userVersion < 4 && this.needsActivationItemsUpgrade()) {
       this.upgradeActivationItemsSchema();
+    }
+
+    if (userVersion < 5 && this.needsSubscriptionTerminalTargetUpgrade()) {
+      this.upgradeSubscriptionTerminalTargetSchema();
+    }
+
+    if (userVersion < 6) {
+      this.createTerminalSchema();
+    }
+
+    if (userVersion < 7 && this.needsTerminalRuntimeUpgrade()) {
+      this.upgradeTerminalRuntimeSchema();
     }
 
     this.setUserVersion(SCHEMA_VERSION);
@@ -227,6 +241,10 @@ export class AgentInboxStore {
     return !this.columnExists("activations", "items_json");
   }
 
+  private needsSubscriptionTerminalTargetUpgrade(): boolean {
+    return !this.columnExists("subscriptions", "terminal_target_id");
+  }
+
   private upgradeActivationSchema(): void {
     this.inTransaction(() => {
       this.db.exec(`
@@ -281,6 +299,12 @@ export class AgentInboxStore {
     });
   }
 
+  private upgradeSubscriptionTerminalTargetSchema(): void {
+    this.inTransaction(() => {
+      this.db.exec("alter table subscriptions add column terminal_target_id text;");
+    });
+  }
+
   private createCurrentSchema(): void {
     this.createCurrentSchemaBase();
     this.createCurrentIndexes();
@@ -314,6 +338,7 @@ export class AgentInboxStore {
         inbox_id text not null,
         match_rules_json text not null,
         activation_target text,
+        terminal_target_id text,
         activation_mode text not null,
         start_policy text not null,
         start_offset integer,
@@ -406,6 +431,57 @@ export class AgentInboxStore {
         committed_at text not null
       );
     `);
+    this.createTerminalSchema();
+  }
+
+  private createTerminalSchema(): void {
+    this.db.exec(`
+      create table if not exists terminal_targets (
+        target_id text primary key,
+        agent_id text not null,
+        runtime_kind text not null default 'unknown',
+        runtime_session_id text,
+        backend text not null,
+        mode text not null,
+        tmux_pane_id text,
+        tty text,
+        term_program text,
+        iterm_session_id text,
+        notify_lease_ms integer not null,
+        created_at text not null,
+        updated_at text not null,
+        last_seen_at text not null
+      );
+
+      create table if not exists terminal_dispatch_states (
+        inbox_id text not null,
+        target_id text not null,
+        status text not null,
+        lease_expires_at text,
+        pending_new_item_count integer not null,
+        pending_summary text,
+        pending_subscription_ids_json text not null,
+        pending_source_ids_json text not null,
+        updated_at text not null,
+        primary key (inbox_id, target_id)
+      );
+    `);
+  }
+
+  private needsTerminalRuntimeUpgrade(): boolean {
+    return !this.columnExists("terminal_targets", "runtime_kind")
+      || !this.columnExists("terminal_targets", "runtime_session_id");
+  }
+
+  private upgradeTerminalRuntimeSchema(): void {
+    this.inTransaction(() => {
+      if (!this.columnExists("terminal_targets", "runtime_kind")) {
+        this.db.exec("alter table terminal_targets add column runtime_kind text not null default 'unknown';");
+      }
+      if (!this.columnExists("terminal_targets", "runtime_session_id")) {
+        this.db.exec("alter table terminal_targets add column runtime_session_id text;");
+      }
+    });
   }
 
   private createCurrentIndexes(): void {
@@ -421,6 +497,21 @@ export class AgentInboxStore {
 
       create index if not exists idx_consumer_commits_consumer
         on consumer_commits(consumer_id, committed_offset);
+
+      create unique index if not exists idx_terminal_targets_tmux_pane
+        on terminal_targets(tmux_pane_id)
+        where tmux_pane_id is not null;
+
+      create unique index if not exists idx_terminal_targets_iterm_session
+        on terminal_targets(iterm_session_id)
+        where iterm_session_id is not null;
+
+      create unique index if not exists idx_terminal_targets_runtime_session
+        on terminal_targets(runtime_kind, runtime_session_id)
+        where runtime_session_id is not null;
+
+      create index if not exists idx_terminal_dispatch_states_target
+        on terminal_dispatch_states(target_id, lease_expires_at);
     `);
   }
 
@@ -564,8 +655,8 @@ export class AgentInboxStore {
       `
       insert into subscriptions (
         subscription_id, agent_id, source_id, inbox_id, match_rules_json,
-        activation_target, activation_mode, start_policy, start_offset, start_time, created_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        activation_target, terminal_target_id, activation_mode, start_policy, start_offset, start_time, created_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         subscription.subscriptionId,
@@ -574,6 +665,7 @@ export class AgentInboxStore {
         subscription.inboxId,
         JSON.stringify(subscription.matchRules),
         subscription.activationTarget ?? null,
+        subscription.terminalTargetId ?? null,
         subscription.activationMode,
         subscription.startPolicy,
         subscription.startOffset ?? null,
@@ -595,6 +687,151 @@ export class AgentInboxStore {
       [sourceId],
     );
     return rows.map((row) => this.mapSubscription(row));
+  }
+
+  getTerminalTarget(targetId: string): TerminalTarget | null {
+    const row = this.getOne("select * from terminal_targets where target_id = ?", [targetId]);
+    return row ? this.mapTerminalTarget(row) : null;
+  }
+
+  getTerminalTargetByTmuxPaneId(tmuxPaneId: string): TerminalTarget | null {
+    const row = this.getOne("select * from terminal_targets where tmux_pane_id = ?", [tmuxPaneId]);
+    return row ? this.mapTerminalTarget(row) : null;
+  }
+
+  getTerminalTargetByItermSessionId(itermSessionId: string): TerminalTarget | null {
+    const row = this.getOne("select * from terminal_targets where iterm_session_id = ?", [itermSessionId]);
+    return row ? this.mapTerminalTarget(row) : null;
+  }
+
+  getTerminalTargetByTty(tty: string): TerminalTarget | null {
+    const row = this.getOne("select * from terminal_targets where tty = ?", [tty]);
+    return row ? this.mapTerminalTarget(row) : null;
+  }
+
+  getTerminalTargetByRuntimeSession(runtimeKind: string, runtimeSessionId: string): TerminalTarget | null {
+    const row = this.getOne(
+      "select * from terminal_targets where runtime_kind = ? and runtime_session_id = ?",
+      [runtimeKind, runtimeSessionId],
+    );
+    return row ? this.mapTerminalTarget(row) : null;
+  }
+
+  insertTerminalTarget(target: TerminalTarget): void {
+    this.db.run(
+      `
+      insert into terminal_targets (
+        target_id, agent_id, runtime_kind, runtime_session_id, backend, mode, tmux_pane_id, tty, term_program, iterm_session_id,
+        notify_lease_ms, created_at, updated_at, last_seen_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      [
+        target.targetId,
+        target.agentId,
+        target.runtimeKind,
+        target.runtimeSessionId ?? null,
+        target.backend,
+        target.mode,
+        target.tmuxPaneId ?? null,
+        target.tty ?? null,
+        target.termProgram ?? null,
+        target.itermSessionId ?? null,
+        target.notifyLeaseMs,
+        target.createdAt,
+        target.updatedAt,
+        target.lastSeenAt,
+      ],
+    );
+    this.persist();
+  }
+
+  updateTerminalTargetHeartbeat(
+    targetId: string,
+    input: { updatedAt: string; lastSeenAt: string },
+  ): TerminalTarget {
+    const target = this.getTerminalTarget(targetId);
+    if (!target) {
+      throw new Error(`unknown terminal target: ${targetId}`);
+    }
+    this.db.run(
+      `
+      update terminal_targets
+      set updated_at = ?, last_seen_at = ?
+      where target_id = ?
+    `,
+      [
+        input.updatedAt,
+        input.lastSeenAt,
+        targetId,
+      ],
+    );
+    this.persist();
+    return this.getTerminalTarget(targetId)!;
+  }
+
+  listTerminalTargets(): TerminalTarget[] {
+    const rows = this.getAll("select * from terminal_targets order by created_at asc");
+    return rows.map((row) => this.mapTerminalTarget(row));
+  }
+
+  getTerminalDispatchState(inboxId: string, targetId: string): TerminalDispatchState | null {
+    const row = this.getOne(
+      "select * from terminal_dispatch_states where inbox_id = ? and target_id = ?",
+      [inboxId, targetId],
+    );
+    return row ? this.mapTerminalDispatchState(row) : null;
+  }
+
+  listTerminalDispatchStates(): TerminalDispatchState[] {
+    const rows = this.getAll("select * from terminal_dispatch_states order by updated_at asc");
+    return rows.map((row) => this.mapTerminalDispatchState(row));
+  }
+
+  listTerminalDispatchStatesForInbox(inboxId: string): TerminalDispatchState[] {
+    const rows = this.getAll(
+      "select * from terminal_dispatch_states where inbox_id = ? order by updated_at asc",
+      [inboxId],
+    );
+    return rows.map((row) => this.mapTerminalDispatchState(row));
+  }
+
+  upsertTerminalDispatchState(state: TerminalDispatchState): void {
+    this.db.run(
+      `
+      insert into terminal_dispatch_states (
+        inbox_id, target_id, status, lease_expires_at, pending_new_item_count, pending_summary,
+        pending_subscription_ids_json, pending_source_ids_json, updated_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      on conflict(inbox_id, target_id) do update set
+        status = excluded.status,
+        lease_expires_at = excluded.lease_expires_at,
+        pending_new_item_count = excluded.pending_new_item_count,
+        pending_summary = excluded.pending_summary,
+        pending_subscription_ids_json = excluded.pending_subscription_ids_json,
+        pending_source_ids_json = excluded.pending_source_ids_json,
+        updated_at = excluded.updated_at
+    `,
+      [
+        state.inboxId,
+        state.targetId,
+        state.status,
+        state.leaseExpiresAt ?? null,
+        state.pendingNewItemCount,
+        state.pendingSummary ?? null,
+        JSON.stringify(state.pendingSubscriptionIds),
+        JSON.stringify(state.pendingSourceIds),
+        state.updatedAt,
+      ],
+    );
+    this.persist();
+  }
+
+  deleteTerminalDispatchState(inboxId: string, targetId: string): void {
+    this.db.run(
+      "delete from terminal_dispatch_states where inbox_id = ? and target_id = ?",
+      [inboxId, targetId],
+    );
+    this.persist();
   }
 
   insertInboxItem(item: InboxItem): boolean {
@@ -673,6 +910,19 @@ export class AgentInboxStore {
       this.persist();
     }
     return changes;
+  }
+
+  countInboxItems(inboxId: string, includeAcked: boolean): number {
+    const row = this.getOne(
+      `
+      select count(*) as count
+      from inbox_items
+      where inbox_id = ?
+      ${includeAcked ? "" : "and acked_at is null"}
+    `,
+      [inboxId],
+    );
+    return Number(row?.count ?? 0);
   }
 
   insertActivation(activation: Activation): void {
@@ -959,6 +1209,8 @@ export class AgentInboxStore {
       pendingInboxItems: this.count("inbox_items where acked_at is null"),
       activations: this.count("activations"),
       deliveries: this.count("deliveries"),
+      terminalTargets: this.count("terminal_targets"),
+      terminalDispatchStates: this.count("terminal_dispatch_states"),
     };
   }
 
@@ -980,7 +1232,7 @@ export class AgentInboxStore {
   private getOne(sql: string, params: SqlBindParams = []): Record<string, unknown> | undefined {
     const statement = this.db.prepare(sql);
     try {
-      statement.bind(params);
+      statement.bind(params as never);
       if (!statement.step()) {
         return undefined;
       }
@@ -993,7 +1245,7 @@ export class AgentInboxStore {
   private getAll(sql: string, params: SqlBindParams = []): Record<string, unknown>[] {
     const statement = this.db.prepare(sql);
     try {
-      statement.bind(params);
+      statement.bind(params as never);
       const rows: Record<string, unknown>[] = [];
       while (statement.step()) {
         rows.push(statement.getAsObject() as Record<string, unknown>);
@@ -1034,6 +1286,7 @@ export class AgentInboxStore {
       inboxId: String(row.inbox_id),
       matchRules: parseJson<Record<string, unknown>>(row.match_rules_json as string),
       activationTarget: row.activation_target ? String(row.activation_target) : null,
+      terminalTargetId: row.terminal_target_id ? String(row.terminal_target_id) : null,
       activationMode: (row.activation_mode ? String(row.activation_mode) : "activation_only") as Subscription["activationMode"],
       startPolicy: row.start_policy as SubscriptionStartPolicy,
       startOffset: row.start_offset != null ? Number(row.start_offset) : null,
@@ -1087,6 +1340,39 @@ export class AgentInboxStore {
       payload: parseJson<Record<string, unknown>>(row.payload_json as string),
       status: row.status as DeliveryAttempt["status"],
       createdAt: String(row.created_at),
+    };
+  }
+
+  private mapTerminalTarget(row: Record<string, unknown>): TerminalTarget {
+    return {
+      targetId: String(row.target_id),
+      agentId: String(row.agent_id),
+      runtimeKind: row.runtime_kind ? String(row.runtime_kind) as TerminalTarget["runtimeKind"] : "unknown",
+      runtimeSessionId: row.runtime_session_id ? String(row.runtime_session_id) : null,
+      backend: row.backend as TerminalTarget["backend"],
+      mode: row.mode as TerminalTarget["mode"],
+      tmuxPaneId: row.tmux_pane_id ? String(row.tmux_pane_id) : null,
+      tty: row.tty ? String(row.tty) : null,
+      termProgram: row.term_program ? String(row.term_program) : null,
+      itermSessionId: row.iterm_session_id ? String(row.iterm_session_id) : null,
+      notifyLeaseMs: Number(row.notify_lease_ms),
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
+      lastSeenAt: String(row.last_seen_at),
+    };
+  }
+
+  private mapTerminalDispatchState(row: Record<string, unknown>): TerminalDispatchState {
+    return {
+      inboxId: String(row.inbox_id),
+      targetId: String(row.target_id),
+      status: row.status as TerminalDispatchState["status"],
+      leaseExpiresAt: row.lease_expires_at ? String(row.lease_expires_at) : null,
+      pendingNewItemCount: Number(row.pending_new_item_count),
+      pendingSummary: row.pending_summary ? String(row.pending_summary) : null,
+      pendingSubscriptionIds: parseJson<string[]>(row.pending_subscription_ids_json as string),
+      pendingSourceIds: parseJson<string[]>(row.pending_source_ids_json as string),
+      updatedAt: String(row.updated_at),
     };
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -107,6 +107,7 @@ export class AgentInboxStore {
       this.upgradeTerminalRuntimeSchema();
     }
 
+    this.createCurrentIndexes();
     this.setUserVersion(SCHEMA_VERSION);
   }
 
@@ -747,7 +748,16 @@ export class AgentInboxStore {
 
   updateTerminalTargetHeartbeat(
     targetId: string,
-    input: { updatedAt: string; lastSeenAt: string },
+    input: {
+      updatedAt: string;
+      lastSeenAt: string;
+      runtimeKind?: TerminalTarget["runtimeKind"];
+      runtimeSessionId?: string | null;
+      tty?: string | null;
+      termProgram?: string | null;
+      itermSessionId?: string | null;
+      tmuxPaneId?: string | null;
+    },
   ): TerminalTarget {
     const target = this.getTerminalTarget(targetId);
     if (!target) {
@@ -756,10 +766,16 @@ export class AgentInboxStore {
     this.db.run(
       `
       update terminal_targets
-      set updated_at = ?, last_seen_at = ?
+      set runtime_kind = ?, runtime_session_id = ?, tmux_pane_id = ?, tty = ?, term_program = ?, iterm_session_id = ?, updated_at = ?, last_seen_at = ?
       where target_id = ?
     `,
       [
+        input.runtimeKind ?? target.runtimeKind,
+        input.runtimeSessionId ?? target.runtimeSessionId ?? null,
+        input.tmuxPaneId ?? target.tmuxPaneId ?? null,
+        input.tty ?? target.tty ?? null,
+        input.termProgram ?? target.termProgram ?? null,
+        input.itermSessionId ?? target.itermSessionId ?? null,
         input.updatedAt,
         input.lastSeenAt,
         targetId,

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,0 +1,225 @@
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+import crypto from "node:crypto";
+import { RuntimeKind, TerminalBackend, TerminalTarget } from "./model";
+
+const execFileAsync = promisify(execFile);
+
+export interface DetectedTerminalContext {
+  runtimeKind: RuntimeKind;
+  runtimeSessionId?: string | null;
+  backend: TerminalBackend;
+  tmuxPaneId?: string | null;
+  tty?: string | null;
+  termProgram?: string | null;
+  itermSessionId?: string | null;
+}
+
+export function detectTerminalContext(env: NodeJS.ProcessEnv = process.env): DetectedTerminalContext {
+  const tmuxPaneId = normalizeOptionalString(env.TMUX_PANE);
+  const termProgram = normalizeOptionalString(env.TERM_PROGRAM);
+  const tty = detectTty(env);
+  const itermSessionId = normalizeItermSessionId(env.ITERM_SESSION_ID ?? env.TERM_SESSION_ID);
+  const runtime = detectRuntimeContext(env);
+
+  if (tmuxPaneId) {
+    return {
+      runtimeKind: runtime.runtimeKind,
+      runtimeSessionId: runtime.runtimeSessionId,
+      backend: "tmux",
+      tmuxPaneId,
+      tty,
+      termProgram,
+      itermSessionId,
+    };
+  }
+
+  if (itermSessionId || termProgram === "iTerm.app") {
+    return {
+      runtimeKind: runtime.runtimeKind,
+      runtimeSessionId: runtime.runtimeSessionId,
+      backend: "iterm2",
+      tty,
+      termProgram,
+      itermSessionId,
+    };
+  }
+
+  throw new Error("unable to detect a supported terminal context");
+}
+
+export function renderAgentPrompt(input: {
+  inboxId: string;
+  newItemCount: number;
+  summary?: string | null;
+}): string {
+  const base = `AgentInbox: ${input.newItemCount} new items arrived in inbox ${input.inboxId}.`;
+  if (input.summary) {
+    return `${base} Summary: ${input.summary}. Please read the inbox, process them, and ack when finished.`;
+  }
+  return `${base} Please read the inbox, process them, and ack when finished.`;
+}
+
+export function assignedAgentIdFromContext(input: {
+  runtimeKind?: RuntimeKind | null;
+  runtimeSessionId?: string | null;
+  backend: TerminalBackend;
+  tmuxPaneId?: string | null;
+  itermSessionId?: string | null;
+  tty?: string | null;
+}): string {
+  const primary = normalizeOptionalString(input.runtimeSessionId)
+    ?? normalizeOptionalString(input.tmuxPaneId)
+    ?? normalizeOptionalString(input.itermSessionId)
+    ?? normalizeOptionalString(input.tty);
+  if (!primary) {
+    throw new Error("unable to derive agentId from terminal context");
+  }
+  const normalized = primary.replace(/[^a-zA-Z0-9]+/g, "").toLowerCase();
+  if (normalized.length > 0) {
+    return `agent_${input.runtimeKind ?? "unknown"}_${normalized.slice(0, 40)}`;
+  }
+  const digest = crypto.createHash("sha256").update(primary).digest("hex").slice(0, 16);
+  return `agent_${input.runtimeKind ?? "unknown"}_${digest}`;
+}
+
+export class TerminalDispatcher {
+  async dispatch(target: TerminalTarget, prompt: string): Promise<void> {
+    if (target.backend === "tmux") {
+      if (!target.tmuxPaneId) {
+        throw new Error(`tmux terminal target ${target.targetId} is missing tmuxPaneId`);
+      }
+      await execFileAsync("tmux", ["send-keys", "-t", target.tmuxPaneId, prompt, "Enter"]);
+      return;
+    }
+
+    if (target.backend === "iterm2") {
+      await dispatchToIterm2(target, prompt);
+      return;
+    }
+
+    throw new Error(`unsupported terminal backend: ${String(target.backend)}`);
+  }
+}
+
+function detectTty(env: NodeJS.ProcessEnv): string | null {
+  const direct = tryReadCurrentTty();
+  if (direct) {
+    return direct;
+  }
+  const parent = tryReadParentTty(env.PPID);
+  return parent;
+}
+
+function tryReadCurrentTty(): string | null {
+  try {
+    const tty = execFileSync("tty", [], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    if (!tty || tty === "not a tty") {
+      return null;
+    }
+    return tty;
+  } catch {
+    return null;
+  }
+}
+
+function tryReadParentTty(ppid: string | undefined): string | null {
+  if (!ppid) {
+    return null;
+  }
+  try {
+    const tty = execFileSync("ps", ["-o", "tty=", "-p", ppid], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!tty || tty === "??") {
+      return null;
+    }
+    return tty.startsWith("/dev/") ? tty : `/dev/${tty}`;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeItermSessionId(raw: string | undefined): string | null {
+  const value = normalizeOptionalString(raw);
+  if (!value) {
+    return null;
+  }
+  const parts = value.split(":");
+  return parts[parts.length - 1] || null;
+}
+
+function detectRuntimeContext(env: NodeJS.ProcessEnv): {
+  runtimeKind: RuntimeKind;
+  runtimeSessionId: string | null;
+} {
+  const codexThreadId = normalizeOptionalString(env.CODEX_THREAD_ID);
+  if (codexThreadId) {
+    return {
+      runtimeKind: "codex",
+      runtimeSessionId: codexThreadId,
+    };
+  }
+
+  const claudeSessionId = normalizeOptionalString(
+    env.CLAUDE_CODE_SESSION_ID
+      ?? env.CLAUDECODE_SESSION_ID
+      ?? env.CLAUDE_SESSION_ID,
+  );
+  if (claudeSessionId) {
+    return {
+      runtimeKind: "claude_code",
+      runtimeSessionId: claudeSessionId,
+    };
+  }
+
+  return {
+    runtimeKind: "unknown",
+    runtimeSessionId: null,
+  };
+}
+
+function normalizeOptionalString(value: string | undefined | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function dispatchToIterm2(target: TerminalTarget, prompt: string): Promise<void> {
+  const script = `
+set targetTty to system attribute "TARGET_TTY"
+set targetSessionId to system attribute "TARGET_SESSION_ID"
+set promptText to system attribute "AGENT_PROMPT"
+tell application "iTerm2"
+  repeat with aWindow in windows
+    repeat with aTab in tabs of aWindow
+      repeat with aSession in sessions of aTab
+        tell aSession
+          if ((targetTty is not "" and (tty as text) is equal to targetTty) or (targetSessionId is not "" and (unique ID as text) is equal to targetSessionId)) then
+            write text promptText
+            return "sent"
+          end if
+        end tell
+      end repeat
+    end repeat
+  end repeat
+end tell
+return "not-found"
+`;
+
+  const { stdout } = await execFileAsync("osascript", ["-e", script], {
+    env: {
+      ...process.env,
+      TARGET_TTY: target.tty ?? "",
+      TARGET_SESSION_ID: target.itermSessionId ?? "",
+      AGENT_PROMPT: prompt,
+    },
+  });
+
+  if (!stdout.includes("sent")) {
+    throw new Error(`unable to find iTerm2 session for terminal target ${target.targetId}`);
+  }
+}

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -8,8 +8,9 @@ import { AgentInboxStore } from "../src/store";
 import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { AdapterRegistry } from "../src/adapters";
 import { SqliteEventBusBackend } from "../src/backend";
-import { Activation, InboxWatchEvent, SubscriptionSource } from "../src/model";
+import { Activation, InboxWatchEvent, SubscriptionSource, TerminalTarget } from "../src/model";
 import { nowIso } from "../src/util";
+import { TerminalDispatcher } from "../src/terminal";
 
 class RecordingActivationDispatcher extends ActivationDispatcher {
   public readonly calls: Array<{ target: string | null | undefined; activation: Activation }> = [];
@@ -19,8 +20,17 @@ class RecordingActivationDispatcher extends ActivationDispatcher {
   }
 }
 
+class RecordingTerminalDispatcher extends TerminalDispatcher {
+  public readonly calls: Array<{ target: TerminalTarget; prompt: string }> = [];
+
+  override async dispatch(target: TerminalTarget, prompt: string): Promise<void> {
+    this.calls.push({ target, prompt });
+  }
+}
+
 async function makeAsyncService(options?: {
   dispatcher?: ActivationDispatcher;
+  terminalDispatcher?: TerminalDispatcher;
   activationWindowMs?: number;
   activationMaxItems?: number;
 }): Promise<{ store: AgentInboxStore; service: AgentInboxService; dir: string }> {
@@ -37,6 +47,7 @@ async function makeAsyncService(options?: {
       windowMs: options?.activationWindowMs,
       maxItems: options?.activationMaxItems,
     },
+    options?.terminalDispatcher,
   );
   return { store, service, dir };
 }
@@ -675,6 +686,133 @@ test("activation_with_items includes inbox item snapshots in the webhook body", 
     assert.equal(activation.items[0].rawPayload.text, "hello");
     assert.equal(store.listActivations().length, 1);
     assert.equal(store.listActivations()[0].items?.length, 1);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("terminal targets can be registered and attached to subscriptions", async () => {
+  const { store, service, dir } = await makeAsyncService();
+  try {
+    const target = service.registerTerminalTarget({
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-123",
+      backend: "tmux",
+      tmuxPaneId: "%42",
+      tty: "/dev/ttys042",
+      termProgram: "tmux",
+    });
+    assert.equal(target.backend, "tmux");
+    assert.equal(target.tmuxPaneId, "%42");
+    assert.equal(target.runtimeKind, "codex");
+    assert.equal(target.runtimeSessionId, "thread-123");
+    assert.match(target.agentId, /^agent_codex_/);
+
+    const duplicate = service.registerTerminalTarget({
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-123",
+      backend: "tmux",
+      tmuxPaneId: "%42",
+      tty: "/dev/ttys042",
+      termProgram: "tmux",
+    });
+    assert.equal(duplicate.targetId, target.targetId);
+
+    const source = await service.registerSource({
+      sourceType: "custom",
+      sourceKey: "project-alpha",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: target.agentId,
+      sourceId: source.sourceId,
+      terminalTargetId: target.targetId,
+    });
+    const details = await service.getSubscriptionDetails(subscription.subscriptionId);
+    assert.equal((details.terminalTarget as TerminalTarget).targetId, target.targetId);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("terminal notifications are gated by ack and retried after lease expiry", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { store, service, dir } = await makeAsyncService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+  });
+  try {
+    const target = service.registerTerminalTarget({
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-lease",
+      backend: "tmux",
+      tmuxPaneId: "%7",
+      notifyLeaseMs: 30,
+    });
+    const source = await service.registerSource({
+      sourceType: "fixture",
+      sourceKey: "terminal-demo",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: target.agentId,
+      sourceId: source.sourceId,
+      terminalTargetId: target.targetId,
+      startPolicy: "earliest",
+    });
+
+    await service.start();
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "evt-1",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.match(terminalDispatcher.calls[0].prompt, new RegExp(subscription.inboxId));
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "evt-2",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.equal(store.listTerminalDispatchStatesForInbox(subscription.inboxId)[0]?.status, "dirty");
+
+    const currentItems = service.listInboxItems(subscription.inboxId, { includeAcked: false });
+    service.ackInboxItems(subscription.inboxId, [currentItems[0].itemId]);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    assert.equal(terminalDispatcher.calls.length, 2);
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "evt-3",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    assert.equal(terminalDispatcher.calls.length, 2);
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+    assert.equal(terminalDispatcher.calls.length, 3);
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
## Summary
- add runtime-aware terminal registration and assigned agent IDs
- record runtime session ids such as CODEX_THREAD_ID alongside terminal identity
- keep subscription APIs unchanged while letting terminal register return the agentId agents should reuse

## Testing
- npm test
- npm run build