### PR TITLE
Refactor AgentInbox around agents and activation targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,19 @@ Run the local daemon:
 agentinbox serve
 ```
 
-Register the current terminal session and get back an assigned `agentId` plus a
-`terminalTargetId`:
+Register the current terminal session. `AgentInbox` detects the runtime and
+terminal context, assigns a stable `agentId`, and attaches a terminal
+activation target to that agent:
 
 ```bash
-agentinbox terminal register
+agentinbox agent register
 ```
 
-Create a custom source, subscribe the current agent to it, and route
-notifications back into the same terminal session:
+Create a custom source and subscribe the returned `agentId` to it:
 
 ```bash
 agentinbox source add custom local-demo
-agentinbox subscription add <agent_id> <source_id> --terminal-target <target_id>
+agentinbox subscription add <agent_id> <source_id>
 agentinbox source event <source_id> --native-id demo-1 --event custom.demo
 ```
 
@@ -167,22 +167,22 @@ Recommended layers:
   - a shared source hosted by `AgentInbox`
 - `StreamEvent`
   - one normalized source event written into the source stream
+- `Agent`
+  - the runtime identity and default activation target owner
 - `Subscription`
   - an agent-specific filter and consumer on top of a source
 - `Inbox`
-  - the delivery target for one or more subscriptions
+  - the agent's durable internal inbox
 - `InboxItem`
   - a normalized inbound item materialized into an inbox after subscription matching
 - `Activation`
   - a lightweight wake signal sent to an agent runtime
 
-Inside `AgentInbox`, the primary model should stay:
+Inside `AgentInbox`, the primary model is now:
 
 - source first
-- subscription second
-
-That allows one source to serve many agents with different filters and delivery
-rules.
+- agent second
+- subscription as the routing rule between them
 
 ## Inbound / Outbound
 
@@ -261,7 +261,7 @@ This repository now includes the first runnable `M0/M1` scaffold:
 - `agentinbox serve` local daemon
 - local HTTP control API for source registration, subscription polling, inbox access, delivery, and status
 - thin `agentinbox` CLI for shell-first agents and operators
-- SQLite-backed state for sources, streams, stream events, subscriptions, inboxes, inbox items, activations, and deliveries
+- SQLite-backed state for agents, activation targets, sources, streams, stream events, subscriptions, inbox items, activations, and deliveries
 - fixture source path for end-to-end local testing
 - GitHub source ingestion through `uxc` poll subscriptions
 - Feishu bot source ingestion through `uxc` long-connection subscriptions
@@ -269,8 +269,9 @@ This repository now includes the first runnable `M0/M1` scaffold:
 - Unix socket-first local control plane with TCP fallback for explicit debug usage
 - Feishu delivery through `uxc` OpenAPI calls
 
-The current implementation proves the source-ingress / event-log / inbox-delivery
-boundary with per-subscription consumer offsets.
+The current implementation proves the source-ingress / event-log / agent-inbox
+boundary with per-subscription consumer offsets and shared activation target
+dispatch semantics.
 
 ## Quick Start
 
@@ -297,24 +298,30 @@ All client commands accept:
 --url <http://127.0.0.1:4747>
 ```
 
+Register the current session as an agent:
+
+```bash
+agentinbox agent register
+```
+
 Create a programmable local event bus source and publish events into it:
 
 ```bash
 agentinbox source add custom project-alpha
-agentinbox subscription add alpha <source_id> --match-json '{"channel":"engineering"}'
+agentinbox subscription add <agent_id> <source_id> --match-json '{"channel":"engineering"}'
 agentinbox source event <source_id> \
   --native-id evt-1 \
   --event message.created \
   --metadata-json '{"channel":"engineering"}' \
   --payload-json '{"text":"hello from a local producer"}'
 agentinbox subscription poll <subscription_id>
-agentinbox inbox read inbox_alpha
+agentinbox inbox read <agent_id>
 ```
 
 For a long-lived local consumer, keep a watch open:
 
 ```bash
-agentinbox inbox watch inbox_alpha
+agentinbox inbox watch <agent_id>
 ```
 
 ## Source Adapters
@@ -344,7 +351,7 @@ Example:
 ```bash
 agentinbox source add github_repo holon-run/agentinbox \
   --config-json '{"owner":"holon-run","repo":"agentinbox","uxcAuth":"github-default","pollIntervalSecs":30}'
-agentinbox subscription add alpha <source_id> --match-json '{"mentions":["alpha"]}'
+agentinbox subscription add <agent_id> <source_id> --match-json '{"mentions":["alpha"]}'
 agentinbox source poll <source_id>
 ```
 
@@ -356,7 +363,7 @@ state transitions such as failures on a branch or workflow.
 ```bash
 agentinbox source add github_repo_ci holon-run/agentinbox \
   --config-json '{"owner":"holon-run","repo":"agentinbox","uxcAuth":"github-default","pollIntervalSecs":30,"perPage":20}'
-agentinbox subscription add alpha <source_id> --match-json '{"conclusion":"failure","headBranch":"main"}'
+agentinbox subscription add <agent_id> <source_id> --match-json '{"conclusion":"failure","headBranch":"main"}'
 agentinbox source poll <source_id>
 ```
 
@@ -372,39 +379,29 @@ Prerequisites:
 
 ## Activations
 
-Subscriptions default to `activation_only`.
-
-For low-frequency flows, you can push the newly created inbox items directly in
-the activation webhook body:
+Activation defaults now belong to the agent, not the subscription. Add a webhook
+activation target to an agent:
 
 ```bash
-agentinbox subscription add alpha <source_id> \
-  --activation-target http://127.0.0.1:8080/webhooks/agentinbox/alpha \
+agentinbox agent target add webhook <agent_id> \
+  --url http://127.0.0.1:8080/webhooks/agentinbox/alpha \
   --activation-mode activation_with_items
 ```
 
-## Terminal Targets
+## Agent Registration And Activation Targets
 
 For local agent sessions that do not expose a notification API, `AgentInbox`
-can register the current terminal session and inject an `agent_prompt` back
-into it when new inbox items arrive.
+registers the current terminal session as an agent and injects an
+`agent_prompt` back into it when new inbox items arrive.
 
 Register the current session:
 
 ```bash
-agentinbox terminal register
+agentinbox agent register
 ```
 
-The response includes an assigned `agentId` and a `targetId`. Use the returned
-`agentId` for later subscription and inbox commands, and use the returned
-`targetId` when you want a subscription to notify this terminal session.
-
-Attach that terminal target to a subscription:
-
-```bash
-agentinbox subscription add <agent_id> <source_id> \
-  --terminal-target <target_id>
-```
+The response includes an assigned `agentId` and the current terminal activation
+target. Use the returned `agentId` for later subscription and inbox commands.
 
 `AgentInbox` detects the current terminal context automatically. `tmux` targets
 are injected with `send-keys ... Enter`. `iTerm2` targets are injected through
@@ -412,7 +409,7 @@ AppleScript using the current session identity. When available, runtime session
 identities such as `CODEX_THREAD_ID` are recorded and used to derive a stable
 assigned `agentId`.
 
-Terminal notifications are gated by inbox acknowledgement:
+All activation targets share the same gating behavior:
 
 - the first batch of new inbox items triggers one injected prompt
 - no further prompt is injected until the inbox is acknowledged
@@ -456,7 +453,7 @@ Register a Feishu bot source backed by `uxc` long-connection subscription:
 ```bash
 node dist/src/cli.js source add feishu_bot feishu-default \
   --config-json '{"uxcAuth":"feishu-default","eventTypes":["im.message.receive_v1"]}'
-node dist/src/cli.js subscription add alpha <source_id> --match-json '{"mentions":["Alpha"]}'
+node dist/src/cli.js subscription add <agent_id> <source_id> --match-json '{"mentions":["Alpha"]}'
 node dist/src/cli.js source poll <source_id>
 ```
 
@@ -465,9 +462,9 @@ Emit a fixture event for tests and local demos:
 ```bash
 node dist/src/cli.js fixture emit <source_id> --metadata-json '{"channel":"engineering"}' --payload-json '{"text":"hello"}'
 node dist/src/cli.js subscription poll <subscription_id>
-node dist/src/cli.js inbox list
-node dist/src/cli.js inbox read inbox_alpha
-node dist/src/cli.js inbox watch inbox_alpha
+node dist/src/cli.js inbox show <agent_id>
+node dist/src/cli.js inbox read <agent_id>
+node dist/src/cli.js inbox watch <agent_id>
 ```
 
 Record a delivery attempt:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { AgentInboxStore } from "./store";
-import { AgentInboxService } from "./service";
-import { createServer } from "./http";
-import { jsonResponse, parseJsonArg } from "./util";
 import { AdapterRegistry } from "./adapters";
 import { AgentInboxClient } from "./client";
 import { startControlServer } from "./control_server";
+import { createServer } from "./http";
 import { resolveClientTransport, resolveServeConfig } from "./paths";
+import { AgentInboxService } from "./service";
+import { AgentInboxStore } from "./store";
 import { detectTerminalContext } from "./terminal";
+import { jsonResponse, parseJsonArg } from "./util";
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -41,23 +41,16 @@ async function main(): Promise<void> {
 
   const client = createClient(normalized);
 
-  if (command === "source" && hasHelpFlag(normalized.slice(1))) {
-    printHelp(["source"]);
-    return;
-  }
-
   if (command === "source" && normalized[1] === "add") {
     const [type, sourceKey] = normalized.slice(2, 4);
     if (!type || !sourceKey) {
       throw new Error("usage: agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]");
     }
-    const configJson = takeFlagValue(normalized, "--config-json");
-    const configRef = takeFlagValue(normalized, "--config-ref");
     await printRemote(client, "/sources/register", {
       sourceType: type,
       sourceKey,
-      configRef: configRef ?? null,
-      config: parseJsonArg(configJson),
+      configRef: takeFlagValue(normalized, "--config-ref") ?? null,
+      config: parseJsonArg(takeFlagValue(normalized, "--config-json")),
     });
     return;
   }
@@ -102,24 +95,77 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "subscription" && hasHelpFlag(normalized.slice(1))) {
-    printHelp(["subscription"]);
+  if (command === "agent" && normalized[1] === "register") {
+    const detected = detectTerminalContext(process.env);
+    await printRemote(client, "/agents/register", {
+      backend: detected.backend,
+      runtimeKind: detected.runtimeKind,
+      runtimeSessionId: detected.runtimeSessionId ?? null,
+      tmuxPaneId: detected.tmuxPaneId ?? null,
+      tty: detected.tty ?? null,
+      termProgram: detected.termProgram ?? null,
+      itermSessionId: detected.itermSessionId ?? null,
+      notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? null,
+    });
+    return;
+  }
+
+  if (command === "agent" && normalized[1] === "list") {
+    await printRemote(client, "/agents", undefined, "GET");
+    return;
+  }
+
+  if (command === "agent" && normalized[1] === "show") {
+    const agentId = normalized[2];
+    if (!agentId) {
+      throw new Error("usage: agentinbox agent show <agentId>");
+    }
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}`, undefined, "GET");
+    return;
+  }
+
+  if (command === "agent" && normalized[1] === "target" && normalized[2] === "add" && normalized[3] === "webhook") {
+    const agentId = normalized[4];
+    const url = takeFlagValue(normalized, "--url");
+    if (!agentId || !url) {
+      throw new Error("usage: agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N]");
+    }
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/targets`, {
+      kind: "webhook",
+      url,
+      activationMode: takeFlagValue(normalized, "--activation-mode") ?? undefined,
+      notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? null,
+    });
+    return;
+  }
+
+  if (command === "agent" && normalized[1] === "target" && normalized[2] === "list") {
+    const agentId = normalized[3];
+    if (!agentId) {
+      throw new Error("usage: agentinbox agent target list <agentId>");
+    }
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/targets`, undefined, "GET");
+    return;
+  }
+
+  if (command === "agent" && normalized[1] === "target" && normalized[2] === "remove") {
+    const [agentId, targetId] = normalized.slice(3, 5);
+    if (!agentId || !targetId) {
+      throw new Error("usage: agentinbox agent target remove <agentId> <targetId>");
+    }
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/targets/${encodeURIComponent(targetId)}`, undefined, "DELETE");
     return;
   }
 
   if (command === "subscription" && normalized[1] === "add") {
     const [agentId, sourceId] = normalized.slice(2, 4);
     if (!agentId || !sourceId) {
-      throw new Error("usage: agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--terminal-target ID] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
+      throw new Error("usage: agentinbox subscription add <agentId> <sourceId> [--match-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
     }
     await printRemote(client, "/subscriptions/register", {
       agentId,
       sourceId,
-      inboxId: takeFlagValue(normalized, "--inbox-id") ?? undefined,
       matchRules: parseJsonArg(takeFlagValue(normalized, "--match-json")),
-      activationTarget: takeFlagValue(normalized, "--activation-target") ?? null,
-      terminalTargetId: takeFlagValue(normalized, "--terminal-target") ?? null,
-      activationMode: takeFlagValue(normalized, "--activation-mode") ?? undefined,
       startPolicy: takeFlagValue(normalized, "--start-policy") ?? undefined,
       startOffset: parseOptionalNumber(takeFlagValue(normalized, "--start-offset")),
       startTime: takeFlagValue(normalized, "--start-time") ?? undefined,
@@ -131,7 +177,6 @@ async function main(): Promise<void> {
     const query = buildQuery({
       source_id: takeFlagValue(normalized, "--source-id"),
       agent_id: takeFlagValue(normalized, "--agent-id"),
-      inbox_id: takeFlagValue(normalized, "--inbox-id"),
     });
     await printRemote(client, `/subscriptions${query}`, undefined, "GET");
     return;
@@ -178,50 +223,39 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (command === "inbox" && hasHelpFlag(normalized.slice(1))) {
-    printHelp(["inbox"]);
-    return;
-  }
-
   if (command === "inbox" && normalized[1] === "list") {
-    await printRemote(client, "/inboxes", undefined, "GET");
-    return;
-  }
-
-  if (command === "inbox" && normalized[1] === "ensure") {
-    const inboxId = normalized[2];
-    const agentId = takeFlagValue(normalized, "--agent-id");
-    if (!inboxId || !agentId) {
-      throw new Error("usage: agentinbox inbox ensure <inboxId> --agent-id <agentId>");
-    }
-    await printRemote(client, "/inboxes/ensure", { inboxId, agentId });
+    await printRemote(client, "/agents", undefined, "GET");
     return;
   }
 
   if (command === "inbox" && normalized[1] === "show") {
-    const inboxId = normalized[2];
-    if (!inboxId) {
-      throw new Error("usage: agentinbox inbox show <inboxId>");
+    const agentId = normalized[2];
+    if (!agentId) {
+      throw new Error("usage: agentinbox inbox show <agentId>");
     }
-    await printRemote(client, `/inboxes/${encodeURIComponent(inboxId)}`, undefined, "GET");
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox`, undefined, "GET");
     return;
   }
 
   if (command === "inbox" && normalized[1] === "read") {
-    const inboxId = normalized[2];
-    if (!inboxId) {
-      throw new Error("usage: agentinbox inbox read <inboxId>");
+    const agentId = normalized[2];
+    if (!agentId) {
+      throw new Error("usage: agentinbox inbox read <agentId>");
     }
-    await printRemote(client, `/inboxes/${encodeURIComponent(inboxId)}/items`, undefined, "GET");
+    const query = buildQuery({
+      after_item_id: takeFlagValue(normalized, "--after-item"),
+      include_acked: hasFlag(normalized, "--include-acked") ? "true" : undefined,
+    });
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox/items${query}`, undefined, "GET");
     return;
   }
 
   if (command === "inbox" && normalized[1] === "watch") {
-    const inboxId = normalized[2];
-    if (!inboxId) {
-      throw new Error("usage: agentinbox inbox watch <inboxId> [--after-item ID] [--include-acked] [--heartbeat-ms N]");
+    const agentId = normalized[2];
+    if (!agentId) {
+      throw new Error("usage: agentinbox inbox watch <agentId> [--after-item ID] [--include-acked] [--heartbeat-ms N]");
     }
-    for await (const event of client.watchInbox(inboxId, {
+    for await (const event of client.watchInbox(agentId, {
       afterItemId: takeFlagValue(normalized, "--after-item"),
       includeAcked: hasFlag(normalized, "--include-acked"),
       heartbeatMs: parseOptionalNumber(takeFlagValue(normalized, "--heartbeat-ms")),
@@ -235,60 +269,17 @@ async function main(): Promise<void> {
   }
 
   if (command === "inbox" && normalized[1] === "ack") {
-    const inboxId = normalized[2];
+    const agentId = normalized[2];
     const itemId = takeFlagValue(normalized, "--item");
     const ackAll = hasFlag(normalized, "--all");
-    if (ackAll && itemId) {
-      throw new Error("usage: agentinbox inbox ack <inboxId> (--item <itemId> | --all)");
-    }
-    if (!inboxId || (!itemId && !ackAll)) {
-      throw new Error("usage: agentinbox inbox ack <inboxId> (--item <itemId> | --all)");
+    if (!agentId || (ackAll && itemId) || (!ackAll && !itemId)) {
+      throw new Error("usage: agentinbox inbox ack <agentId> (--item <itemId> | --all)");
     }
     if (ackAll) {
-      await printRemote(client, `/inboxes/${encodeURIComponent(inboxId)}/ack-all`, {});
+      await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox/ack-all`, {});
       return;
     }
-    await printRemote(client, `/inboxes/${encodeURIComponent(inboxId)}/ack`, { itemIds: [itemId] });
-    return;
-  }
-
-  if (command === "terminal" && hasHelpFlag(normalized.slice(1))) {
-    printHelp(["terminal"]);
-    return;
-  }
-
-  if (command === "terminal" && normalized[1] === "register") {
-    const detected = detectTerminalContext(process.env);
-    await printRemote(client, "/terminals/register", {
-      backend: detected.backend,
-      runtimeKind: detected.runtimeKind,
-      runtimeSessionId: detected.runtimeSessionId ?? null,
-      mode: "agent_prompt",
-      tmuxPaneId: detected.tmuxPaneId ?? null,
-      tty: detected.tty ?? null,
-      termProgram: detected.termProgram ?? null,
-      itermSessionId: detected.itermSessionId ?? null,
-      notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? null,
-    });
-    return;
-  }
-
-  if (command === "terminal" && normalized[1] === "list") {
-    await printRemote(client, "/terminals", undefined, "GET");
-    return;
-  }
-
-  if (command === "terminal" && normalized[1] === "show") {
-    const targetId = normalized[2];
-    if (!targetId) {
-      throw new Error("usage: agentinbox terminal show <targetId>");
-    }
-    await printRemote(client, `/terminals/${encodeURIComponent(targetId)}`, undefined, "GET");
-    return;
-  }
-
-  if (command === "fixture" && hasHelpFlag(normalized.slice(1))) {
-    printHelp(["fixture"]);
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox/ack`, { itemIds: [itemId] });
     return;
   }
 
@@ -306,11 +297,6 @@ async function main(): Promise<void> {
       metadata: parseJsonArg(takeFlagValue(normalized, "--metadata-json")),
       rawPayload: parseJsonArg(takeFlagValue(normalized, "--payload-json")),
     });
-    return;
-  }
-
-  if (command === "deliver" && hasHelpFlag(normalized.slice(1))) {
-    printHelp(["deliver"]);
     return;
   }
 
@@ -339,6 +325,11 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (hasHelpFlag(normalized.slice(1))) {
+    printHelp([command]);
+    return;
+  }
+
   throw new Error(`unknown command: ${args.join(" ")}`);
 }
 
@@ -352,8 +343,7 @@ async function runServe(args: string[]): Promise<void> {
     portOverride: port,
   });
 
-  const dbPath = serveConfig.dbPath;
-  const store = await AgentInboxStore.open(dbPath);
+  const store = await AgentInboxStore.open(serveConfig.dbPath);
   let service: AgentInboxService;
   const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
   service = new AgentInboxService(store, adapters);
@@ -364,9 +354,10 @@ async function runServe(args: string[]): Promise<void> {
   console.log(jsonResponse({
     ok: true,
     homeDir: serveConfig.homeDir,
-    dbPath,
+    dbPath: serveConfig.dbPath,
     ...controlServer.info,
   }));
+
   const shutdown = () => {
     void controlServer.close().finally(() => {
       void adapters.stop();
@@ -380,20 +371,19 @@ async function runServe(args: string[]): Promise<void> {
 }
 
 function createClient(args: string[]): AgentInboxClient {
-  const transport = resolveClientTransport({
+  return new AgentInboxClient(resolveClientTransport({
     env: process.env,
     homeDirOverride: takeFlagValue(args, "--home"),
     socketPathOverride: takeFlagValue(args, "--socket"),
     baseUrlOverride: takeFlagValue(args, "--url"),
-  });
-  return new AgentInboxClient(transport);
+  }));
 }
 
 async function printRemote(
   client: AgentInboxClient,
   endpoint: string,
   body?: unknown,
-  method: "GET" | "POST" = "POST",
+  method: "GET" | "POST" | "DELETE" = "POST",
 ): Promise<void> {
   const response = await client.request(endpoint, body, method);
   if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -464,16 +454,13 @@ Usage:
 Commands:
   serve
   source
+  agent
   subscription
   inbox
-  terminal
   fixture
   deliver
   status
   version
-
-Try:
-  agentinbox <command> --help
 `,
     serve: `agentinbox serve
 
@@ -490,11 +477,21 @@ Usage:
   agentinbox source poll <sourceId>
   agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]
 `,
+    agent: `agentinbox agent
+
+Usage:
+  agentinbox agent register [--notify-lease-ms N]
+  agentinbox agent list
+  agentinbox agent show <agentId>
+  agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N]
+  agentinbox agent target list <agentId>
+  agentinbox agent target remove <agentId> <targetId>
+`,
     subscription: `agentinbox subscription
 
 Usage:
-  agentinbox subscription add <agentId> <sourceId> [--inbox-id ID] [--match-json JSON] [--activation-target URL] [--terminal-target ID] [--activation-mode MODE] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
-  agentinbox subscription list [--source-id ID] [--agent-id ID] [--inbox-id ID]
+  agentinbox subscription add <agentId> <sourceId> [--match-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
+  agentinbox subscription list [--source-id ID] [--agent-id ID]
   agentinbox subscription show <subscriptionId>
   agentinbox subscription poll <subscriptionId>
   agentinbox subscription lag <subscriptionId>
@@ -504,18 +501,10 @@ Usage:
 
 Usage:
   agentinbox inbox list
-  agentinbox inbox ensure <inboxId> --agent-id <agentId>
-  agentinbox inbox show <inboxId>
-  agentinbox inbox read <inboxId>
-  agentinbox inbox watch <inboxId> [--after-item ID] [--include-acked] [--heartbeat-ms N]
-  agentinbox inbox ack <inboxId> (--item <itemId> | --all)
-`,
-    terminal: `agentinbox terminal
-
-Usage:
-  agentinbox terminal register [--notify-lease-ms N]
-  agentinbox terminal list
-  agentinbox terminal show <targetId>
+  agentinbox inbox show <agentId>
+  agentinbox inbox read <agentId> [--after-item ID] [--include-acked]
+  agentinbox inbox watch <agentId> [--after-item ID] [--include-acked] [--heartbeat-ms N]
+  agentinbox inbox ack <agentId> (--item <itemId> | --all)
 `,
     fixture: `agentinbox fixture
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,7 @@ export class AgentInboxClient {
   async request<T = unknown>(
     endpoint: string,
     body?: unknown,
-    method: "GET" | "POST" = "POST",
+    method: "GET" | "POST" | "DELETE" = "POST",
   ): Promise<AgentInboxResponse<T>> {
     if (this.transport.kind === "socket") {
       return requestViaSocket<T>(this.transport.socketPath, endpoint, body, method);
@@ -22,7 +22,7 @@ export class AgentInboxClient {
     return requestViaUrl<T>(this.transport.baseUrl, endpoint, body, method);
   }
 
-  watchInbox(inboxId: string, options: WatchInboxOptions = {}): AsyncIterable<InboxWatchEvent> {
+  watchInbox(agentId: string, options: WatchInboxOptions = {}): AsyncIterable<InboxWatchEvent> {
     const query = new URLSearchParams();
     if (options.afterItemId) {
       query.set("after_item_id", options.afterItemId);
@@ -33,7 +33,7 @@ export class AgentInboxClient {
     if (options.heartbeatMs) {
       query.set("heartbeat_ms", String(options.heartbeatMs));
     }
-    const endpoint = `/inboxes/${encodeURIComponent(inboxId)}/watch${query.size > 0 ? `?${query.toString()}` : ""}`;
+    const endpoint = `/agents/${encodeURIComponent(agentId)}/inbox/watch${query.size > 0 ? `?${query.toString()}` : ""}`;
 
     if (this.transport.kind === "socket") {
       return watchViaSocket(this.transport.socketPath, endpoint);
@@ -46,7 +46,7 @@ function requestViaSocket<T>(
   socketPath: string,
   endpoint: string,
   body: unknown,
-  method: "GET" | "POST",
+  method: "GET" | "POST" | "DELETE",
 ): Promise<AgentInboxResponse<T>> {
   return new Promise((resolve, reject) => {
     const payload = body ? JSON.stringify(body) : undefined;
@@ -78,7 +78,7 @@ function requestViaUrl<T>(
   baseUrl: string,
   endpoint: string,
   body: unknown,
-  method: "GET" | "POST",
+  method: "GET" | "POST" | "DELETE",
 ): Promise<AgentInboxResponse<T>> {
   return new Promise((resolve, reject) => {
     const url = new URL(normalizeEndpoint(endpoint), baseUrl);

--- a/src/http.ts
+++ b/src/http.ts
@@ -241,7 +241,7 @@ export function createServer(service: AgentInboxService): http.Server {
             ? url.searchParams.get("include_acked") === "true"
             : undefined,
           heartbeatMs: url.searchParams.has("heartbeat_ms")
-            ? Number(url.searchParams.get("heartbeat_ms"))
+            ? parsePositiveInteger(url.searchParams.get("heartbeat_ms"))
             : undefined,
         };
 
@@ -270,10 +270,12 @@ export function createServer(service: AgentInboxService): http.Server {
           });
         }, heartbeatMs);
 
-        req.on("close", () => {
+        const cleanup = () => {
           clearInterval(heartbeat);
           session.close();
-        });
+        };
+        req.on("close", cleanup);
+        req.on("error", cleanup);
         return;
       }
 
@@ -298,9 +300,20 @@ export function createServer(service: AgentInboxService): http.Server {
 
       send(res, 404, { error: "not found" });
     } catch (error) {
-      send(res, 400, {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      if (error instanceof SyntaxError) {
+        send(res, 400, { error: error.message });
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.startsWith("unknown ")) {
+        send(res, 404, { error: message });
+        return;
+      }
+      if (isBadRequestError(message)) {
+        send(res, 400, { error: message });
+        return;
+      }
+      send(res, 500, { error: message });
     }
   });
 }
@@ -330,6 +343,37 @@ function parseOptionalInteger(value: unknown): number | undefined {
     throw new Error(`expected integer, received ${String(value)}`);
   }
   return parsed;
+}
+
+function parsePositiveInteger(value: unknown): number {
+  const parsed = parseOptionalInteger(value);
+  if (parsed == null || parsed <= 0) {
+    throw new Error(`expected positive integer, received ${String(value)}`);
+  }
+  return parsed;
+}
+
+function isBadRequestError(message: string): boolean {
+  return (
+    message.startsWith("manual append is not supported") ||
+    message.startsWith("fixtures/emit requires") ||
+    message.startsWith("sources/events requires") ||
+    message.startsWith("deliveryHandle requires") ||
+    message.startsWith("subscriptions/reset requires") ||
+    message.startsWith("agents/register requires") ||
+    message.startsWith("agents/targets requires") ||
+    message.startsWith("unsupported activation target kind") ||
+    message.startsWith("unsupported start policy") ||
+    message.startsWith("unsupported terminal") ||
+    message.startsWith("expected integer") ||
+    message.startsWith("expected positive integer") ||
+    message.startsWith("notifyLeaseMs must be a positive integer") ||
+    message.startsWith("invalid webhook activation target") ||
+    message.includes("requires tmuxPaneId") ||
+    message.includes("requires iTerm2 session identity") ||
+    message.includes("requires a supported terminal context") ||
+    message.includes("belongs to agent")
+  );
 }
 
 function parseOptionalDeliveryHandle(value: unknown): DeliveryHandle | null {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,7 +1,7 @@
 import http from "node:http";
 import { AgentInboxService } from "./service";
+import { ActivationMode, DeliveryHandle, WatchInboxOptions } from "./model";
 import { asObject, jsonResponse } from "./util";
-import { DeliveryHandle, WatchInboxOptions } from "./model";
 
 async function readJson(req: http.IncomingMessage): Promise<Record<string, unknown>> {
   const chunks: Buffer[] = [];
@@ -37,6 +37,7 @@ export function createServer(service: AgentInboxService): http.Server {
         send(res, 400, { error: "missing request metadata" });
         return;
       }
+
       const url = new URL(req.url, "http://127.0.0.1");
 
       if (req.method === "GET" && url.pathname === "/healthz") {
@@ -55,8 +56,7 @@ export function createServer(service: AgentInboxService): http.Server {
       }
 
       if (req.method === "POST" && url.pathname === "/sources/register") {
-        const source = await service.registerSource(await readJson(req) as never);
-        send(res, 200, source);
+        send(res, 200, await service.registerSource(await readJson(req) as never));
         return;
       }
 
@@ -68,71 +68,40 @@ export function createServer(service: AgentInboxService): http.Server {
 
       const sourcePollMatch = url.pathname.match(/^\/sources\/([^/]+)\/poll$/);
       if (req.method === "POST" && sourcePollMatch) {
-        const result = await service.pollSource(decodeURIComponent(sourcePollMatch[1]));
-        send(res, 200, result);
+        send(res, 200, await service.pollSource(decodeURIComponent(sourcePollMatch[1])));
         return;
       }
 
       const sourceEventsMatch = url.pathname.match(/^\/sources\/([^/]+)\/events$/);
       if (req.method === "POST" && sourceEventsMatch) {
-        const sourceId = decodeURIComponent(sourceEventsMatch[1]);
         const body = await readJson(req);
+        const sourceId = decodeURIComponent(sourceEventsMatch[1]);
         const sourceNativeId = parseRequiredString(body.sourceNativeId, "sources/events requires sourceNativeId");
         const eventVariant = parseRequiredString(body.eventVariant, "sources/events requires eventVariant");
-        if (!sourceNativeId) {
-          send(res, 400, { error: "sources/events requires sourceNativeId" });
-          return;
-        }
-        if (!eventVariant) {
-          send(res, 400, { error: "sources/events requires eventVariant" });
-          return;
-        }
-        const result = await service.appendSourceEventByCaller(sourceId, {
+        send(res, 200, await service.appendSourceEventByCaller(sourceId, {
           sourceNativeId,
           eventVariant,
           occurredAt: parseOptionalString(body.occurredAt),
           metadata: asObject(body.metadata),
           rawPayload: asObject(body.rawPayload),
           deliveryHandle: parseOptionalDeliveryHandle(body.deliveryHandle),
-        });
-        send(res, 200, result);
+        }));
         return;
       }
 
-      if (req.method === "GET" && url.pathname === "/subscriptions") {
-        send(res, 200, {
-          subscriptions: service.listSubscriptions({
-            sourceId: url.searchParams.get("source_id") ?? undefined,
-            agentId: url.searchParams.get("agent_id") ?? undefined,
-            inboxId: url.searchParams.get("inbox_id") ?? undefined,
-          }),
-        });
+      if (req.method === "GET" && url.pathname === "/agents") {
+        send(res, 200, { agents: service.listAgents() });
         return;
       }
 
-      if (req.method === "POST" && url.pathname === "/subscriptions/register") {
-        const subscription = await service.registerSubscription(await readJson(req) as never);
-        send(res, 200, subscription);
-        return;
-      }
-
-      if (req.method === "GET" && url.pathname === "/terminals") {
-        send(res, 200, { terminals: service.listTerminalTargets() });
-        return;
-      }
-
-      if (req.method === "POST" && url.pathname === "/terminals/register") {
+      if (req.method === "POST" && url.pathname === "/agents/register") {
         const body = await readJson(req);
-        const backend = parseRequiredString(body.backend, "terminals/register requires backend");
-        if (!backend) {
-          send(res, 400, { error: "terminals/register requires backend" });
-          return;
-        }
-        send(res, 200, service.registerTerminalTarget({
+        const backend = parseRequiredString(body.backend, "agents/register requires backend");
+        send(res, 200, service.registerAgent({
           backend: backend as never,
           runtimeKind: parseOptionalString(body.runtimeKind) as never,
           runtimeSessionId: parseOptionalString(body.runtimeSessionId),
-          mode: parseOptionalString(body.mode) as never,
+          mode: "agent_prompt",
           tmuxPaneId: parseOptionalString(body.tmuxPaneId),
           tty: parseOptionalString(body.tty),
           termProgram: parseOptionalString(body.termProgram),
@@ -142,9 +111,58 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
-      const terminalMatch = url.pathname.match(/^\/terminals\/([^/]+)$/);
-      if (req.method === "GET" && terminalMatch) {
-        send(res, 200, service.getTerminalTarget(decodeURIComponent(terminalMatch[1])));
+      const agentMatch = url.pathname.match(/^\/agents\/([^/]+)$/);
+      if (req.method === "GET" && agentMatch) {
+        send(res, 200, service.getAgentDetails(decodeURIComponent(agentMatch[1])));
+        return;
+      }
+
+      const agentTargetsMatch = url.pathname.match(/^\/agents\/([^/]+)\/targets$/);
+      if (req.method === "GET" && agentTargetsMatch) {
+        send(res, 200, {
+          targets: service.listActivationTargets(decodeURIComponent(agentTargetsMatch[1])),
+        });
+        return;
+      }
+
+      if (req.method === "POST" && agentTargetsMatch) {
+        const body = await readJson(req);
+        const agentId = decodeURIComponent(agentTargetsMatch[1]);
+        const kind = parseRequiredString(body.kind, "agents/targets requires kind");
+        if (kind !== "webhook") {
+          send(res, 400, { error: `unsupported activation target kind: ${kind}` });
+          return;
+        }
+        const urlValue = parseRequiredString(body.url, "agents/targets requires url");
+        send(res, 200, service.addWebhookActivationTarget(agentId, {
+          url: urlValue,
+          activationMode: parseOptionalString(body.activationMode) as ActivationMode | undefined,
+          notifyLeaseMs: parseOptionalInteger(body.notifyLeaseMs) ?? null,
+        }));
+        return;
+      }
+
+      const agentTargetMatch = url.pathname.match(/^\/agents\/([^/]+)\/targets\/([^/]+)$/);
+      if (req.method === "DELETE" && agentTargetMatch) {
+        send(res, 200, service.removeActivationTarget(
+          decodeURIComponent(agentTargetMatch[1]),
+          decodeURIComponent(agentTargetMatch[2]),
+        ));
+        return;
+      }
+
+      if (req.method === "GET" && url.pathname === "/subscriptions") {
+        send(res, 200, {
+          subscriptions: service.listSubscriptions({
+            sourceId: url.searchParams.get("source_id") ?? undefined,
+            agentId: url.searchParams.get("agent_id") ?? undefined,
+          }),
+        });
+        return;
+      }
+
+      if (req.method === "POST" && url.pathname === "/subscriptions/register") {
+        send(res, 200, await service.registerSubscription(await readJson(req) as never));
         return;
       }
 
@@ -156,8 +174,7 @@ export function createServer(service: AgentInboxService): http.Server {
 
       const subscriptionPollMatch = url.pathname.match(/^\/subscriptions\/([^/]+)\/poll$/);
       if (req.method === "POST" && subscriptionPollMatch) {
-        const result = await service.pollSubscription(decodeURIComponent(subscriptionPollMatch[1]));
-        send(res, 200, result);
+        send(res, 200, await service.pollSubscription(decodeURIComponent(subscriptionPollMatch[1])));
         return;
       }
 
@@ -171,10 +188,6 @@ export function createServer(service: AgentInboxService): http.Server {
       if (req.method === "POST" && subscriptionResetMatch) {
         const body = await readJson(req);
         const startPolicy = parseRequiredString(body.startPolicy, "subscriptions/reset requires startPolicy");
-        if (!startPolicy) {
-          send(res, 400, { error: "subscriptions/reset requires startPolicy" });
-          return;
-        }
         send(res, 200, await service.resetSubscription({
           subscriptionId: decodeURIComponent(subscriptionResetMatch[1]),
           startPolicy: startPolicy as never,
@@ -187,63 +200,29 @@ export function createServer(service: AgentInboxService): http.Server {
       if (req.method === "POST" && url.pathname === "/fixtures/emit") {
         const body = await readJson(req);
         const sourceId = parseRequiredString(body.sourceId, "fixtures/emit requires sourceId");
-        if (!sourceId) {
-          send(res, 400, { error: "fixtures/emit requires sourceId" });
-          return;
-        }
         const sourceNativeId = parseRequiredString(body.sourceNativeId, "fixtures/emit requires sourceNativeId");
-        if (!sourceNativeId) {
-          send(res, 400, { error: "fixtures/emit requires sourceNativeId" });
-          return;
-        }
         const eventVariant = parseRequiredString(body.eventVariant, "fixtures/emit requires eventVariant");
-        if (!eventVariant) {
-          send(res, 400, { error: "fixtures/emit requires eventVariant" });
-          return;
-        }
-        const result = await service.appendFixtureEvent(sourceId, {
+        send(res, 200, await service.appendFixtureEvent(sourceId, {
           sourceNativeId,
           eventVariant,
           occurredAt: parseOptionalString(body.occurredAt),
           metadata: asObject(body.metadata),
           rawPayload: asObject(body.rawPayload),
           deliveryHandle: parseOptionalDeliveryHandle(body.deliveryHandle),
-        });
-        send(res, 200, result);
+        }));
         return;
       }
 
-      if (req.method === "GET" && url.pathname === "/inboxes") {
-        send(res, 200, { inboxes: service.listInboxes() });
+      const agentInboxMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox$/);
+      if (req.method === "GET" && agentInboxMatch) {
+        send(res, 200, service.getInboxDetailsByAgent(decodeURIComponent(agentInboxMatch[1])));
         return;
       }
 
-      if (req.method === "POST" && url.pathname === "/inboxes/ensure") {
-        const body = await readJson(req);
-        const inboxId = parseRequiredString(body.inboxId, "inboxes/ensure requires inboxId");
-        const agentId = parseRequiredString(body.agentId, "inboxes/ensure requires agentId");
-        if (!inboxId) {
-          send(res, 400, { error: "inboxes/ensure requires inboxId" });
-          return;
-        }
-        if (!agentId) {
-          send(res, 400, { error: "inboxes/ensure requires agentId" });
-          return;
-        }
-        send(res, 200, service.ensureInboxByCaller(inboxId, agentId));
-        return;
-      }
-
-      const inboxShowMatch = url.pathname.match(/^\/inboxes\/([^/]+)$/);
-      if (req.method === "GET" && inboxShowMatch) {
-        send(res, 200, service.getInboxDetails(decodeURIComponent(inboxShowMatch[1])));
-        return;
-      }
-
-      const inboxMatch = url.pathname.match(/^\/inboxes\/([^/]+)\/items$/);
-      if (req.method === "GET" && inboxMatch) {
+      const agentInboxItemsMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/items$/);
+      if (req.method === "GET" && agentInboxItemsMatch) {
         send(res, 200, {
-          items: service.listInboxItems(decodeURIComponent(inboxMatch[1]), {
+          items: service.listInboxItems(decodeURIComponent(agentInboxItemsMatch[1]), {
             afterItemId: url.searchParams.get("after_item_id") ?? undefined,
             includeAcked: url.searchParams.has("include_acked")
               ? url.searchParams.get("include_acked") === "true"
@@ -253,133 +232,85 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
-      const inboxWatchMatch = url.pathname.match(/^\/inboxes\/([^/]+)\/watch$/);
-      if (req.method === "GET" && inboxWatchMatch) {
-        const inboxId = decodeURIComponent(inboxWatchMatch[1]);
+      const agentInboxWatchMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/watch$/);
+      if (req.method === "GET" && agentInboxWatchMatch) {
+        const agentId = decodeURIComponent(agentInboxWatchMatch[1]);
         const watchOptions: WatchInboxOptions = {
           afterItemId: url.searchParams.get("after_item_id") ?? undefined,
-          includeAcked: url.searchParams.get("include_acked") === "true",
-          heartbeatMs: parsePositiveInteger(url.searchParams.get("heartbeat_ms")) ?? 15_000,
+          includeAcked: url.searchParams.has("include_acked")
+            ? url.searchParams.get("include_acked") === "true"
+            : undefined,
+          heartbeatMs: url.searchParams.has("heartbeat_ms")
+            ? Number(url.searchParams.get("heartbeat_ms"))
+            : undefined,
         };
-        const session = service.watchInbox(inboxId, watchOptions, (event) => {
-          sendSse(res, event.event, event);
-        });
 
         res.writeHead(200, {
           "content-type": "text/event-stream; charset=utf-8",
           "cache-control": "no-cache, no-transform",
           connection: "keep-alive",
         });
-        res.flushHeaders?.();
 
-        if (session.initialItems.length > 0) {
-          sendSse(res, "items", {
-            event: "items",
-            inboxId,
-            items: session.initialItems,
-          });
-        }
+        const session = service.watchInbox(agentId, watchOptions, (event) => {
+          sendSse(res, event.event, event);
+        });
+        sendSse(res, "items", {
+          event: "items",
+          agentId,
+          items: session.initialItems,
+        });
         session.start();
 
+        const heartbeatMs = watchOptions.heartbeatMs ?? 15_000;
         const heartbeat = setInterval(() => {
           sendSse(res, "heartbeat", {
             event: "heartbeat",
-            inboxId,
+            agentId,
             timestamp: new Date().toISOString(),
           });
-        }, watchOptions.heartbeatMs ?? 15_000);
+        }, heartbeatMs);
 
-        const cleanup = () => {
+        req.on("close", () => {
           clearInterval(heartbeat);
           session.close();
-        };
-        req.on("close", cleanup);
-        req.on("error", cleanup);
+        });
         return;
       }
 
-      const inboxAckMatch = url.pathname.match(/^\/inboxes\/([^/]+)\/ack$/);
-      if (req.method === "POST" && inboxAckMatch) {
+      const agentInboxAckAllMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/ack-all$/);
+      if (req.method === "POST" && agentInboxAckAllMatch) {
+        send(res, 200, service.ackAllInboxItems(decodeURIComponent(agentInboxAckAllMatch[1])));
+        return;
+      }
+
+      const agentInboxAckMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/ack$/);
+      if (req.method === "POST" && agentInboxAckMatch) {
         const body = await readJson(req);
-        const itemIds = Array.isArray(body.itemIds) ? body.itemIds.map(String) : [];
-        send(res, 200, service.ackInboxItems(decodeURIComponent(inboxAckMatch[1]), itemIds));
-        return;
-      }
-
-      const inboxAckAllMatch = url.pathname.match(/^\/inboxes\/([^/]+)\/ack-all$/);
-      if (req.method === "POST" && inboxAckAllMatch) {
-        send(res, 200, service.ackAllInboxItems(decodeURIComponent(inboxAckAllMatch[1])));
+        const itemIds = Array.isArray(body.itemIds) ? body.itemIds.map((itemId) => String(itemId)) : [];
+        send(res, 200, service.ackInboxItems(decodeURIComponent(agentInboxAckMatch[1]), itemIds));
         return;
       }
 
       if (req.method === "POST" && url.pathname === "/deliveries/send") {
-        const result = await service.sendDelivery(await readJson(req) as never);
-        send(res, 200, result);
+        send(res, 200, await service.sendDelivery(await readJson(req) as never));
         return;
       }
 
       send(res, 404, { error: "not found" });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (message.startsWith("unknown ")) {
-        send(res, 404, { error: message });
-        return;
-      }
-      if (
-        message.startsWith("manual append is not supported") ||
-        message.startsWith("fixtures/emit requires") ||
-        message.startsWith("sources/events requires") ||
-        message.startsWith("deliveryHandle requires") ||
-        message.startsWith("subscriptions/reset requires") ||
-        message.startsWith("terminals/register requires") ||
-        message.startsWith("inboxes/ensure requires") ||
-        message.startsWith("inbox ") ||
-        message.startsWith("unsupported start policy") ||
-        message.startsWith("unsupported terminal") ||
-        message.includes("requires tmuxPaneId") ||
-        message.includes("requires itermSessionId") ||
-        message.includes("already belongs to agent") ||
-        message.includes("belongs to agent")
-      ) {
-        send(res, 400, { error: message });
-        return;
-      }
-      if (message.startsWith("expected positive integer") || message.startsWith("expected integer")) {
-        send(res, 400, { error: message });
-        return;
-      }
-      send(res, 500, { error: message });
+      send(res, 400, {
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   });
 }
 
-function parsePositiveInteger(value: string | null): number | undefined {
-  if (!value) {
-    return undefined;
-  }
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(`expected positive integer, received ${value}`);
+function parseRequiredString(value: unknown, message: string): string {
+  const parsed = parseOptionalString(value);
+  if (!parsed) {
+    throw new Error(message);
   }
   return parsed;
-}
-
-function parseOptionalInteger(value: unknown): number | undefined {
-  if (value == null) {
-    return undefined;
-  }
-  if (typeof value !== "number" || !Number.isInteger(value)) {
-    throw new Error(`expected integer, received ${String(value)}`);
-  }
-  return value;
-}
-
-function parseRequiredString(value: unknown, _errorMessage: string): string {
-  if (typeof value !== "string") {
-    return "";
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : "";
 }
 
 function parseOptionalString(value: unknown): string | undefined {
@@ -390,22 +321,30 @@ function parseOptionalString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function parseOptionalDeliveryHandle(value: unknown): DeliveryHandle | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+function parseOptionalInteger(value: unknown): number | undefined {
+  if (value == null) {
     return undefined;
   }
-  const record = value as Record<string, unknown>;
-  const provider = parseOptionalString(record.provider);
-  const surface = parseOptionalString(record.surface);
-  const targetRef = parseOptionalString(record.targetRef);
-  if (!provider || !surface || !targetRef) {
-    throw new Error("deliveryHandle requires provider, surface, and targetRef");
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) {
+    throw new Error(`expected integer, received ${String(value)}`);
   }
+  return parsed;
+}
+
+function parseOptionalDeliveryHandle(value: unknown): DeliveryHandle | null {
+  if (!value) {
+    return null;
+  }
+  const object = asObject(value);
+  const provider = parseRequiredString(object.provider, "deliveryHandle.provider is required");
+  const surface = parseRequiredString(object.surface, "deliveryHandle.surface is required");
+  const targetRef = parseRequiredString(object.targetRef, "deliveryHandle.targetRef is required");
   return {
     provider,
     surface,
     targetRef,
-    threadRef: parseOptionalString(record.threadRef) ?? null,
-    replyMode: parseOptionalString(record.replyMode) ?? null,
+    threadRef: parseOptionalString(object.threadRef) ?? null,
+    replyMode: parseOptionalString(object.replyMode) ?? null,
   };
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -5,6 +5,8 @@ export type ActivationMode = "activation_only" | "activation_with_items";
 export type TerminalBackend = "tmux" | "iterm2";
 export type TerminalMode = "agent_prompt";
 export type RuntimeKind = "codex" | "claude_code" | "unknown";
+export type ActivationTargetKind = "webhook" | "terminal";
+export type ActivationDispatchStatus = "notified" | "dirty";
 
 export interface DeliveryHandle {
   provider: string;
@@ -26,6 +28,15 @@ export interface SubscriptionSource {
   updatedAt: string;
 }
 
+export interface Agent {
+  agentId: string;
+  runtimeKind: RuntimeKind;
+  runtimeSessionId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastSeenAt: string;
+}
+
 export interface Inbox {
   inboxId: string;
   ownerAgentId: string;
@@ -36,38 +47,47 @@ export interface Subscription {
   subscriptionId: string;
   agentId: string;
   sourceId: string;
-  inboxId: string;
   matchRules: Record<string, unknown>;
-  activationTarget?: string | null;
-  terminalTargetId?: string | null;
-  activationMode: ActivationMode;
   startPolicy: SubscriptionStartPolicy;
   startOffset?: number | null;
   startTime?: string | null;
   createdAt: string;
 }
 
-export interface TerminalTarget {
+interface ActivationTargetBase {
   targetId: string;
   agentId: string;
-  runtimeKind: RuntimeKind;
-  runtimeSessionId?: string | null;
-  backend: TerminalBackend;
-  mode: TerminalMode;
-  tmuxPaneId?: string | null;
-  tty?: string | null;
-  termProgram?: string | null;
-  itermSessionId?: string | null;
+  kind: ActivationTargetKind;
   notifyLeaseMs: number;
   createdAt: string;
   updatedAt: string;
   lastSeenAt: string;
 }
 
-export interface TerminalDispatchState {
-  inboxId: string;
+export interface WebhookActivationTarget extends ActivationTargetBase {
+  kind: "webhook";
+  mode: ActivationMode;
+  url: string;
+}
+
+export interface TerminalActivationTarget extends ActivationTargetBase {
+  kind: "terminal";
+  mode: TerminalMode;
+  runtimeKind: RuntimeKind;
+  runtimeSessionId?: string | null;
+  backend: TerminalBackend;
+  tmuxPaneId?: string | null;
+  tty?: string | null;
+  termProgram?: string | null;
+  itermSessionId?: string | null;
+}
+
+export type ActivationTarget = WebhookActivationTarget | TerminalActivationTarget;
+
+export interface ActivationDispatchState {
+  agentId: string;
   targetId: string;
-  status: "notified" | "dirty";
+  status: ActivationDispatchStatus;
   leaseExpiresAt: string | null;
   pendingNewItemCount: number;
   pendingSummary: string | null;
@@ -106,6 +126,8 @@ export interface Activation {
   activationId: string;
   agentId: string;
   inboxId: string;
+  targetId: string;
+  targetKind: ActivationTargetKind;
   subscriptionIds: string[];
   sourceIds: string[];
   newItemCount: number;
@@ -135,29 +157,37 @@ export interface RegisterSourceInput {
   config?: Record<string, unknown>;
 }
 
-export interface RegisterSubscriptionInput {
-  agentId: string;
-  sourceId: string;
-  inboxId?: string;
-  matchRules?: Record<string, unknown>;
-  activationTarget?: string | null;
-  terminalTargetId?: string | null;
-  activationMode?: ActivationMode;
-  startPolicy?: SubscriptionStartPolicy;
-  startOffset?: number | null;
-  startTime?: string | null;
-}
-
-export interface RegisterTerminalTargetInput {
-  backend: TerminalBackend;
+export interface RegisterAgentInput {
   runtimeKind?: RuntimeKind | null;
   runtimeSessionId?: string | null;
+  backend: TerminalBackend;
   mode?: TerminalMode;
   tmuxPaneId?: string | null;
   tty?: string | null;
   termProgram?: string | null;
   itermSessionId?: string | null;
   notifyLeaseMs?: number | null;
+}
+
+export interface RegisterAgentResult {
+  agent: Agent;
+  terminalTarget: TerminalActivationTarget;
+  inbox: Inbox;
+}
+
+export interface AddWebhookActivationTargetInput {
+  url: string;
+  activationMode?: ActivationMode;
+  notifyLeaseMs?: number | null;
+}
+
+export interface RegisterSubscriptionInput {
+  agentId: string;
+  sourceId: string;
+  matchRules?: Record<string, unknown>;
+  startPolicy?: SubscriptionStartPolicy;
+  startOffset?: number | null;
+  startTime?: string | null;
 }
 
 export interface AppendSourceEventInput {
@@ -177,7 +207,7 @@ export interface AppendSourceEventResult {
 }
 
 export interface DeliveryRequest {
-  inboxId?: string;
+  agentId?: string;
   deliveryHandle?: DeliveryHandle | null;
   provider?: string;
   surface?: string;
@@ -223,13 +253,13 @@ export interface WatchInboxOptions extends ListInboxItemsOptions {
 
 export interface InboxWatchItemsEvent {
   event: "items";
-  inboxId: string;
+  agentId: string;
   items: InboxItem[];
 }
 
 export interface InboxWatchHeartbeatEvent {
   event: "heartbeat";
-  inboxId: string;
+  agentId: string;
   timestamp: string;
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,6 +1,9 @@
 import {
   Activation,
   ActivationItem,
+  ActivationTarget,
+  AddWebhookActivationTargetInput,
+  Agent,
   AppendSourceEventInput,
   AppendSourceEventResult,
   DeliveryAttempt,
@@ -9,24 +12,25 @@ import {
   Inbox,
   InboxItem,
   InboxWatchEvent,
+  RegisterAgentInput,
+  RegisterAgentResult,
   RegisterSourceInput,
   RegisterSubscriptionInput,
-  RegisterTerminalTargetInput,
   SourcePollResult,
   Subscription,
   SubscriptionPollResult,
   SubscriptionSource,
-  TerminalDispatchState,
-  TerminalTarget,
+  TerminalActivationTarget,
   WatchInboxOptions,
+  WebhookActivationTarget,
 } from "./model";
 import { AgentInboxStore } from "./store";
 import { AdapterRegistry } from "./adapters";
 import {
-  defaultInboxIdForAgent,
   ConsumerLag,
   EventBusBackend,
   SqliteEventBusBackend,
+  defaultInboxIdForAgent,
   streamKeyForSource,
   toAppendResult,
 } from "./backend";
@@ -37,40 +41,24 @@ import { assignedAgentIdFromContext, detectTerminalContext, renderAgentPrompt, T
 const DEFAULT_SUBSCRIPTION_POLL_LIMIT = 100;
 const DEFAULT_ACTIVATION_WINDOW_MS = 3_000;
 const DEFAULT_ACTIVATION_MAX_ITEMS = 20;
-const DEFAULT_TERMINAL_NOTIFY_LEASE_MS = 10 * 60 * 1000;
-const DEFAULT_TERMINAL_RETRY_MS = 5_000;
-const ACTIVATION_MODES = new Set<Subscription["activationMode"]>(["activation_only", "activation_with_items"]);
+const DEFAULT_NOTIFY_LEASE_MS = 10 * 60 * 1000;
+const DEFAULT_NOTIFY_RETRY_MS = 5_000;
+const WEBHOOK_ACTIVATION_MODES = new Set<WebhookActivationTarget["mode"]>(["activation_only", "activation_with_items"]);
 const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
-const TERMINAL_MODES = new Set<TerminalTarget["mode"]>(["agent_prompt"]);
-
-interface ActivationBuffer {
-  agentId: string;
-  inboxId: string;
-  activationTarget: string | null;
-  activationMode: Subscription["activationMode"];
-  pending: Array<{
-    subscriptionId: string;
-    sourceId: string;
-    summary: string;
-    item?: ActivationItem;
-  }>;
-  timer: NodeJS.Timeout | null;
-  inFlight: boolean;
-}
 
 interface ActivationPolicy {
   windowMs?: number;
   maxItems?: number;
 }
 
-interface BufferedTerminalNotification {
-  inboxId: string;
-  terminalTargetId: string;
+interface BufferedNotification {
   agentId: string;
+  targetId: string;
   pending: Array<{
     subscriptionId: string;
     sourceId: string;
     summary: string;
+    item: ActivationItem;
   }>;
   timer: NodeJS.Timeout | null;
   inFlight: boolean;
@@ -91,10 +79,9 @@ export class AgentInboxService {
   private readonly inFlightSubscriptions = new Set<string>();
   private readonly activationWindowMs: number;
   private readonly activationMaxItems: number;
-  private readonly activationBuffers = new Map<string, ActivationBuffer>();
-  private readonly terminalBuffers = new Map<string, BufferedTerminalNotification>();
+  private readonly notificationBuffers = new Map<string, BufferedNotification>();
   private readonly inboxWatchers = new Map<string, Set<InboxWatcher>>();
-  private subscriptionInterval: NodeJS.Timeout | null = null;
+  private syncInterval: NodeJS.Timeout | null = null;
   private stopping = false;
 
   constructor(
@@ -116,39 +103,31 @@ export class AgentInboxService {
   private readonly terminalDispatcher: TerminalDispatcher;
 
   async start(): Promise<void> {
-    if (this.subscriptionInterval) {
+    if (this.syncInterval) {
       return;
     }
     this.stopping = false;
-    this.subscriptionInterval = setInterval(() => {
+    this.syncInterval = setInterval(() => {
       void this.syncAllSubscriptions();
-      void this.syncTerminalDispatchStates();
+      void this.syncActivationDispatchStates();
     }, 2_000);
     await this.syncAllSubscriptions();
-    await this.syncTerminalDispatchStates();
+    await this.syncActivationDispatchStates();
   }
 
   async stop(): Promise<void> {
     this.stopping = true;
-    for (const buffer of this.activationBuffers.values()) {
+    for (const buffer of this.notificationBuffers.values()) {
       if (buffer.timer) {
         clearTimeout(buffer.timer);
         buffer.timer = null;
       }
     }
-    for (const buffer of this.terminalBuffers.values()) {
-      if (buffer.timer) {
-        clearTimeout(buffer.timer);
-        buffer.timer = null;
-      }
+    if (this.syncInterval) {
+      clearInterval(this.syncInterval);
+      this.syncInterval = null;
     }
-    if (!this.subscriptionInterval) {
-      await this.flushAllPendingActivations();
-      return;
-    }
-    clearInterval(this.subscriptionInterval);
-    this.subscriptionInterval = null;
-    await this.flushAllPendingActivations();
+    await this.flushAllPendingNotifications();
   }
 
   async registerSource(input: RegisterSourceInput): Promise<SubscriptionSource> {
@@ -156,6 +135,7 @@ export class AgentInboxService {
     if (existing) {
       return existing;
     }
+    const now = nowIso();
     const source: SubscriptionSource = {
       sourceId: generateId("src"),
       sourceType: input.sourceType,
@@ -164,8 +144,8 @@ export class AgentInboxService {
       config: input.config ?? {},
       status: "active",
       checkpoint: null,
-      createdAt: nowIso(),
-      updatedAt: nowIso(),
+      createdAt: now,
+      updatedAt: now,
     };
     this.store.insertSource(source);
     await this.ensureStreamForSource(source);
@@ -194,35 +174,151 @@ export class AgentInboxService {
     };
   }
 
+  registerAgent(input: RegisterAgentInput): RegisterAgentResult {
+    validateNotifyLeaseMs(input.notifyLeaseMs);
+    validateTerminalRegistration(input);
+
+    const runtimeKind = input.runtimeKind ?? "unknown";
+    const agentId = assignedAgentIdFromContext({
+      runtimeKind,
+      runtimeSessionId: input.runtimeSessionId ?? null,
+      backend: input.backend,
+      tmuxPaneId: input.tmuxPaneId ?? null,
+      itermSessionId: input.itermSessionId ?? null,
+      tty: input.tty ?? null,
+    });
+    const now = nowIso();
+    const existingAgent = this.store.getAgent(agentId);
+    const agent = existingAgent
+      ? this.store.updateAgent(agentId, {
+          runtimeKind,
+          runtimeSessionId: input.runtimeSessionId ?? null,
+          updatedAt: now,
+          lastSeenAt: now,
+        })
+      : (() => {
+          const created: Agent = {
+            agentId,
+            runtimeKind,
+            runtimeSessionId: input.runtimeSessionId ?? null,
+            createdAt: now,
+            updatedAt: now,
+            lastSeenAt: now,
+          };
+          this.store.insertAgent(created);
+          return created;
+        })();
+
+    const terminalTarget = this.upsertTerminalActivationTarget(agent.agentId, input, now);
+    const inbox = this.ensureInboxForAgent(agent.agentId);
+    return {
+      agent,
+      terminalTarget,
+      inbox,
+    };
+  }
+
+  detectAndRegisterAgent(notifyLeaseMs?: number | null, env: NodeJS.ProcessEnv = process.env): RegisterAgentResult {
+    const detected = detectTerminalContext(env);
+    return this.registerAgent({
+      runtimeKind: detected.runtimeKind,
+      runtimeSessionId: detected.runtimeSessionId ?? null,
+      backend: detected.backend,
+      mode: "agent_prompt",
+      tmuxPaneId: detected.tmuxPaneId ?? null,
+      tty: detected.tty ?? null,
+      termProgram: detected.termProgram ?? null,
+      itermSessionId: detected.itermSessionId ?? null,
+      notifyLeaseMs: notifyLeaseMs ?? null,
+    });
+  }
+
+  listAgents(): Agent[] {
+    return this.store.listAgents();
+  }
+
+  getAgent(agentId: string): Agent {
+    const agent = this.store.getAgent(agentId);
+    if (!agent) {
+      throw new Error(`unknown agent: ${agentId}`);
+    }
+    return agent;
+  }
+
+  getAgentDetails(agentId: string): Record<string, unknown> {
+    const agent = this.getAgent(agentId);
+    return {
+      agent,
+      inbox: this.ensureInboxForAgent(agent.agentId),
+      subscriptions: this.store.listSubscriptionsForAgent(agent.agentId),
+      activationTargets: this.store.listActivationTargetsForAgent(agent.agentId),
+      activationDispatchStates: this.store.listActivationDispatchStatesForAgent(agent.agentId),
+      itemCounts: this.inboxCounts(agent.agentId),
+    };
+  }
+
+  addWebhookActivationTarget(agentId: string, input: AddWebhookActivationTargetInput): WebhookActivationTarget {
+    this.getAgent(agentId);
+    validateNotifyLeaseMs(input.notifyLeaseMs);
+    const mode = normalizeWebhookActivationMode(input.activationMode);
+    const now = nowIso();
+    const target: WebhookActivationTarget = {
+      targetId: generateId("tgt"),
+      agentId,
+      kind: "webhook",
+      mode,
+      url: input.url,
+      notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_NOTIFY_LEASE_MS,
+      createdAt: now,
+      updatedAt: now,
+      lastSeenAt: now,
+    };
+    this.store.insertActivationTarget(target);
+    return target;
+  }
+
+  listActivationTargets(agentId?: string): ActivationTarget[] {
+    if (agentId) {
+      this.getAgent(agentId);
+      return this.store.listActivationTargetsForAgent(agentId);
+    }
+    return this.store.listActivationTargets();
+  }
+
+  getActivationTarget(targetId: string): ActivationTarget {
+    const target = this.store.getActivationTarget(targetId);
+    if (!target) {
+      throw new Error(`unknown activation target: ${targetId}`);
+    }
+    return target;
+  }
+
+  removeActivationTarget(agentId: string, targetId: string): { removed: boolean } {
+    const target = this.getActivationTarget(targetId);
+    if (target.agentId !== agentId) {
+      throw new Error(`activation target ${targetId} does not belong to agent ${agentId}`);
+    }
+    this.store.deleteActivationTarget(agentId, targetId);
+    return { removed: true };
+  }
+
   async registerSubscription(input: RegisterSubscriptionInput): Promise<Subscription> {
+    this.getAgent(input.agentId);
     const source = this.store.getSource(input.sourceId);
     if (!source) {
       throw new Error(`unknown source: ${input.sourceId}`);
     }
-    const activationMode = normalizeActivationMode(input.activationMode);
-    const terminalTarget = input.terminalTargetId
-      ? this.getTerminalTarget(input.terminalTargetId)
-      : null;
-    if (terminalTarget && terminalTarget.agentId !== input.agentId) {
-      throw new Error(`terminal target ${terminalTarget.targetId} does not belong to agent ${input.agentId}`);
-    }
-
-    const inboxId = input.inboxId ?? defaultInboxIdForAgent(input.agentId);
-    this.ensureInbox(inboxId, input.agentId);
     const subscription: Subscription = {
       subscriptionId: generateId("sub"),
       agentId: input.agentId,
       sourceId: input.sourceId,
-      inboxId,
       matchRules: input.matchRules ?? {},
-      activationTarget: input.activationTarget ?? null,
-      terminalTargetId: terminalTarget?.targetId ?? null,
-      activationMode,
       startPolicy: input.startPolicy ?? "latest",
       startOffset: input.startOffset ?? null,
       startTime: input.startTime ?? null,
       createdAt: nowIso(),
     };
+    this.ensureInboxForAgent(subscription.agentId);
     this.store.insertSubscription(subscription);
 
     const stream = await this.ensureStreamForSource(source);
@@ -237,95 +333,15 @@ export class AgentInboxService {
     return subscription;
   }
 
-  registerTerminalTarget(input: RegisterTerminalTargetInput): TerminalTarget {
-    const mode = normalizeTerminalMode(input.mode);
-    validateTerminalIdentity(input);
-    validateNotifyLeaseMs(input.notifyLeaseMs);
-    const runtimeKind = input.runtimeKind ?? "unknown";
-    const agentId = assignedAgentIdFromContext({
-      runtimeKind,
-      runtimeSessionId: input.runtimeSessionId ?? null,
-      backend: input.backend,
-      tmuxPaneId: input.tmuxPaneId ?? null,
-      itermSessionId: input.itermSessionId ?? null,
-      tty: input.tty ?? null,
-    });
-
-    const now = nowIso();
-    const existing = findExistingTerminalTarget(this.store, input);
-    if (existing) {
-      return this.store.updateTerminalTargetHeartbeat(existing.targetId, {
-        runtimeKind,
-        runtimeSessionId: input.runtimeSessionId ?? null,
-        tmuxPaneId: input.tmuxPaneId ?? null,
-        tty: input.tty ?? null,
-        termProgram: input.termProgram ?? null,
-        itermSessionId: input.itermSessionId ?? null,
-        updatedAt: now,
-        lastSeenAt: now,
-      });
-    }
-
-    const target: TerminalTarget = {
-      targetId: generateId("term"),
-      agentId,
-      runtimeKind,
-      runtimeSessionId: input.runtimeSessionId ?? null,
-      backend: input.backend,
-      mode,
-      tmuxPaneId: input.tmuxPaneId ?? null,
-      tty: input.tty ?? null,
-      termProgram: input.termProgram ?? null,
-      itermSessionId: input.itermSessionId ?? null,
-      notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_TERMINAL_NOTIFY_LEASE_MS,
-      createdAt: now,
-      updatedAt: now,
-      lastSeenAt: now,
-    };
-    this.store.insertTerminalTarget(target);
-    return target;
-  }
-
-  detectAndRegisterTerminalTarget(notifyLeaseMs?: number | null, env: NodeJS.ProcessEnv = process.env): TerminalTarget {
-    const detected = detectTerminalContext(env);
-    return this.registerTerminalTarget({
-      runtimeKind: detected.runtimeKind,
-      runtimeSessionId: detected.runtimeSessionId ?? null,
-      backend: detected.backend,
-      mode: "agent_prompt",
-      tmuxPaneId: detected.tmuxPaneId ?? null,
-      tty: detected.tty ?? null,
-      termProgram: detected.termProgram ?? null,
-      itermSessionId: detected.itermSessionId ?? null,
-      notifyLeaseMs: notifyLeaseMs ?? null,
-    });
-  }
-
-  listTerminalTargets(): TerminalTarget[] {
-    return this.store.listTerminalTargets();
-  }
-
-  getTerminalTarget(targetId: string): TerminalTarget {
-    const target = this.store.getTerminalTarget(targetId);
-    if (!target) {
-      throw new Error(`unknown terminal target: ${targetId}`);
-    }
-    return target;
-  }
-
   listSubscriptions(filters?: {
     sourceId?: string;
     agentId?: string;
-    inboxId?: string;
   }): Subscription[] {
     return this.store.listSubscriptions().filter((subscription) => {
       if (filters?.sourceId && subscription.sourceId !== filters.sourceId) {
         return false;
       }
       if (filters?.agentId && subscription.agentId !== filters.agentId) {
-        return false;
-      }
-      if (filters?.inboxId && subscription.inboxId !== filters.inboxId) {
         return false;
       }
       return true;
@@ -349,8 +365,8 @@ export class AgentInboxService {
     return {
       subscription,
       source: this.getSource(subscription.sourceId),
-      inbox: this.getInbox(subscription.inboxId),
-      terminalTarget: subscription.terminalTargetId ? this.getTerminalTarget(subscription.terminalTargetId) : null,
+      inbox: this.ensureInboxForAgent(subscription.agentId),
+      activationTargets: this.store.listActivationTargetsForAgent(subscription.agentId),
       consumer,
       lag: await this.backend.getConsumerLag({ consumerId: consumer.consumerId }),
     };
@@ -401,108 +417,58 @@ export class AgentInboxService {
     return toAppendResult(result);
   }
 
-  async appendSourceEventByCaller(
-    sourceId: string,
-    input: Omit<AppendSourceEventInput, "sourceId">,
-  ): Promise<AppendSourceEventResult> {
-    const source = this.store.getSource(sourceId);
-    if (!source) {
-      throw new Error(`unknown source: ${sourceId}`);
-    }
+  async appendSourceEventByCaller(sourceId: string, input: Omit<AppendSourceEventInput, "sourceId">): Promise<AppendSourceEventResult> {
+    const source = this.getSource(sourceId);
     if (source.sourceType !== "custom") {
       throw new Error(`manual append is not supported for source type: ${source.sourceType}`);
     }
-    return this.appendSourceEvent({
-      sourceId,
-      sourceNativeId: input.sourceNativeId,
-      eventVariant: input.eventVariant,
-      occurredAt: input.occurredAt,
-      metadata: input.metadata,
-      rawPayload: input.rawPayload,
-      deliveryHandle: input.deliveryHandle,
-    });
+    return this.appendSourceEvent({ ...input, sourceId });
   }
 
-  async appendFixtureEvent(
-    sourceId: string,
-    input: Omit<AppendSourceEventInput, "sourceId">,
-  ): Promise<AppendSourceEventResult> {
-    const source = this.store.getSource(sourceId);
-    if (!source) {
-      throw new Error(`unknown source: ${sourceId}`);
-    }
+  async appendFixtureEvent(sourceId: string, input: Omit<AppendSourceEventInput, "sourceId">): Promise<AppendSourceEventResult> {
+    const source = this.getSource(sourceId);
     if (source.sourceType !== "fixture") {
       throw new Error(`fixtures/emit requires fixture source, received: ${source.sourceType}`);
     }
-    return this.appendSourceEvent({
-      sourceId,
-      sourceNativeId: input.sourceNativeId,
-      eventVariant: input.eventVariant,
-      occurredAt: input.occurredAt,
-      metadata: input.metadata,
-      rawPayload: input.rawPayload,
-      deliveryHandle: input.deliveryHandle,
-    });
+    return this.appendSourceEvent({ ...input, sourceId });
   }
 
-  listInboxIds(): string[] {
-    return this.store.listInboxes().map((inbox) => inbox.inboxId);
+  listInboxAgentIds(): string[] {
+    return this.store.listInboxes().map((inbox) => inbox.ownerAgentId);
   }
 
-  listInboxes(): Inbox[] {
-    return this.store.listInboxes();
-  }
-
-  ensureInboxByCaller(inboxId: string, ownerAgentId: string): Inbox {
-    return this.ensureInbox(inboxId, ownerAgentId);
-  }
-
-  getInbox(inboxId: string): Inbox {
-    const inbox = this.store.getInbox(inboxId);
-    if (!inbox) {
-      throw new Error(`unknown inbox: ${inboxId}`);
-    }
-    return inbox;
-  }
-
-  getInboxDetails(inboxId: string): Record<string, unknown> {
-    const inbox = this.getInbox(inboxId);
-    const subscriptions = this.listSubscriptions({ inboxId });
+  getInboxDetailsByAgent(agentId: string): Record<string, unknown> {
+    const inbox = this.ensureInboxForAgent(agentId);
     return {
+      agent: this.getAgent(agentId),
       inbox,
-      subscriptions,
-      terminalDispatchStates: this.store.listTerminalDispatchStatesForInbox(inboxId),
-      itemCounts: {
-        total: this.store.countInboxItems(inboxId, true),
-        unacked: this.store.countInboxItems(inboxId, false),
-        acked: this.store.countInboxItems(inboxId, true) - this.store.countInboxItems(inboxId, false),
-      },
+      subscriptions: this.store.listSubscriptionsForAgent(agentId),
+      activationTargets: this.store.listActivationTargetsForAgent(agentId),
+      activationDispatchStates: this.store.listActivationDispatchStatesForAgent(agentId),
+      itemCounts: this.inboxCounts(agentId),
     };
   }
 
-  listInboxItems(inboxId: string, options?: WatchInboxOptions): InboxItem[] {
-    return this.store.listInboxItems(inboxId, options);
+  listInboxItems(agentId: string, options?: WatchInboxOptions): InboxItem[] {
+    return this.store.listInboxItems(this.ensureInboxForAgent(agentId).inboxId, options);
   }
 
   watchInbox(
-    inboxId: string,
+    agentId: string,
     options: WatchInboxOptions,
     onEvent: (event: InboxWatchEvent) => void,
   ): InboxWatchSession {
-    const inbox = this.store.getInbox(inboxId);
-    if (!inbox) {
-      throw new Error(`unknown inbox: ${inboxId}`);
-    }
-
+    const inbox = this.ensureInboxForAgent(agentId);
     const pendingItems: InboxItem[] = [];
     let started = false;
+
     const emitItems = (items: InboxItem[]) => {
       if (items.length === 0) {
         return;
       }
       onEvent({
         event: "items",
-        inboxId,
+        agentId,
         items,
       });
     };
@@ -517,10 +483,10 @@ export class AgentInboxService {
       },
     };
 
-    let watchers = this.inboxWatchers.get(inboxId);
+    let watchers = this.inboxWatchers.get(agentId);
     if (!watchers) {
       watchers = new Set();
-      this.inboxWatchers.set(inboxId, watchers);
+      this.inboxWatchers.set(agentId, watchers);
     }
     watchers.add(watcher);
 
@@ -533,13 +499,12 @@ export class AgentInboxService {
     } catch (error) {
       watchers.delete(watcher);
       if (watchers.size === 0) {
-        this.inboxWatchers.delete(inboxId);
+        this.inboxWatchers.delete(agentId);
       }
       throw error;
     }
 
     const initialItemIds = new Set(initialItems.map((item) => item.itemId));
-
     return {
       initialItems,
       start: () => {
@@ -552,49 +517,44 @@ export class AgentInboxService {
         emitItems(replayItems);
       },
       close: () => {
-        const activeWatchers = this.inboxWatchers.get(inboxId);
+        const activeWatchers = this.inboxWatchers.get(agentId);
         if (!activeWatchers) {
           return;
         }
         activeWatchers.delete(watcher);
         if (activeWatchers.size === 0) {
-          this.inboxWatchers.delete(inboxId);
+          this.inboxWatchers.delete(agentId);
         }
       },
     };
   }
 
-  ackInboxItems(inboxId: string, itemIds: string[]): { acked: number } {
-    const acked = this.store.ackItems(inboxId, itemIds, nowIso());
+  ackInboxItems(agentId: string, itemIds: string[]): { acked: number } {
+    const inbox = this.ensureInboxForAgent(agentId);
+    const acked = this.store.ackItems(inbox.inboxId, itemIds, nowIso());
     if (acked > 0) {
-      void this.handleInboxAckEffects(inboxId);
+      void this.handleInboxAckEffects(agentId);
     }
     return { acked };
   }
 
-  ackAllInboxItems(inboxId: string): { acked: number } {
-    const itemIds = this.store.listInboxItems(inboxId, { includeAcked: false }).map((item) => item.itemId);
-    const acked = this.store.ackItems(inboxId, itemIds, nowIso());
+  ackAllInboxItems(agentId: string): { acked: number } {
+    const inbox = this.ensureInboxForAgent(agentId);
+    const itemIds = this.store.listInboxItems(inbox.inboxId, { includeAcked: false }).map((item) => item.itemId);
+    const acked = this.store.ackItems(inbox.inboxId, itemIds, nowIso());
     if (acked > 0) {
-      void this.handleInboxAckEffects(inboxId);
+      void this.handleInboxAckEffects(agentId);
     }
     return { acked };
   }
 
   async pollSource(sourceId: string): Promise<SourcePollResult> {
-    const source = this.store.getSource(sourceId);
-    if (!source) {
-      throw new Error(`unknown source: ${sourceId}`);
-    }
-    return this.adapters.pollSource(source);
+    return this.adapters.pollSource(this.getSource(sourceId));
   }
 
   async pollSubscription(subscriptionId: string): Promise<SubscriptionPollResult> {
     if (this.inFlightSubscriptions.has(subscriptionId)) {
-      const subscription = this.store.getSubscription(subscriptionId);
-      if (!subscription) {
-        throw new Error(`unknown subscription: ${subscriptionId}`);
-      }
+      const subscription = this.getSubscription(subscriptionId);
       return {
         subscriptionId,
         sourceId: subscription.sourceId,
@@ -608,14 +568,8 @@ export class AgentInboxService {
 
     this.inFlightSubscriptions.add(subscriptionId);
     try {
-      const subscription = this.store.getSubscription(subscriptionId);
-      if (!subscription) {
-        throw new Error(`unknown subscription: ${subscriptionId}`);
-      }
-      const source = this.store.getSource(subscription.sourceId);
-      if (!source) {
-        throw new Error(`unknown source: ${subscription.sourceId}`);
-      }
+      const subscription = this.getSubscription(subscriptionId);
+      const source = this.getSource(subscription.sourceId);
       const stream = await this.ensureStreamForSource(source);
       const consumer = await this.backend.ensureConsumer({
         streamId: stream.streamId,
@@ -631,6 +585,8 @@ export class AgentInboxService {
         limit: DEFAULT_SUBSCRIPTION_POLL_LIMIT,
       });
 
+      const inbox = this.ensureInboxForAgent(subscription.agentId);
+      const targets = this.store.listActivationTargetsForAgent(subscription.agentId);
       let matched = 0;
       let inboxItemsCreated = 0;
       let lastProcessedOffset: number | null = null;
@@ -648,7 +604,7 @@ export class AgentInboxService {
             sourceId: event.sourceId,
             sourceNativeId: event.sourceNativeId,
             eventVariant: event.eventVariant,
-            inboxId: subscription.inboxId,
+            inboxId: inbox.inboxId,
             occurredAt: event.occurredAt,
             metadata: { ...event.metadata, matchReason: match.reason, agentId: subscription.agentId },
             rawPayload: event.rawPayload,
@@ -661,44 +617,31 @@ export class AgentInboxService {
           }
           inboxItemsCreated += 1;
           insertedItems.push(item);
-          this.enqueueActivation({
-            agentId: subscription.agentId,
-            inboxId: subscription.inboxId,
-            activationTarget: subscription.activationTarget ?? null,
-            activationMode: subscription.activationMode,
-            subscriptionId: subscription.subscriptionId,
-            sourceId: source.sourceId,
-            eventVariant: event.eventVariant,
-            sourceType: source.sourceType,
-            sourceKey: source.sourceKey,
-            item: {
-              itemId: item.itemId,
-              sourceId: item.sourceId,
-              sourceNativeId: item.sourceNativeId,
-              eventVariant: item.eventVariant,
-              inboxId: item.inboxId,
-              occurredAt: item.occurredAt,
-              metadata: item.metadata,
-              rawPayload: item.rawPayload,
-              deliveryHandle: item.deliveryHandle,
-            },
-          });
-          if (subscription.terminalTargetId) {
-            this.enqueueTerminalNotification({
+
+          const activationItem: ActivationItem = {
+            itemId: item.itemId,
+            sourceId: item.sourceId,
+            sourceNativeId: item.sourceNativeId,
+            eventVariant: item.eventVariant,
+            inboxId: item.inboxId,
+            occurredAt: item.occurredAt,
+            metadata: item.metadata,
+            rawPayload: item.rawPayload,
+            deliveryHandle: item.deliveryHandle,
+          };
+          for (const target of targets) {
+            this.enqueueActivationTarget(target, {
               agentId: subscription.agentId,
-              inboxId: subscription.inboxId,
-              terminalTargetId: subscription.terminalTargetId,
               subscriptionId: subscription.subscriptionId,
               sourceId: source.sourceId,
-              eventVariant: event.eventVariant,
-              sourceType: source.sourceType,
-              sourceKey: source.sourceKey,
+              summary: summarizeSourceEvent(source.sourceType, source.sourceKey, event.eventVariant),
+              item: activationItem,
             });
           }
         }
       } catch (error) {
         if (insertedItems.length > 0) {
-          this.notifyInboxWatchers(subscription.inboxId, insertedItems);
+          this.notifyInboxWatchers(subscription.agentId, insertedItems);
         }
         if (lastProcessedOffset != null) {
           await this.backend.commit({
@@ -710,9 +653,8 @@ export class AgentInboxService {
       }
 
       if (insertedItems.length > 0) {
-        this.notifyInboxWatchers(subscription.inboxId, insertedItems);
+        this.notifyInboxWatchers(subscription.agentId, insertedItems);
       }
-
       if (lastProcessedOffset != null) {
         await this.backend.commit({
           consumerId: consumer.consumerId,
@@ -758,34 +700,43 @@ export class AgentInboxService {
   status(): Record<string, unknown> {
     return {
       counts: this.store.getCounts(),
+      agents: this.store.listAgents(),
       sources: this.store.listSources(),
       subscriptions: this.store.listSubscriptions(),
       inboxes: this.store.listInboxes(),
+      activationTargets: this.store.listActivationTargets(),
+      activationDispatchStates: this.store.listActivationDispatchStates(),
       streams: this.store.listStreams(),
       consumers: this.store.listConsumers(),
       adapters: this.adapters.status(),
       recentActivations: this.store.listActivations().slice(0, 10),
       recentDeliveries: this.store.listDeliveries().slice(0, 10),
-      terminalTargets: this.store.listTerminalTargets(),
-      terminalDispatchStates: this.store.listTerminalDispatchStates(),
     };
   }
 
-  private ensureInbox(inboxId: string, ownerAgentId: string): Inbox {
-    const existing = this.store.getInbox(inboxId);
+  private ensureInboxForAgent(agentId: string): Inbox {
+    const existing = this.store.getInboxByAgentId(agentId);
     if (existing) {
-      if (existing.ownerAgentId !== ownerAgentId) {
-        throw new Error(`inbox ${inboxId} already belongs to agent ${existing.ownerAgentId}`);
-      }
       return existing;
     }
     const inbox: Inbox = {
-      inboxId,
-      ownerAgentId,
+      inboxId: defaultInboxIdForAgent(agentId),
+      ownerAgentId: agentId,
       createdAt: nowIso(),
     };
     this.store.insertInbox(inbox);
     return inbox;
+  }
+
+  private inboxCounts(agentId: string): Record<string, number> {
+    const inbox = this.ensureInboxForAgent(agentId);
+    const total = this.store.countInboxItems(inbox.inboxId, true);
+    const unacked = this.store.countInboxItems(inbox.inboxId, false);
+    return {
+      total,
+      unacked,
+      acked: total - unacked,
+    };
   }
 
   private async ensureStreamForSource(source: SubscriptionSource) {
@@ -793,6 +744,304 @@ export class AgentInboxService {
       sourceId: source.sourceId,
       streamKey: streamKeyForSource(source.sourceType, source.sourceKey),
       backend: "sqlite",
+    });
+  }
+
+  private notifyInboxWatchers(agentId: string, items: InboxItem[]): void {
+    const watchers = this.inboxWatchers.get(agentId);
+    if (!watchers || watchers.size === 0) {
+      return;
+    }
+    for (const watcher of watchers) {
+      watcher.onItems(items);
+    }
+  }
+
+  private upsertTerminalActivationTarget(agentId: string, input: RegisterAgentInput, now: string): TerminalActivationTarget {
+    const existing = findExistingTerminalActivationTarget(this.store, input);
+    if (existing) {
+      const target = this.store.updateTerminalActivationTargetHeartbeat(existing.targetId, {
+        runtimeKind: input.runtimeKind ?? "unknown",
+        runtimeSessionId: input.runtimeSessionId ?? null,
+        tmuxPaneId: input.tmuxPaneId ?? null,
+        tty: input.tty ?? null,
+        termProgram: input.termProgram ?? null,
+        itermSessionId: input.itermSessionId ?? null,
+        updatedAt: now,
+        lastSeenAt: now,
+      });
+      if (target.agentId !== agentId) {
+        throw new Error(`terminal target ${target.targetId} is already bound to agent ${target.agentId}`);
+      }
+      return target;
+    }
+
+    const target: TerminalActivationTarget = {
+      targetId: generateId("tgt"),
+      agentId,
+      kind: "terminal",
+      mode: "agent_prompt",
+      notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_NOTIFY_LEASE_MS,
+      runtimeKind: input.runtimeKind ?? "unknown",
+      runtimeSessionId: input.runtimeSessionId ?? null,
+      backend: input.backend,
+      tmuxPaneId: input.tmuxPaneId ?? null,
+      tty: input.tty ?? null,
+      termProgram: input.termProgram ?? null,
+      itermSessionId: input.itermSessionId ?? null,
+      createdAt: now,
+      updatedAt: now,
+      lastSeenAt: now,
+    };
+    this.store.insertActivationTarget(target);
+    return target;
+  }
+
+  private enqueueActivationTarget(
+    target: ActivationTarget,
+    input: {
+      agentId: string;
+      subscriptionId: string;
+      sourceId: string;
+      summary: string;
+      item: ActivationItem;
+    },
+  ): void {
+    const key = notificationBufferKey(target.agentId, target.targetId);
+    let buffer = this.notificationBuffers.get(key);
+    if (!buffer) {
+      buffer = {
+        agentId: target.agentId,
+        targetId: target.targetId,
+        pending: [],
+        timer: null,
+        inFlight: false,
+      };
+      this.notificationBuffers.set(key, buffer);
+    }
+
+    buffer.pending.push({
+      subscriptionId: input.subscriptionId,
+      sourceId: input.sourceId,
+      summary: input.summary,
+      item: input.item,
+    });
+
+    if (!buffer.timer && !buffer.inFlight) {
+      buffer.timer = setTimeout(() => {
+        void this.flushNotificationBuffer(key);
+      }, this.activationWindowMs);
+    }
+
+    if (buffer.pending.length >= this.activationMaxItems) {
+      if (buffer.timer) {
+        clearTimeout(buffer.timer);
+        buffer.timer = null;
+      }
+      void this.flushNotificationBuffer(key);
+    }
+  }
+
+  private async flushAllPendingNotifications(): Promise<void> {
+    const keys = Array.from(this.notificationBuffers.keys());
+    for (const key of keys) {
+      await this.flushNotificationBuffer(key);
+    }
+  }
+
+  private async flushNotificationBuffer(key: string): Promise<void> {
+    const buffer = this.notificationBuffers.get(key);
+    if (!buffer || buffer.inFlight || buffer.pending.length === 0) {
+      return;
+    }
+    if (buffer.timer) {
+      clearTimeout(buffer.timer);
+      buffer.timer = null;
+    }
+
+    buffer.inFlight = true;
+    const entries = buffer.pending.splice(0, buffer.pending.length);
+    try {
+      const state = this.store.getActivationDispatchState(buffer.agentId, buffer.targetId);
+      if (!state) {
+        const dispatched = await this.dispatchActivationTarget({
+          agentId: buffer.agentId,
+          targetId: buffer.targetId,
+          newItemCount: entries.length,
+          summary: entries[0]?.summary ?? null,
+          subscriptionIds: uniqueSorted(entries.map((entry) => entry.subscriptionId)),
+          sourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
+          items: entries.map((entry) => entry.item),
+        });
+        if (!dispatched) {
+          this.upsertDirtyDispatchState(buffer.agentId, buffer.targetId, entries);
+        }
+      } else {
+        this.store.upsertActivationDispatchState({
+          agentId: buffer.agentId,
+          targetId: buffer.targetId,
+          status: "dirty",
+          leaseExpiresAt: state.leaseExpiresAt,
+          pendingNewItemCount: state.pendingNewItemCount + entries.length,
+          pendingSummary: state.pendingSummary ?? entries[0]?.summary ?? null,
+          pendingSubscriptionIds: uniqueSorted([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)]),
+          pendingSourceIds: uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)]),
+          updatedAt: nowIso(),
+        });
+      }
+
+      const hasPendingDuringFlight = buffer.pending.length > 0;
+      buffer.inFlight = false;
+      if (hasPendingDuringFlight) {
+        buffer.timer = setTimeout(() => {
+          void this.flushNotificationBuffer(key);
+        }, this.activationWindowMs);
+        return;
+      }
+      this.notificationBuffers.delete(key);
+    } catch (error) {
+      buffer.pending.unshift(...entries);
+      buffer.inFlight = false;
+      if (!this.stopping && !buffer.timer) {
+        buffer.timer = setTimeout(() => {
+          void this.flushNotificationBuffer(key);
+        }, this.activationWindowMs);
+      }
+      throw error;
+    }
+  }
+
+  private async handleInboxAckEffects(agentId: string): Promise<void> {
+    const states = this.store.listActivationDispatchStatesForAgent(agentId);
+    for (const state of states) {
+      await this.maybeDispatchActivationTarget(agentId, state.targetId, "ack");
+    }
+  }
+
+  private async maybeDispatchActivationTarget(
+    agentId: string,
+    targetId: string,
+    reason: "ack" | "lease",
+  ): Promise<void> {
+    const state = this.store.getActivationDispatchState(agentId, targetId);
+    if (!state) {
+      return;
+    }
+
+    const inbox = this.ensureInboxForAgent(agentId);
+    const unacked = this.store.countInboxItems(inbox.inboxId, false);
+    if (unacked === 0) {
+      this.store.deleteActivationDispatchState(agentId, targetId);
+      return;
+    }
+
+    if (reason === "ack" && state.status !== "dirty") {
+      return;
+    }
+
+    const dispatched = await this.dispatchActivationTarget({
+      agentId,
+      targetId,
+      newItemCount: state.pendingNewItemCount > 0 ? state.pendingNewItemCount : unacked,
+      summary: state.pendingSummary,
+      subscriptionIds: state.pendingSubscriptionIds,
+      sourceIds: state.pendingSourceIds,
+      items: this.store.listInboxItems(inbox.inboxId, { includeAcked: false }).map((item) => ({
+        itemId: item.itemId,
+        sourceId: item.sourceId,
+        sourceNativeId: item.sourceNativeId,
+        eventVariant: item.eventVariant,
+        inboxId: item.inboxId,
+        occurredAt: item.occurredAt,
+        metadata: item.metadata,
+        rawPayload: item.rawPayload,
+        deliveryHandle: item.deliveryHandle,
+      })),
+    });
+
+    if (!dispatched) {
+      this.store.upsertActivationDispatchState({
+        ...state,
+        status: "dirty",
+        leaseExpiresAt: new Date(Date.now() + DEFAULT_NOTIFY_RETRY_MS).toISOString(),
+        updatedAt: nowIso(),
+      });
+    }
+  }
+
+  private async dispatchActivationTarget(input: {
+    agentId: string;
+    targetId: string;
+    newItemCount: number;
+    summary: string | null;
+    subscriptionIds: string[];
+    sourceIds: string[];
+    items: ActivationItem[];
+  }): Promise<boolean> {
+    const target = this.getActivationTarget(input.targetId);
+    const inbox = this.ensureInboxForAgent(input.agentId);
+    const summary = summarizeActivation(inbox.inboxId, input.newItemCount, input.summary);
+    try {
+      if (target.kind === "terminal") {
+        const prompt = renderAgentPrompt({
+          inboxId: inbox.inboxId,
+          newItemCount: input.newItemCount,
+          summary: input.summary,
+        });
+        await this.terminalDispatcher.dispatch(target, prompt);
+      } else {
+        const activation: Activation = {
+          kind: "agentinbox.activation",
+          activationId: generateId("act"),
+          agentId: input.agentId,
+          inboxId: inbox.inboxId,
+          targetId: target.targetId,
+          targetKind: target.kind,
+          subscriptionIds: input.subscriptionIds,
+          sourceIds: input.sourceIds,
+          newItemCount: input.newItemCount,
+          summary,
+          items: target.mode === "activation_with_items" && input.items.length > 0 ? input.items : undefined,
+          createdAt: nowIso(),
+          deliveredAt: null,
+        };
+        await this.activationDispatcher.dispatch(target.url, activation);
+        this.store.insertActivation(activation);
+      }
+
+      this.store.upsertActivationDispatchState({
+        agentId: input.agentId,
+        targetId: input.targetId,
+        status: "notified",
+        leaseExpiresAt: new Date(Date.now() + target.notifyLeaseMs).toISOString(),
+        pendingNewItemCount: 0,
+        pendingSummary: null,
+        pendingSubscriptionIds: [],
+        pendingSourceIds: [],
+        updatedAt: nowIso(),
+      });
+      return true;
+    } catch (error) {
+      console.warn(`activation target dispatch failed for ${target.targetId}:`, error);
+      return false;
+    }
+  }
+
+  private upsertDirtyDispatchState(
+    agentId: string,
+    targetId: string,
+    entries: Array<{ subscriptionId: string; sourceId: string; summary: string }>,
+  ): void {
+    this.store.upsertActivationDispatchState({
+      agentId,
+      targetId,
+      status: "dirty",
+      leaseExpiresAt: new Date(Date.now() + DEFAULT_NOTIFY_RETRY_MS).toISOString(),
+      pendingNewItemCount: entries.length,
+      pendingSummary: entries[0]?.summary ?? null,
+      pendingSubscriptionIds: uniqueSorted(entries.map((entry) => entry.subscriptionId)),
+      pendingSourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
+      updatedAt: nowIso(),
     });
   }
 
@@ -807,9 +1056,9 @@ export class AgentInboxService {
     }
   }
 
-  private async syncTerminalDispatchStates(): Promise<void> {
+  private async syncActivationDispatchStates(): Promise<void> {
     const now = Date.now();
-    const states = this.store.listTerminalDispatchStates();
+    const states = this.store.listActivationDispatchStates();
     for (const state of states) {
       if (!state.leaseExpiresAt) {
         continue;
@@ -819,345 +1068,11 @@ export class AgentInboxService {
         continue;
       }
       try {
-        await this.maybeDispatchTerminalNotification(state.inboxId, state.targetId, "lease");
+        await this.maybeDispatchActivationTarget(state.agentId, state.targetId, "lease");
       } catch (error) {
-        console.warn(`terminal notify lease sync failed for ${state.targetId}/${state.inboxId}:`, error);
+        console.warn(`activation target lease sync failed for ${state.targetId}/${state.agentId}:`, error);
       }
     }
-  }
-
-  private notifyInboxWatchers(inboxId: string, items: InboxItem[]): void {
-    const watchers = this.inboxWatchers.get(inboxId);
-    if (!watchers || watchers.size === 0) {
-      return;
-    }
-    for (const watcher of watchers) {
-      watcher.onItems(items);
-    }
-  }
-
-  private enqueueTerminalNotification(input: {
-    agentId: string;
-    inboxId: string;
-    terminalTargetId: string;
-    subscriptionId: string;
-    sourceId: string;
-    eventVariant: string;
-    sourceType: string;
-    sourceKey: string;
-  }): void {
-    const key = terminalBufferKey(input.inboxId, input.terminalTargetId);
-    let buffer = this.terminalBuffers.get(key);
-    if (!buffer) {
-      buffer = {
-        inboxId: input.inboxId,
-        terminalTargetId: input.terminalTargetId,
-        agentId: input.agentId,
-        pending: [],
-        timer: null,
-        inFlight: false,
-      };
-      this.terminalBuffers.set(key, buffer);
-    }
-
-    buffer.pending.push({
-      subscriptionId: input.subscriptionId,
-      sourceId: input.sourceId,
-      summary: summarizeSourceEvent(input.sourceType, input.sourceKey, input.eventVariant),
-    });
-
-    if (!buffer.timer && !buffer.inFlight) {
-      buffer.timer = setTimeout(() => {
-        void this.flushTerminalBuffer(key);
-      }, this.activationWindowMs);
-    }
-
-    if (buffer.pending.length >= this.activationMaxItems) {
-      if (buffer.timer) {
-        clearTimeout(buffer.timer);
-        buffer.timer = null;
-      }
-      void this.flushTerminalBuffer(key);
-    }
-  }
-
-  private enqueueActivation(input: {
-    agentId: string;
-    inboxId: string;
-    activationTarget: string | null;
-    activationMode: Subscription["activationMode"];
-    subscriptionId: string;
-    sourceId: string;
-    eventVariant: string;
-    sourceType: string;
-    sourceKey: string;
-    item: ActivationItem;
-  }): void {
-    const key = activationBufferKey(input.inboxId, input.activationTarget, input.activationMode);
-    let buffer = this.activationBuffers.get(key);
-    if (!buffer) {
-      buffer = {
-        agentId: input.agentId,
-        inboxId: input.inboxId,
-        activationTarget: input.activationTarget,
-        activationMode: input.activationMode,
-        pending: [],
-        timer: null,
-        inFlight: false,
-      };
-      this.activationBuffers.set(key, buffer);
-    }
-
-    buffer.pending.push({
-      subscriptionId: input.subscriptionId,
-      sourceId: input.sourceId,
-      summary: summarizeSourceEvent(input.sourceType, input.sourceKey, input.eventVariant),
-      item: input.activationMode === "activation_with_items" ? input.item : undefined,
-    });
-
-    if (!buffer.timer && !buffer.inFlight) {
-      buffer.timer = setTimeout(() => {
-        void this.flushActivationBuffer(key);
-      }, this.activationWindowMs);
-    }
-
-    if (buffer.pending.length >= this.activationMaxItems) {
-      if (buffer.timer) {
-        clearTimeout(buffer.timer);
-        buffer.timer = null;
-      }
-      void this.flushActivationBuffer(key);
-    }
-  }
-
-  private async flushAllPendingActivations(): Promise<void> {
-    const keys = Array.from(this.activationBuffers.keys());
-    for (const key of keys) {
-      await this.flushActivationBuffer(key);
-    }
-  }
-
-  private async flushActivationBuffer(key: string): Promise<void> {
-    const buffer = this.activationBuffers.get(key);
-    if (!buffer || buffer.inFlight || buffer.pending.length === 0) {
-      return;
-    }
-    if (buffer.timer) {
-      clearTimeout(buffer.timer);
-      buffer.timer = null;
-    }
-
-    buffer.inFlight = true;
-    const dispatchedEntries = buffer.pending.splice(0, buffer.pending.length);
-    try {
-      const dispatchedCount = dispatchedEntries.length;
-      const dispatchedSubscriptionIds = Array.from(new Set(dispatchedEntries.map((entry) => entry.subscriptionId))).sort();
-      const dispatchedSourceIds = Array.from(new Set(dispatchedEntries.map((entry) => entry.sourceId))).sort();
-      const dispatchedSummary = dispatchedEntries[0]?.summary ?? null;
-      const dispatchedItems = buffer.activationMode === "activation_with_items"
-        ? dispatchedEntries
-          .map((entry) => entry.item)
-          .filter((item): item is ActivationItem => Boolean(item))
-        : undefined;
-      const activation: Activation = {
-        kind: "agentinbox.activation",
-        activationId: generateId("act"),
-        agentId: buffer.agentId,
-        inboxId: buffer.inboxId,
-        subscriptionIds: dispatchedSubscriptionIds,
-        sourceIds: dispatchedSourceIds,
-        newItemCount: dispatchedCount,
-        summary: summarizeActivation(buffer.inboxId, dispatchedCount, dispatchedSummary),
-        items: dispatchedItems && dispatchedItems.length > 0 ? dispatchedItems : undefined,
-        createdAt: nowIso(),
-        deliveredAt: null,
-      };
-      await this.activationDispatcher.dispatch(buffer.activationTarget, activation);
-      this.store.insertActivation(activation);
-
-      const hasPendingDuringFlight = buffer.pending.length > 0;
-      buffer.inFlight = false;
-
-      if (hasPendingDuringFlight) {
-        buffer.timer = setTimeout(() => {
-          void this.flushActivationBuffer(key);
-        }, this.activationWindowMs);
-        return;
-      }
-
-      this.activationBuffers.delete(key);
-    } catch (error) {
-      buffer.pending.unshift(...dispatchedEntries);
-      buffer.inFlight = false;
-      if (!this.stopping && !buffer.timer) {
-        buffer.timer = setTimeout(() => {
-          void this.flushActivationBuffer(key);
-        }, this.activationWindowMs);
-      }
-      throw error;
-    }
-  }
-
-  private async flushTerminalBuffer(key: string): Promise<void> {
-    const buffer = this.terminalBuffers.get(key);
-    if (!buffer || buffer.inFlight || buffer.pending.length === 0) {
-      return;
-    }
-    if (buffer.timer) {
-      clearTimeout(buffer.timer);
-      buffer.timer = null;
-    }
-
-    buffer.inFlight = true;
-    const entries = buffer.pending.splice(0, buffer.pending.length);
-    try {
-      const summary = entries[0]?.summary ?? null;
-      const state = this.store.getTerminalDispatchState(buffer.inboxId, buffer.terminalTargetId);
-      if (!state) {
-        const dispatched = await this.dispatchTerminalNotification({
-          inboxId: buffer.inboxId,
-          targetId: buffer.terminalTargetId,
-          agentId: buffer.agentId,
-          newItemCount: entries.length,
-          summary,
-          subscriptionIds: uniqueSorted(entries.map((entry) => entry.subscriptionId)),
-          sourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
-        });
-        if (!dispatched) {
-          this.upsertDirtyTerminalState(buffer.inboxId, buffer.terminalTargetId, entries);
-        }
-      } else {
-        this.store.upsertTerminalDispatchState({
-          inboxId: buffer.inboxId,
-          targetId: buffer.terminalTargetId,
-          status: "dirty",
-          leaseExpiresAt: state.leaseExpiresAt,
-          pendingNewItemCount: state.pendingNewItemCount + entries.length,
-          pendingSummary: state.pendingSummary ?? summary,
-          pendingSubscriptionIds: uniqueSorted([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)]),
-          pendingSourceIds: uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)]),
-          updatedAt: nowIso(),
-        });
-      }
-
-      const hasPendingDuringFlight = buffer.pending.length > 0;
-      buffer.inFlight = false;
-      if (hasPendingDuringFlight) {
-        buffer.timer = setTimeout(() => {
-          void this.flushTerminalBuffer(key);
-        }, this.activationWindowMs);
-        return;
-      }
-      this.terminalBuffers.delete(key);
-    } catch (error) {
-      buffer.pending.unshift(...entries);
-      buffer.inFlight = false;
-      if (!this.stopping && !buffer.timer) {
-        buffer.timer = setTimeout(() => {
-          void this.flushTerminalBuffer(key);
-        }, this.activationWindowMs);
-      }
-      throw error;
-    }
-  }
-
-  private async handleInboxAckEffects(inboxId: string): Promise<void> {
-    const states = this.store.listTerminalDispatchStatesForInbox(inboxId);
-    for (const state of states) {
-      await this.maybeDispatchTerminalNotification(inboxId, state.targetId, "ack");
-    }
-  }
-
-  private async maybeDispatchTerminalNotification(
-    inboxId: string,
-    targetId: string,
-    reason: "ack" | "lease",
-  ): Promise<void> {
-    const state = this.store.getTerminalDispatchState(inboxId, targetId);
-    if (!state) {
-      return;
-    }
-    const unacked = this.store.countInboxItems(inboxId, false);
-    if (unacked === 0) {
-      this.store.deleteTerminalDispatchState(inboxId, targetId);
-      return;
-    }
-
-    if (reason === "ack" && state.status !== "dirty") {
-      return;
-    }
-
-    const dispatched = await this.dispatchTerminalNotification({
-      inboxId,
-      targetId,
-      agentId: this.getTerminalTarget(targetId).agentId,
-      newItemCount: state.pendingNewItemCount > 0 ? state.pendingNewItemCount : unacked,
-      summary: state.pendingSummary,
-      subscriptionIds: state.pendingSubscriptionIds,
-      sourceIds: state.pendingSourceIds,
-    });
-
-    if (!dispatched) {
-      this.store.upsertTerminalDispatchState({
-        ...state,
-        status: "dirty",
-        leaseExpiresAt: new Date(Date.now() + DEFAULT_TERMINAL_RETRY_MS).toISOString(),
-        updatedAt: nowIso(),
-      });
-    }
-  }
-
-  private async dispatchTerminalNotification(input: {
-    inboxId: string;
-    targetId: string;
-    agentId: string;
-    newItemCount: number;
-    summary: string | null;
-    subscriptionIds: string[];
-    sourceIds: string[];
-  }): Promise<boolean> {
-    const target = this.getTerminalTarget(input.targetId);
-    const prompt = renderAgentPrompt({
-      inboxId: input.inboxId,
-      newItemCount: input.newItemCount,
-      summary: input.summary,
-    });
-    try {
-      await this.terminalDispatcher.dispatch(target, prompt);
-      this.store.upsertTerminalDispatchState({
-        inboxId: input.inboxId,
-        targetId: input.targetId,
-        status: "notified",
-        leaseExpiresAt: new Date(Date.now() + target.notifyLeaseMs).toISOString(),
-        pendingNewItemCount: 0,
-        pendingSummary: null,
-        pendingSubscriptionIds: [],
-        pendingSourceIds: [],
-        updatedAt: nowIso(),
-      });
-      return true;
-    } catch (error) {
-      console.warn(`terminal dispatch failed for ${target.targetId}:`, error);
-      return false;
-    }
-  }
-
-  private upsertDirtyTerminalState(
-    inboxId: string,
-    targetId: string,
-    entries: Array<{ subscriptionId: string; sourceId: string; summary: string }>,
-  ): void {
-    this.store.upsertTerminalDispatchState({
-      inboxId,
-      targetId,
-      status: "dirty",
-      leaseExpiresAt: new Date(Date.now() + DEFAULT_TERMINAL_RETRY_MS).toISOString(),
-      pendingNewItemCount: entries.length,
-      pendingSummary: entries[0]?.summary ?? null,
-      pendingSubscriptionIds: uniqueSorted(entries.map((entry) => entry.subscriptionId)),
-      pendingSourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
-      updatedAt: nowIso(),
-    });
   }
 }
 
@@ -1178,67 +1093,33 @@ function resolveDeliveryHandle(request: DeliveryRequest): DeliveryHandle {
 }
 
 export class ActivationDispatcher {
-  async dispatch(target: string | null | undefined, activation: Activation): Promise<void> {
-    if (!target) {
-      return;
-    }
+  async dispatch(targetUrl: string, activation: Activation): Promise<void> {
     try {
-      const response = await fetch(target, {
+      const response = await fetch(targetUrl, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(activation),
       });
       if (!response.ok) {
-        console.warn(`activation dispatch failed for ${target}: ${response.status}`);
+        throw new Error(`activation dispatch failed for ${targetUrl}: ${response.status}`);
       }
     } catch (error) {
-      console.warn(`activation dispatch error for ${target}:`, error);
+      console.warn(`activation dispatch error for ${targetUrl}:`, error);
+      throw error;
     }
   }
 }
 
-function activationBufferKey(
-  inboxId: string,
-  activationTarget: string | null,
-  activationMode: Subscription["activationMode"],
-): string {
-  return `${inboxId}::${activationTarget ?? ""}::${activationMode}`;
-}
-
-function summarizeActivation(inboxId: string, newItemCount: number, firstSummary: string | null): string {
-  const itemWord = newItemCount === 1 ? "item" : "items";
-  if (firstSummary) {
-    return `${newItemCount} new ${itemWord} in ${inboxId} from ${firstSummary}`;
-  }
-  return `${newItemCount} new ${itemWord} in ${inboxId}`;
-}
-
-function normalizeActivationMode(mode: RegisterSubscriptionInput["activationMode"]): Subscription["activationMode"] {
-  const resolved = mode ?? "activation_only";
-  if (!ACTIVATION_MODES.has(resolved)) {
-    throw new Error(`unsupported activation mode: ${String(mode)}`);
-  }
-  return resolved;
-}
-
-function normalizeTerminalMode(mode: RegisterTerminalTargetInput["mode"]): TerminalTarget["mode"] {
-  const resolved = mode ?? "agent_prompt";
-  if (!TERMINAL_MODES.has(resolved)) {
-    throw new Error(`unsupported terminal mode: ${String(mode)}`);
-  }
-  return resolved;
-}
-
-function validateTerminalIdentity(input: RegisterTerminalTargetInput): void {
+function validateTerminalRegistration(input: RegisterAgentInput): void {
   if (input.backend === "tmux") {
     if (!input.tmuxPaneId) {
-      throw new Error("tmux terminal target requires tmuxPaneId");
+      throw new Error("tmux agent registration requires tmuxPaneId");
     }
     return;
   }
   if (input.backend === "iterm2") {
     if (!input.itermSessionId && !input.tty) {
-      throw new Error("iterm2 terminal target requires itermSessionId or tty");
+      throw new Error("iterm2 agent registration requires itermSessionId or tty");
     }
     return;
   }
@@ -1254,22 +1135,30 @@ function validateNotifyLeaseMs(value: number | null | undefined): void {
   }
 }
 
-function findExistingTerminalTarget(store: AgentInboxStore, input: RegisterTerminalTargetInput): TerminalTarget | null {
+function normalizeWebhookActivationMode(mode: AddWebhookActivationTargetInput["activationMode"]): WebhookActivationTarget["mode"] {
+  const resolved = mode ?? "activation_only";
+  if (!WEBHOOK_ACTIVATION_MODES.has(resolved)) {
+    throw new Error(`unsupported activation mode: ${String(mode)}`);
+  }
+  return resolved;
+}
+
+function findExistingTerminalActivationTarget(store: AgentInboxStore, input: RegisterAgentInput): TerminalActivationTarget | null {
   if (input.runtimeSessionId) {
-    const target = store.getTerminalTargetByRuntimeSession(input.runtimeKind ?? "unknown", input.runtimeSessionId);
+    const target = store.getTerminalActivationTargetByRuntimeSession(input.runtimeKind ?? "unknown", input.runtimeSessionId);
     if (target) {
       return target;
     }
   }
   if (input.backend === "tmux" && input.tmuxPaneId) {
-    return store.getTerminalTargetByTmuxPaneId(input.tmuxPaneId);
+    return store.getTerminalActivationTargetByTmuxPaneId(input.tmuxPaneId);
   }
   if (input.backend === "iterm2") {
     if (input.itermSessionId) {
-      return store.getTerminalTargetByItermSessionId(input.itermSessionId);
+      return store.getTerminalActivationTargetByItermSessionId(input.itermSessionId);
     }
     if (input.tty) {
-      return store.getTerminalTargetByTty(input.tty);
+      return store.getTerminalActivationTargetByTty(input.tty);
     }
   }
   return null;
@@ -1279,8 +1168,16 @@ function uniqueSorted(values: string[]): string[] {
   return Array.from(new Set(values)).sort();
 }
 
-function terminalBufferKey(inboxId: string, terminalTargetId: string): string {
-  return `${inboxId}::${terminalTargetId}`;
+function notificationBufferKey(agentId: string, targetId: string): string {
+  return `${agentId}::${targetId}`;
+}
+
+function summarizeActivation(inboxId: string, newItemCount: number, firstSummary: string | null): string {
+  const itemWord = newItemCount === 1 ? "item" : "items";
+  if (firstSummary) {
+    return `${newItemCount} new ${itemWord} in ${inboxId} from ${firstSummary}`;
+  }
+  return `${newItemCount} new ${itemWord} in ${inboxId}`;
 }
 
 function summarizeSourceEvent(sourceType: string, sourceKey: string, eventVariant: string): string {

--- a/src/store.ts
+++ b/src/store.ts
@@ -73,11 +73,18 @@ export class AgentInboxStore {
 
   private migrate(): void {
     const userVersion = this.userVersion();
-    if (userVersion !== SCHEMA_VERSION) {
+    if (userVersion === 0) {
       this.dropKnownTables();
       this.createCurrentSchema();
       this.setUserVersion(SCHEMA_VERSION);
+      return;
     }
+    if (userVersion !== SCHEMA_VERSION) {
+      throw new Error(
+        `unsupported database schema version ${userVersion}; delete ${this.dbPath} to recreate`,
+      );
+    }
+    this.createCurrentSchema();
   }
 
   private dropKnownTables(): void {
@@ -1189,12 +1196,16 @@ export class AgentInboxStore {
 
   private mapActivationTarget(row: Record<string, unknown>): ActivationTarget {
     if (String(row.kind) === "webhook") {
+      const url = typeof row.url === "string" && row.url.trim().length > 0 ? row.url.trim() : null;
+      if (!url) {
+        throw new Error(`invalid webhook activation target: ${String(row.target_id)}`);
+      }
       return {
         targetId: String(row.target_id),
         agentId: String(row.agent_id),
         kind: "webhook",
         mode: row.mode as WebhookActivationTarget["mode"],
-        url: String(row.url),
+        url,
         notifyLeaseMs: Number(row.notify_lease_ms),
         createdAt: String(row.created_at),
         updatedAt: String(row.updated_at),

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,22 +9,26 @@ import type {
 } from "./backend";
 import {
   Activation,
-  ActivationItem,
+  ActivationDispatchState,
+  ActivationTarget,
+  AddWebhookActivationTargetInput,
+  Agent,
   AppendSourceEventInput,
   AppendSourceEventResult,
   DeliveryAttempt,
   Inbox,
   InboxItem,
   ListInboxItemsOptions,
+  RegisterAgentInput,
   Subscription,
   SubscriptionSource,
   SubscriptionStartPolicy,
-  TerminalDispatchState,
-  TerminalTarget,
+  TerminalActivationTarget,
+  WebhookActivationTarget,
 } from "./model";
 import { generateId, nowIso } from "./util";
 
-const SCHEMA_VERSION = 7;
+const SCHEMA_VERSION = 8;
 type SqlBindParams = unknown[];
 
 function parseJson<T>(value: string | null): T {
@@ -69,249 +73,42 @@ export class AgentInboxStore {
 
   private migrate(): void {
     const userVersion = this.userVersion();
-    if (userVersion >= SCHEMA_VERSION) {
+    if (userVersion !== SCHEMA_VERSION) {
+      this.dropKnownTables();
       this.createCurrentSchema();
-      return;
+      this.setUserVersion(SCHEMA_VERSION);
     }
+  }
 
-    if (userVersion < 1) {
-      if (this.hasLegacySchema()) {
-        this.migrateLegacySchema();
-      } else {
-        this.createCurrentSchema();
+  private dropKnownTables(): void {
+    const tables = [
+      "consumer_commits",
+      "consumers",
+      "stream_events",
+      "streams",
+      "deliveries",
+      "activations",
+      "inbox_items",
+      "activation_dispatch_states",
+      "activation_targets",
+      "subscriptions",
+      "inboxes",
+      "agents",
+      "sources",
+      "terminal_dispatch_states",
+      "terminal_targets",
+      "interests",
+    ];
+    this.inTransaction(() => {
+      for (const table of tables) {
+        if (this.tableExists(table)) {
+          this.db.exec(`drop table ${table};`);
+        }
       }
-      this.setUserVersion(1);
-    }
-
-    if (userVersion < 2 && this.needsActivationSchemaUpgrade()) {
-      this.upgradeActivationSchema();
-    }
-
-    if (userVersion < 3 && this.needsSubscriptionActivationModeUpgrade()) {
-      this.upgradeSubscriptionActivationModeSchema();
-    }
-
-    if (userVersion < 4 && this.needsActivationItemsUpgrade()) {
-      this.upgradeActivationItemsSchema();
-    }
-
-    if (userVersion < 5 && this.needsSubscriptionTerminalTargetUpgrade()) {
-      this.upgradeSubscriptionTerminalTargetSchema();
-    }
-
-    if (userVersion < 6) {
-      this.createTerminalSchema();
-    }
-
-    if (userVersion < 7 && this.needsTerminalRuntimeUpgrade()) {
-      this.upgradeTerminalRuntimeSchema();
-    }
-
-    this.createCurrentIndexes();
-    this.setUserVersion(SCHEMA_VERSION);
-  }
-
-  private hasLegacySchema(): boolean {
-    return this.tableExists("interests")
-      || this.columnExists("inbox_items", "mailbox_id")
-      || this.columnExists("activations", "mailbox_id");
-  }
-
-  private migrateLegacySchema(): void {
-    this.inTransaction(() => {
-      this.createCurrentSchemaBase();
-
-      this.db.exec(`
-        create table if not exists inbox_items_v2 (
-          item_id text primary key,
-          source_id text not null,
-          source_native_id text not null,
-          event_variant text not null,
-          inbox_id text not null,
-          occurred_at text not null,
-          metadata_json text not null,
-          raw_payload_json text not null,
-          delivery_handle_json text,
-          acked_at text,
-          unique(source_id, source_native_id, event_variant, inbox_id)
-        );
-
-        create table if not exists activations_v2 (
-          activation_id text primary key,
-          kind text not null,
-          agent_id text not null,
-          inbox_id text not null,
-          subscription_ids_json text not null,
-          source_ids_json text not null,
-          new_item_count integer not null,
-          summary text not null,
-          items_json text,
-          created_at text not null,
-          delivered_at text
-        );
-      `);
-
-      this.db.exec(`
-        insert or ignore into inboxes (inbox_id, owner_agent_id, created_at)
-        select mailbox_id, min(agent_id), min(created_at)
-        from interests
-        group by mailbox_id;
-
-        insert or ignore into subscriptions (
-          subscription_id, agent_id, source_id, inbox_id, match_rules_json,
-          activation_target, activation_mode, start_policy, start_offset, start_time, created_at
-        )
-        select
-          interest_id, agent_id, source_id, mailbox_id, match_rules_json,
-          activation_target, 'activation_only', 'latest', null, null, created_at
-        from interests;
-
-        insert or ignore into inbox_items_v2 (
-          item_id, source_id, source_native_id, event_variant, inbox_id, occurred_at,
-          metadata_json, raw_payload_json, delivery_handle_json, acked_at
-        )
-        select
-          item_id, source_id, source_native_id, event_variant, mailbox_id, occurred_at,
-          metadata_json, raw_payload_json, delivery_handle_json, acked_at
-        from inbox_items;
-
-        insert or ignore into activations_v2 (
-          activation_id, kind, agent_id, inbox_id, subscription_ids_json, source_ids_json, new_item_count, summary, items_json, created_at, delivered_at
-        )
-        select
-          activation_id, 'agentinbox.activation', agent_id, mailbox_id, '[]', '[]', new_item_count, summary, null, created_at, delivered_at
-        from activations;
-
-        insert or ignore into streams (stream_id, source_id, stream_key, backend, created_at)
-        select
-          'stream_' || source_id,
-          source_id,
-          source_type || ':' || source_key,
-          'sqlite',
-          created_at
-        from sources;
-
-        insert or ignore into consumers (
-          consumer_id, stream_id, subscription_id, consumer_key, start_policy,
-          start_offset, start_time, next_offset, created_at, updated_at
-        )
-        select
-          'consumer_' || subscription_id,
-          'stream_' || source_id,
-          subscription_id,
-          'subscription:' || subscription_id,
-          'latest',
-          null,
-          null,
-          1,
-          created_at,
-          created_at
-        from subscriptions;
-      `);
-
-      if (this.tableExists("interests")) {
-        this.db.exec("drop table interests;");
-      }
-      if (this.tableExists("inbox_items")) {
-        this.db.exec("drop table inbox_items;");
-      }
-      if (this.tableExists("activations")) {
-        this.db.exec("drop table activations;");
-      }
-
-      this.db.exec(`
-        alter table inbox_items_v2 rename to inbox_items;
-        alter table activations_v2 rename to activations;
-      `);
-
-      this.createCurrentIndexes();
-    });
-  }
-
-  private needsActivationSchemaUpgrade(): boolean {
-    return !this.columnExists("activations", "kind")
-      || !this.columnExists("activations", "subscription_ids_json")
-      || !this.columnExists("activations", "source_ids_json");
-  }
-
-  private needsSubscriptionActivationModeUpgrade(): boolean {
-    return !this.columnExists("subscriptions", "activation_mode");
-  }
-
-  private needsActivationItemsUpgrade(): boolean {
-    return !this.columnExists("activations", "items_json");
-  }
-
-  private needsSubscriptionTerminalTargetUpgrade(): boolean {
-    return !this.columnExists("subscriptions", "terminal_target_id");
-  }
-
-  private upgradeActivationSchema(): void {
-    this.inTransaction(() => {
-      this.db.exec(`
-        create table if not exists activations_v3 (
-          activation_id text primary key,
-          kind text not null,
-          agent_id text not null,
-          inbox_id text not null,
-          subscription_ids_json text not null,
-          source_ids_json text not null,
-          new_item_count integer not null,
-          summary text not null,
-          items_json text,
-          created_at text not null,
-          delivered_at text
-        );
-      `);
-
-      this.db.exec(`
-        insert or ignore into activations_v3 (
-          activation_id, kind, agent_id, inbox_id, subscription_ids_json, source_ids_json, new_item_count, summary, items_json, created_at, delivered_at
-        )
-        select
-          activation_id,
-          'agentinbox.activation',
-          agent_id,
-          inbox_id,
-          '[]',
-          '[]',
-          new_item_count,
-          summary,
-          null,
-          created_at,
-          delivered_at
-        from activations;
-      `);
-
-      this.db.exec("drop table activations;");
-      this.db.exec("alter table activations_v3 rename to activations;");
-    });
-  }
-
-  private upgradeSubscriptionActivationModeSchema(): void {
-    this.inTransaction(() => {
-      this.db.exec("alter table subscriptions add column activation_mode text not null default 'activation_only';");
-    });
-  }
-
-  private upgradeActivationItemsSchema(): void {
-    this.inTransaction(() => {
-      this.db.exec("alter table activations add column items_json text;");
-    });
-  }
-
-  private upgradeSubscriptionTerminalTargetSchema(): void {
-    this.inTransaction(() => {
-      this.db.exec("alter table subscriptions add column terminal_target_id text;");
     });
   }
 
   private createCurrentSchema(): void {
-    this.createCurrentSchemaBase();
-    this.createCurrentIndexes();
-  }
-
-  private createCurrentSchemaBase(): void {
     this.db.exec(`
       create table if not exists sources (
         source_id text primary key,
@@ -326,9 +123,18 @@ export class AgentInboxStore {
         unique(source_type, source_key)
       );
 
+      create table if not exists agents (
+        agent_id text primary key,
+        runtime_kind text not null,
+        runtime_session_id text,
+        created_at text not null,
+        updated_at text not null,
+        last_seen_at text not null
+      );
+
       create table if not exists inboxes (
         inbox_id text primary key,
-        owner_agent_id text not null,
+        owner_agent_id text not null unique,
         created_at text not null
       );
 
@@ -336,15 +142,43 @@ export class AgentInboxStore {
         subscription_id text primary key,
         agent_id text not null,
         source_id text not null,
-        inbox_id text not null,
         match_rules_json text not null,
-        activation_target text,
-        terminal_target_id text,
-        activation_mode text not null,
         start_policy text not null,
         start_offset integer,
         start_time text,
         created_at text not null
+      );
+
+      create table if not exists activation_targets (
+        target_id text primary key,
+        agent_id text not null,
+        kind text not null,
+        mode text not null,
+        notify_lease_ms integer not null,
+        url text,
+        runtime_kind text,
+        runtime_session_id text,
+        backend text,
+        tmux_pane_id text,
+        tty text,
+        term_program text,
+        iterm_session_id text,
+        created_at text not null,
+        updated_at text not null,
+        last_seen_at text not null
+      );
+
+      create table if not exists activation_dispatch_states (
+        agent_id text not null,
+        target_id text not null,
+        status text not null,
+        lease_expires_at text,
+        pending_new_item_count integer not null,
+        pending_summary text,
+        pending_subscription_ids_json text not null,
+        pending_source_ids_json text not null,
+        updated_at text not null,
+        primary key (agent_id, target_id)
       );
 
       create table if not exists inbox_items (
@@ -366,6 +200,8 @@ export class AgentInboxStore {
         kind text not null,
         agent_id text not null,
         inbox_id text not null,
+        target_id text not null,
+        target_kind text not null,
         subscription_ids_json text not null,
         source_ids_json text not null,
         new_item_count integer not null,
@@ -431,62 +267,22 @@ export class AgentInboxStore {
         committed_offset integer not null,
         committed_at text not null
       );
-    `);
-    this.createTerminalSchema();
-  }
 
-  private createTerminalSchema(): void {
-    this.db.exec(`
-      create table if not exists terminal_targets (
-        target_id text primary key,
-        agent_id text not null,
-        runtime_kind text not null default 'unknown',
-        runtime_session_id text,
-        backend text not null,
-        mode text not null,
-        tmux_pane_id text,
-        tty text,
-        term_program text,
-        iterm_session_id text,
-        notify_lease_ms integer not null,
-        created_at text not null,
-        updated_at text not null,
-        last_seen_at text not null
-      );
+      create unique index if not exists idx_activation_targets_terminal_tmux
+        on activation_targets(tmux_pane_id)
+        where kind = 'terminal' and tmux_pane_id is not null;
 
-      create table if not exists terminal_dispatch_states (
-        inbox_id text not null,
-        target_id text not null,
-        status text not null,
-        lease_expires_at text,
-        pending_new_item_count integer not null,
-        pending_summary text,
-        pending_subscription_ids_json text not null,
-        pending_source_ids_json text not null,
-        updated_at text not null,
-        primary key (inbox_id, target_id)
-      );
-    `);
-  }
+      create unique index if not exists idx_activation_targets_terminal_iterm
+        on activation_targets(iterm_session_id)
+        where kind = 'terminal' and iterm_session_id is not null;
 
-  private needsTerminalRuntimeUpgrade(): boolean {
-    return !this.columnExists("terminal_targets", "runtime_kind")
-      || !this.columnExists("terminal_targets", "runtime_session_id");
-  }
+      create unique index if not exists idx_activation_targets_runtime_session
+        on activation_targets(runtime_kind, runtime_session_id)
+        where kind = 'terminal' and runtime_session_id is not null;
 
-  private upgradeTerminalRuntimeSchema(): void {
-    this.inTransaction(() => {
-      if (!this.columnExists("terminal_targets", "runtime_kind")) {
-        this.db.exec("alter table terminal_targets add column runtime_kind text not null default 'unknown';");
-      }
-      if (!this.columnExists("terminal_targets", "runtime_session_id")) {
-        this.db.exec("alter table terminal_targets add column runtime_session_id text;");
-      }
-    });
-  }
+      create index if not exists idx_activation_dispatch_states_target
+        on activation_dispatch_states(target_id, lease_expires_at);
 
-  private createCurrentIndexes(): void {
-    this.db.exec(`
       create index if not exists idx_stream_events_stream_offset
         on stream_events(stream_id, offset);
 
@@ -498,21 +294,6 @@ export class AgentInboxStore {
 
       create index if not exists idx_consumer_commits_consumer
         on consumer_commits(consumer_id, committed_offset);
-
-      create unique index if not exists idx_terminal_targets_tmux_pane
-        on terminal_targets(tmux_pane_id)
-        where tmux_pane_id is not null;
-
-      create unique index if not exists idx_terminal_targets_iterm_session
-        on terminal_targets(iterm_session_id)
-        where iterm_session_id is not null;
-
-      create unique index if not exists idx_terminal_targets_runtime_session
-        on terminal_targets(runtime_kind, runtime_session_id)
-        where runtime_session_id is not null;
-
-      create index if not exists idx_terminal_dispatch_states_target
-        on terminal_dispatch_states(target_id, lease_expires_at);
     `);
   }
 
@@ -550,14 +331,6 @@ export class AgentInboxStore {
       [name],
     );
     return Boolean(row);
-  }
-
-  private columnExists(tableName: string, columnName: string): boolean {
-    if (!this.tableExists(tableName)) {
-      return false;
-    }
-    const rows = this.getAll(`pragma table_info(${tableName});`);
-    return rows.some((row) => String(row.name) === columnName);
   }
 
   getSourceByKey(sourceType: string, sourceKey: string): SubscriptionSource | null {
@@ -625,17 +398,72 @@ export class AgentInboxStore {
     this.persist();
   }
 
+  getAgent(agentId: string): Agent | null {
+    const row = this.getOne("select * from agents where agent_id = ?", [agentId]);
+    return row ? this.mapAgent(row) : null;
+  }
+
+  insertAgent(agent: Agent): void {
+    this.db.run(
+      `
+      insert into agents (
+        agent_id, runtime_kind, runtime_session_id, created_at, updated_at, last_seen_at
+      ) values (?, ?, ?, ?, ?, ?)
+    `,
+      [
+        agent.agentId,
+        agent.runtimeKind,
+        agent.runtimeSessionId ?? null,
+        agent.createdAt,
+        agent.updatedAt,
+        agent.lastSeenAt,
+      ],
+    );
+    this.persist();
+  }
+
+  updateAgent(agentId: string, input: {
+    runtimeKind: Agent["runtimeKind"];
+    runtimeSessionId?: string | null;
+    updatedAt: string;
+    lastSeenAt: string;
+  }): Agent {
+    this.db.run(
+      `
+      update agents
+      set runtime_kind = ?, runtime_session_id = ?, updated_at = ?, last_seen_at = ?
+      where agent_id = ?
+    `,
+      [
+        input.runtimeKind,
+        input.runtimeSessionId ?? null,
+        input.updatedAt,
+        input.lastSeenAt,
+        agentId,
+      ],
+    );
+    this.persist();
+    return this.getAgent(agentId)!;
+  }
+
+  listAgents(): Agent[] {
+    const rows = this.getAll("select * from agents order by created_at asc");
+    return rows.map((row) => this.mapAgent(row));
+  }
+
   getInbox(inboxId: string): Inbox | null {
     const row = this.getOne("select * from inboxes where inbox_id = ?", [inboxId]);
     return row ? this.mapInbox(row) : null;
   }
 
+  getInboxByAgentId(agentId: string): Inbox | null {
+    const row = this.getOne("select * from inboxes where owner_agent_id = ?", [agentId]);
+    return row ? this.mapInbox(row) : null;
+  }
+
   insertInbox(inbox: Inbox): void {
     this.db.run(
-      `
-      insert into inboxes (inbox_id, owner_agent_id, created_at)
-      values (?, ?, ?)
-    `,
+      "insert into inboxes (inbox_id, owner_agent_id, created_at) values (?, ?, ?)",
       [inbox.inboxId, inbox.ownerAgentId, inbox.createdAt],
     );
     this.persist();
@@ -655,19 +483,14 @@ export class AgentInboxStore {
     this.db.run(
       `
       insert into subscriptions (
-        subscription_id, agent_id, source_id, inbox_id, match_rules_json,
-        activation_target, terminal_target_id, activation_mode, start_policy, start_offset, start_time, created_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        subscription_id, agent_id, source_id, match_rules_json, start_policy, start_offset, start_time, created_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         subscription.subscriptionId,
         subscription.agentId,
         subscription.sourceId,
-        subscription.inboxId,
         JSON.stringify(subscription.matchRules),
-        subscription.activationTarget ?? null,
-        subscription.terminalTargetId ?? null,
-        subscription.activationMode,
         subscription.startPolicy,
         subscription.startOffset ?? null,
         subscription.startTime ?? null,
@@ -690,135 +513,195 @@ export class AgentInboxStore {
     return rows.map((row) => this.mapSubscription(row));
   }
 
-  getTerminalTarget(targetId: string): TerminalTarget | null {
-    const row = this.getOne("select * from terminal_targets where target_id = ?", [targetId]);
-    return row ? this.mapTerminalTarget(row) : null;
+  listSubscriptionsForAgent(agentId: string): Subscription[] {
+    const rows = this.getAll(
+      "select * from subscriptions where agent_id = ? order by created_at asc",
+      [agentId],
+    );
+    return rows.map((row) => this.mapSubscription(row));
   }
 
-  getTerminalTargetByTmuxPaneId(tmuxPaneId: string): TerminalTarget | null {
-    const row = this.getOne("select * from terminal_targets where tmux_pane_id = ?", [tmuxPaneId]);
-    return row ? this.mapTerminalTarget(row) : null;
+  getActivationTarget(targetId: string): ActivationTarget | null {
+    const row = this.getOne("select * from activation_targets where target_id = ?", [targetId]);
+    return row ? this.mapActivationTarget(row) : null;
   }
 
-  getTerminalTargetByItermSessionId(itermSessionId: string): TerminalTarget | null {
-    const row = this.getOne("select * from terminal_targets where iterm_session_id = ?", [itermSessionId]);
-    return row ? this.mapTerminalTarget(row) : null;
-  }
-
-  getTerminalTargetByTty(tty: string): TerminalTarget | null {
-    const row = this.getOne("select * from terminal_targets where tty = ?", [tty]);
-    return row ? this.mapTerminalTarget(row) : null;
-  }
-
-  getTerminalTargetByRuntimeSession(runtimeKind: string, runtimeSessionId: string): TerminalTarget | null {
+  getTerminalActivationTargetByTmuxPaneId(tmuxPaneId: string): TerminalActivationTarget | null {
     const row = this.getOne(
-      "select * from terminal_targets where runtime_kind = ? and runtime_session_id = ?",
+      "select * from activation_targets where kind = 'terminal' and tmux_pane_id = ?",
+      [tmuxPaneId],
+    );
+    const target = row ? this.mapActivationTarget(row) : null;
+    return target?.kind === "terminal" ? target : null;
+  }
+
+  getTerminalActivationTargetByItermSessionId(itermSessionId: string): TerminalActivationTarget | null {
+    const row = this.getOne(
+      "select * from activation_targets where kind = 'terminal' and iterm_session_id = ?",
+      [itermSessionId],
+    );
+    const target = row ? this.mapActivationTarget(row) : null;
+    return target?.kind === "terminal" ? target : null;
+  }
+
+  getTerminalActivationTargetByTty(tty: string): TerminalActivationTarget | null {
+    const row = this.getOne(
+      "select * from activation_targets where kind = 'terminal' and tty = ?",
+      [tty],
+    );
+    const target = row ? this.mapActivationTarget(row) : null;
+    return target?.kind === "terminal" ? target : null;
+  }
+
+  getTerminalActivationTargetByRuntimeSession(runtimeKind: string, runtimeSessionId: string): TerminalActivationTarget | null {
+    const row = this.getOne(
+      "select * from activation_targets where kind = 'terminal' and runtime_kind = ? and runtime_session_id = ?",
       [runtimeKind, runtimeSessionId],
     );
-    return row ? this.mapTerminalTarget(row) : null;
+    const target = row ? this.mapActivationTarget(row) : null;
+    return target?.kind === "terminal" ? target : null;
   }
 
-  insertTerminalTarget(target: TerminalTarget): void {
-    this.db.run(
-      `
-      insert into terminal_targets (
-        target_id, agent_id, runtime_kind, runtime_session_id, backend, mode, tmux_pane_id, tty, term_program, iterm_session_id,
-        notify_lease_ms, created_at, updated_at, last_seen_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `,
-      [
-        target.targetId,
-        target.agentId,
-        target.runtimeKind,
-        target.runtimeSessionId ?? null,
-        target.backend,
-        target.mode,
-        target.tmuxPaneId ?? null,
-        target.tty ?? null,
-        target.termProgram ?? null,
-        target.itermSessionId ?? null,
-        target.notifyLeaseMs,
-        target.createdAt,
-        target.updatedAt,
-        target.lastSeenAt,
-      ],
-    );
+  insertActivationTarget(target: ActivationTarget): void {
+    if (target.kind === "webhook") {
+      this.db.run(
+        `
+        insert into activation_targets (
+          target_id, agent_id, kind, mode, notify_lease_ms, url, created_at, updated_at, last_seen_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+        [
+          target.targetId,
+          target.agentId,
+          target.kind,
+          target.mode,
+          target.notifyLeaseMs,
+          target.url,
+          target.createdAt,
+          target.updatedAt,
+          target.lastSeenAt,
+        ],
+      );
+    } else {
+      this.db.run(
+        `
+        insert into activation_targets (
+          target_id, agent_id, kind, mode, notify_lease_ms,
+          runtime_kind, runtime_session_id, backend, tmux_pane_id, tty, term_program, iterm_session_id,
+          created_at, updated_at, last_seen_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+        [
+          target.targetId,
+          target.agentId,
+          target.kind,
+          target.mode,
+          target.notifyLeaseMs,
+          target.runtimeKind,
+          target.runtimeSessionId ?? null,
+          target.backend,
+          target.tmuxPaneId ?? null,
+          target.tty ?? null,
+          target.termProgram ?? null,
+          target.itermSessionId ?? null,
+          target.createdAt,
+          target.updatedAt,
+          target.lastSeenAt,
+        ],
+      );
+    }
     this.persist();
   }
 
-  updateTerminalTargetHeartbeat(
+  updateTerminalActivationTargetHeartbeat(
     targetId: string,
     input: {
-      updatedAt: string;
-      lastSeenAt: string;
-      runtimeKind?: TerminalTarget["runtimeKind"];
+      runtimeKind: TerminalActivationTarget["runtimeKind"];
       runtimeSessionId?: string | null;
+      tmuxPaneId?: string | null;
       tty?: string | null;
       termProgram?: string | null;
       itermSessionId?: string | null;
-      tmuxPaneId?: string | null;
+      updatedAt: string;
+      lastSeenAt: string;
     },
-  ): TerminalTarget {
-    const target = this.getTerminalTarget(targetId);
-    if (!target) {
-      throw new Error(`unknown terminal target: ${targetId}`);
-    }
+  ): TerminalActivationTarget {
     this.db.run(
       `
-      update terminal_targets
+      update activation_targets
       set runtime_kind = ?, runtime_session_id = ?, tmux_pane_id = ?, tty = ?, term_program = ?, iterm_session_id = ?, updated_at = ?, last_seen_at = ?
-      where target_id = ?
+      where target_id = ? and kind = 'terminal'
     `,
       [
-        input.runtimeKind ?? target.runtimeKind,
-        input.runtimeSessionId ?? target.runtimeSessionId ?? null,
-        input.tmuxPaneId ?? target.tmuxPaneId ?? null,
-        input.tty ?? target.tty ?? null,
-        input.termProgram ?? target.termProgram ?? null,
-        input.itermSessionId ?? target.itermSessionId ?? null,
+        input.runtimeKind,
+        input.runtimeSessionId ?? null,
+        input.tmuxPaneId ?? null,
+        input.tty ?? null,
+        input.termProgram ?? null,
+        input.itermSessionId ?? null,
         input.updatedAt,
         input.lastSeenAt,
         targetId,
       ],
     );
     this.persist();
-    return this.getTerminalTarget(targetId)!;
+    const target = this.getActivationTarget(targetId);
+    if (!target || target.kind !== "terminal") {
+      throw new Error(`unknown terminal activation target: ${targetId}`);
+    }
+    return target;
   }
 
-  listTerminalTargets(): TerminalTarget[] {
-    const rows = this.getAll("select * from terminal_targets order by created_at asc");
-    return rows.map((row) => this.mapTerminalTarget(row));
+  listActivationTargets(): ActivationTarget[] {
+    const rows = this.getAll("select * from activation_targets order by created_at asc");
+    return rows.map((row) => this.mapActivationTarget(row));
   }
 
-  getTerminalDispatchState(inboxId: string, targetId: string): TerminalDispatchState | null {
-    const row = this.getOne(
-      "select * from terminal_dispatch_states where inbox_id = ? and target_id = ?",
-      [inboxId, targetId],
-    );
-    return row ? this.mapTerminalDispatchState(row) : null;
-  }
-
-  listTerminalDispatchStates(): TerminalDispatchState[] {
-    const rows = this.getAll("select * from terminal_dispatch_states order by updated_at asc");
-    return rows.map((row) => this.mapTerminalDispatchState(row));
-  }
-
-  listTerminalDispatchStatesForInbox(inboxId: string): TerminalDispatchState[] {
+  listActivationTargetsForAgent(agentId: string): ActivationTarget[] {
     const rows = this.getAll(
-      "select * from terminal_dispatch_states where inbox_id = ? order by updated_at asc",
-      [inboxId],
+      "select * from activation_targets where agent_id = ? order by created_at asc",
+      [agentId],
     );
-    return rows.map((row) => this.mapTerminalDispatchState(row));
+    return rows.map((row) => this.mapActivationTarget(row));
   }
 
-  upsertTerminalDispatchState(state: TerminalDispatchState): void {
+  deleteActivationTarget(agentId: string, targetId: string): void {
+    this.inTransaction(() => {
+      this.db.run("delete from activation_dispatch_states where agent_id = ? and target_id = ?", [agentId, targetId]);
+      this.db.run("delete from activation_targets where agent_id = ? and target_id = ?", [agentId, targetId]);
+    });
+    this.persist();
+  }
+
+  getActivationDispatchState(agentId: string, targetId: string): ActivationDispatchState | null {
+    const row = this.getOne(
+      "select * from activation_dispatch_states where agent_id = ? and target_id = ?",
+      [agentId, targetId],
+    );
+    return row ? this.mapActivationDispatchState(row) : null;
+  }
+
+  listActivationDispatchStates(): ActivationDispatchState[] {
+    const rows = this.getAll("select * from activation_dispatch_states order by updated_at asc");
+    return rows.map((row) => this.mapActivationDispatchState(row));
+  }
+
+  listActivationDispatchStatesForAgent(agentId: string): ActivationDispatchState[] {
+    const rows = this.getAll(
+      "select * from activation_dispatch_states where agent_id = ? order by updated_at asc",
+      [agentId],
+    );
+    return rows.map((row) => this.mapActivationDispatchState(row));
+  }
+
+  upsertActivationDispatchState(state: ActivationDispatchState): void {
     this.db.run(
       `
-      insert into terminal_dispatch_states (
-        inbox_id, target_id, status, lease_expires_at, pending_new_item_count, pending_summary,
+      insert into activation_dispatch_states (
+        agent_id, target_id, status, lease_expires_at, pending_new_item_count, pending_summary,
         pending_subscription_ids_json, pending_source_ids_json, updated_at
       ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
-      on conflict(inbox_id, target_id) do update set
+      on conflict(agent_id, target_id) do update set
         status = excluded.status,
         lease_expires_at = excluded.lease_expires_at,
         pending_new_item_count = excluded.pending_new_item_count,
@@ -828,7 +711,7 @@ export class AgentInboxStore {
         updated_at = excluded.updated_at
     `,
       [
-        state.inboxId,
+        state.agentId,
         state.targetId,
         state.status,
         state.leaseExpiresAt ?? null,
@@ -842,10 +725,10 @@ export class AgentInboxStore {
     this.persist();
   }
 
-  deleteTerminalDispatchState(inboxId: string, targetId: string): void {
+  deleteActivationDispatchState(agentId: string, targetId: string): void {
     this.db.run(
-      "delete from terminal_dispatch_states where inbox_id = ? and target_id = ?",
-      [inboxId, targetId],
+      "delete from activation_dispatch_states where agent_id = ? and target_id = ?",
+      [agentId, targetId],
     );
     this.persist();
   }
@@ -910,7 +793,6 @@ export class AgentInboxStore {
   ackItems(inboxId: string, itemIds: string[], ackedAt: string): number {
     let changes = 0;
     for (const itemId of itemIds) {
-      const before = this.changes();
       this.db.run(
         `
         update inbox_items
@@ -919,8 +801,7 @@ export class AgentInboxStore {
       `,
         [ackedAt, inboxId, itemId],
       );
-      const after = this.changes();
-      changes += after - before;
+      changes += this.changes();
     }
     if (changes > 0) {
       this.persist();
@@ -945,14 +826,17 @@ export class AgentInboxStore {
     this.db.run(
       `
       insert into activations (
-        activation_id, kind, agent_id, inbox_id, subscription_ids_json, source_ids_json, new_item_count, summary, items_json, created_at, delivered_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        activation_id, kind, agent_id, inbox_id, target_id, target_kind,
+        subscription_ids_json, source_ids_json, new_item_count, summary, items_json, created_at, delivered_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         activation.activationId,
         activation.kind,
         activation.agentId,
         activation.inboxId,
+        activation.targetId,
+        activation.targetKind,
         JSON.stringify(activation.subscriptionIds),
         JSON.stringify(activation.sourceIds),
         activation.newItemCount,
@@ -1001,10 +885,7 @@ export class AgentInboxStore {
 
   insertStream(stream: StreamRecord): void {
     this.db.run(
-      `
-      insert into streams (stream_id, source_id, stream_key, backend, created_at)
-      values (?, ?, ?, ?, ?)
-    `,
+      "insert into streams (stream_id, source_id, stream_key, backend, created_at) values (?, ?, ?, ?, ?)",
       [stream.streamId, stream.sourceId, stream.streamKey, stream.backend, stream.createdAt],
     );
     this.persist();
@@ -1025,10 +906,7 @@ export class AgentInboxStore {
     return row ? this.mapStream(row) : null;
   }
 
-  insertStreamEvent(
-    streamId: string,
-    event: AppendSourceEventInput,
-  ): AppendSourceEventResult {
+  insertStreamEvent(streamId: string, event: AppendSourceEventInput): AppendSourceEventResult {
     const before = this.changes();
     this.db.run(
       `
@@ -1087,9 +965,7 @@ export class AgentInboxStore {
     return {
       streamId,
       eventCount: Number(row?.event_count ?? 0),
-      highWatermarkOffset: row?.high_watermark_offset != null
-        ? Number(row.high_watermark_offset)
-        : null,
+      highWatermarkOffset: row?.high_watermark_offset != null ? Number(row.high_watermark_offset) : null,
     };
   }
 
@@ -1154,11 +1030,7 @@ export class AgentInboxStore {
     return rows.map((row) => this.mapConsumer(row));
   }
 
-  updateConsumerOffset(
-    consumerId: string,
-    nextOffset: number,
-    committedOffset: number,
-  ): ConsumerRecord {
+  updateConsumerOffset(consumerId: string, nextOffset: number, committedOffset: number): ConsumerRecord {
     const consumer = this.getConsumer(consumerId);
     if (!consumer) {
       throw new Error(`unknown consumer: ${consumerId}`);
@@ -1166,11 +1038,7 @@ export class AgentInboxStore {
     const updatedAt = nowIso();
     this.inTransaction(() => {
       this.db.run(
-        `
-        update consumers
-        set next_offset = ?, updated_at = ?
-        where consumer_id = ?
-      `,
+        "update consumers set next_offset = ?, updated_at = ? where consumer_id = ?",
         [nextOffset, updatedAt, consumerId],
       );
       this.db.run(
@@ -1217,16 +1085,17 @@ export class AgentInboxStore {
   getCounts(): Record<string, number> {
     return {
       sources: this.count("sources"),
+      agents: this.count("agents"),
       subscriptions: this.count("subscriptions"),
       inboxes: this.count("inboxes"),
+      activationTargets: this.count("activation_targets"),
+      activationDispatchStates: this.count("activation_dispatch_states"),
       streamEvents: this.count("stream_events"),
       consumers: this.count("consumers"),
       inboxItems: this.count("inbox_items"),
       pendingInboxItems: this.count("inbox_items where acked_at is null"),
       activations: this.count("activations"),
       deliveries: this.count("deliveries"),
-      terminalTargets: this.count("terminal_targets"),
-      terminalDispatchStates: this.count("terminal_dispatch_states"),
     };
   }
 
@@ -1286,6 +1155,17 @@ export class AgentInboxStore {
     };
   }
 
+  private mapAgent(row: Record<string, unknown>): Agent {
+    return {
+      agentId: String(row.agent_id),
+      runtimeKind: row.runtime_kind as Agent["runtimeKind"],
+      runtimeSessionId: row.runtime_session_id ? String(row.runtime_session_id) : null,
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
+      lastSeenAt: String(row.last_seen_at),
+    };
+  }
+
   private mapInbox(row: Record<string, unknown>): Inbox {
     return {
       inboxId: String(row.inbox_id),
@@ -1299,15 +1179,58 @@ export class AgentInboxStore {
       subscriptionId: String(row.subscription_id),
       agentId: String(row.agent_id),
       sourceId: String(row.source_id),
-      inboxId: String(row.inbox_id),
       matchRules: parseJson<Record<string, unknown>>(row.match_rules_json as string),
-      activationTarget: row.activation_target ? String(row.activation_target) : null,
-      terminalTargetId: row.terminal_target_id ? String(row.terminal_target_id) : null,
-      activationMode: (row.activation_mode ? String(row.activation_mode) : "activation_only") as Subscription["activationMode"],
       startPolicy: row.start_policy as SubscriptionStartPolicy,
       startOffset: row.start_offset != null ? Number(row.start_offset) : null,
       startTime: row.start_time ? String(row.start_time) : null,
       createdAt: String(row.created_at),
+    };
+  }
+
+  private mapActivationTarget(row: Record<string, unknown>): ActivationTarget {
+    if (String(row.kind) === "webhook") {
+      return {
+        targetId: String(row.target_id),
+        agentId: String(row.agent_id),
+        kind: "webhook",
+        mode: row.mode as WebhookActivationTarget["mode"],
+        url: String(row.url),
+        notifyLeaseMs: Number(row.notify_lease_ms),
+        createdAt: String(row.created_at),
+        updatedAt: String(row.updated_at),
+        lastSeenAt: String(row.last_seen_at),
+      };
+    }
+    return {
+      targetId: String(row.target_id),
+      agentId: String(row.agent_id),
+      kind: "terminal",
+      mode: row.mode as TerminalActivationTarget["mode"],
+      notifyLeaseMs: Number(row.notify_lease_ms),
+      runtimeKind: (row.runtime_kind ? String(row.runtime_kind) : "unknown") as TerminalActivationTarget["runtimeKind"],
+      runtimeSessionId: row.runtime_session_id ? String(row.runtime_session_id) : null,
+      backend: row.backend as TerminalActivationTarget["backend"],
+      tmuxPaneId: row.tmux_pane_id ? String(row.tmux_pane_id) : null,
+      tty: row.tty ? String(row.tty) : null,
+      termProgram: row.term_program ? String(row.term_program) : null,
+      itermSessionId: row.iterm_session_id ? String(row.iterm_session_id) : null,
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
+      lastSeenAt: String(row.last_seen_at),
+    };
+  }
+
+  private mapActivationDispatchState(row: Record<string, unknown>): ActivationDispatchState {
+    return {
+      agentId: String(row.agent_id),
+      targetId: String(row.target_id),
+      status: row.status as ActivationDispatchState["status"],
+      leaseExpiresAt: row.lease_expires_at ? String(row.lease_expires_at) : null,
+      pendingNewItemCount: Number(row.pending_new_item_count),
+      pendingSummary: row.pending_summary ? String(row.pending_summary) : null,
+      pendingSubscriptionIds: parseJson<string[]>(row.pending_subscription_ids_json as string),
+      pendingSourceIds: parseJson<string[]>(row.pending_source_ids_json as string),
+      updatedAt: String(row.updated_at),
     };
   }
 
@@ -1322,7 +1245,7 @@ export class AgentInboxStore {
       metadata: parseJson<Record<string, unknown>>(row.metadata_json as string),
       rawPayload: parseJson<Record<string, unknown>>(row.raw_payload_json as string),
       deliveryHandle: row.delivery_handle_json
-        ? parseJson(row.delivery_handle_json as string)
+        ? parseJson<InboxItem["deliveryHandle"]>(row.delivery_handle_json as string)
         : null,
       ackedAt: row.acked_at ? String(row.acked_at) : null,
     };
@@ -1334,11 +1257,13 @@ export class AgentInboxStore {
       activationId: String(row.activation_id),
       agentId: String(row.agent_id),
       inboxId: String(row.inbox_id),
+      targetId: String(row.target_id),
+      targetKind: row.target_kind as Activation["targetKind"],
       subscriptionIds: parseJson<string[]>(row.subscription_ids_json as string),
       sourceIds: parseJson<string[]>(row.source_ids_json as string),
       newItemCount: Number(row.new_item_count),
       summary: String(row.summary),
-      items: row.items_json ? parseJson<ActivationItem[]>(row.items_json as string) : undefined,
+      items: row.items_json ? parseJson<Activation["items"]>(row.items_json as string) : undefined,
       createdAt: String(row.created_at),
       deliveredAt: row.delivered_at ? String(row.delivered_at) : null,
     };
@@ -1356,39 +1281,6 @@ export class AgentInboxStore {
       payload: parseJson<Record<string, unknown>>(row.payload_json as string),
       status: row.status as DeliveryAttempt["status"],
       createdAt: String(row.created_at),
-    };
-  }
-
-  private mapTerminalTarget(row: Record<string, unknown>): TerminalTarget {
-    return {
-      targetId: String(row.target_id),
-      agentId: String(row.agent_id),
-      runtimeKind: row.runtime_kind ? String(row.runtime_kind) as TerminalTarget["runtimeKind"] : "unknown",
-      runtimeSessionId: row.runtime_session_id ? String(row.runtime_session_id) : null,
-      backend: row.backend as TerminalTarget["backend"],
-      mode: row.mode as TerminalTarget["mode"],
-      tmuxPaneId: row.tmux_pane_id ? String(row.tmux_pane_id) : null,
-      tty: row.tty ? String(row.tty) : null,
-      termProgram: row.term_program ? String(row.term_program) : null,
-      itermSessionId: row.iterm_session_id ? String(row.iterm_session_id) : null,
-      notifyLeaseMs: Number(row.notify_lease_ms),
-      createdAt: String(row.created_at),
-      updatedAt: String(row.updated_at),
-      lastSeenAt: String(row.last_seen_at),
-    };
-  }
-
-  private mapTerminalDispatchState(row: Record<string, unknown>): TerminalDispatchState {
-    return {
-      inboxId: String(row.inbox_id),
-      targetId: String(row.target_id),
-      status: row.status as TerminalDispatchState["status"],
-      leaseExpiresAt: row.lease_expires_at ? String(row.lease_expires_at) : null,
-      pendingNewItemCount: Number(row.pending_new_item_count),
-      pendingSummary: row.pending_summary ? String(row.pending_summary) : null,
-      pendingSubscriptionIds: parseJson<string[]>(row.pending_subscription_ids_json as string),
-      pendingSourceIds: parseJson<string[]>(row.pending_source_ids_json as string),
-      updatedAt: String(row.updated_at),
     };
   }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,7 +1,7 @@
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import crypto from "node:crypto";
-import { RuntimeKind, TerminalBackend, TerminalTarget } from "./model";
+import { RuntimeKind, TerminalActivationTarget, TerminalBackend } from "./model";
 
 const execFileAsync = promisify(execFile);
 type ExecFileAsyncLike = (
@@ -95,7 +95,7 @@ export class TerminalDispatcher {
     private readonly execAsync: ExecFileAsyncLike = execFileAsync,
   ) {}
 
-  async dispatch(target: TerminalTarget, prompt: string): Promise<void> {
+  async dispatch(target: TerminalActivationTarget, prompt: string): Promise<void> {
     if (target.backend === "tmux") {
       if (!target.tmuxPaneId) {
         throw new Error(`tmux terminal target ${target.targetId} is missing tmuxPaneId`);
@@ -200,7 +200,7 @@ function normalizeOptionalString(value: string | undefined | null): string | nul
 }
 
 async function dispatchToIterm2(
-  target: TerminalTarget,
+  target: TerminalActivationTarget,
   prompt: string,
   execAsync: ExecFileAsyncLike,
 ): Promise<void> {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -3,32 +3,30 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
-import initSqlJs from "sql.js";
-import { AgentInboxStore } from "../src/store";
-import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { AdapterRegistry } from "../src/adapters";
 import { SqliteEventBusBackend } from "../src/backend";
-import { Activation, InboxWatchEvent, SubscriptionSource, TerminalTarget } from "../src/model";
-import { nowIso } from "../src/util";
+import { Activation, ActivationTarget, AppendSourceEventInput, Subscription, TerminalActivationTarget } from "../src/model";
+import { ActivationDispatcher, AgentInboxService } from "../src/service";
+import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
 
 class RecordingActivationDispatcher extends ActivationDispatcher {
-  public readonly calls: Array<{ target: string | null | undefined; activation: Activation }> = [];
+  public readonly calls: Array<{ targetUrl: string; activation: Activation }> = [];
 
-  override async dispatch(target: string | null | undefined, activation: Activation): Promise<void> {
-    this.calls.push({ target, activation });
+  override async dispatch(targetUrl: string, activation: Activation): Promise<void> {
+    this.calls.push({ targetUrl, activation });
   }
 }
 
 class RecordingTerminalDispatcher extends TerminalDispatcher {
-  public readonly calls: Array<{ target: TerminalTarget; prompt: string }> = [];
+  public readonly calls: Array<{ target: TerminalActivationTarget; prompt: string }> = [];
 
-  override async dispatch(target: TerminalTarget, prompt: string): Promise<void> {
+  override async dispatch(target: TerminalActivationTarget, prompt: string): Promise<void> {
     this.calls.push({ target, prompt });
   }
 }
 
-async function makeAsyncService(options?: {
+async function makeService(options?: {
   dispatcher?: ActivationDispatcher;
   terminalDispatcher?: TerminalDispatcher;
   activationWindowMs?: number;
@@ -37,59 +35,108 @@ async function makeAsyncService(options?: {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-test-"));
   const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
   let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input));
   service = new AgentInboxService(
     store,
     adapters,
     options?.dispatcher,
-    undefined,
+    new SqliteEventBusBackend(store),
     {
       windowMs: options?.activationWindowMs,
       maxItems: options?.activationMaxItems,
     },
-    options?.terminalDispatcher,
+    options?.terminalDispatcher ?? new TerminalDispatcher(async () => ({
+      stdout: "",
+      stderr: "",
+    })),
   );
   return { store, service, dir };
 }
 
-test("shared source can route one stream event to multiple agent inboxes", async () => {
-  const { store, service, dir } = await makeAsyncService();
+async function registerTmuxAgent(service: AgentInboxService, suffix: string): Promise<{ agentId: string; targetId: string }> {
+  const registered = service.registerAgent({
+    backend: "tmux",
+    runtimeKind: "codex",
+    runtimeSessionId: `thread-${suffix}`,
+    tmuxPaneId: `%${suffix}`,
+    notifyLeaseMs: 50,
+  });
+  return {
+    agentId: registered.agent.agentId,
+    targetId: registered.terminalTarget.targetId,
+  };
+}
+
+test("agent register creates a stable agent, inbox, and terminal activation target", async () => {
+  const { store, service, dir } = await makeService();
   try {
+    const first = service.registerAgent({
+      backend: "iterm2",
+      runtimeKind: "codex",
+      runtimeSessionId: "019d57fd-6524-7e20-a850-a89e81957100",
+      itermSessionId: "4B4CB6B2-A73B-4420-94A7-BD2CA216A285",
+      termProgram: "iTerm.app",
+      tty: "/dev/ttys049",
+    });
+    const second = service.registerAgent({
+      backend: "iterm2",
+      runtimeKind: "codex",
+      runtimeSessionId: "019d57fd-6524-7e20-a850-a89e81957100",
+      itermSessionId: "4B4CB6B2-A73B-4420-94A7-BD2CA216A285",
+      termProgram: "iTerm.app",
+      tty: "/dev/ttys049",
+    });
+
+    assert.equal(first.agent.agentId, "agent_codex_019d57fd65247e20a850a89e81957100");
+    assert.equal(second.agent.agentId, first.agent.agentId);
+    assert.equal(second.terminalTarget.targetId, first.terminalTarget.targetId);
+    assert.equal(store.listAgents().length, 1);
+    assert.equal(store.listActivationTargetsForAgent(first.agent.agentId).length, 1);
+    const details = service.getInboxDetailsByAgent(first.agent.agentId) as { inbox: { ownerAgentId: string } };
+    assert.equal(details.inbox.ownerAgentId, first.agent.agentId);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("shared source can route one stream event to multiple agent inboxes", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "1");
+    const beta = await registerTmuxAgent(service, "2");
     const source = await service.registerSource({
       sourceType: "fixture",
       sourceKey: "demo",
       config: {},
     });
     const subscriptionA = await service.registerSubscription({
-      agentId: "alpha",
+      agentId: alpha.agentId,
       sourceId: source.sourceId,
       matchRules: { channel: "engineering" },
     });
     const subscriptionB = await service.registerSubscription({
-      agentId: "beta",
+      agentId: beta.agentId,
       sourceId: source.sourceId,
       matchRules: { channel: "engineering" },
     });
 
-    const appendResult = await service.appendSourceEvent({
+    await service.appendSourceEvent({
       sourceId: source.sourceId,
       sourceNativeId: "evt-1",
       eventVariant: "message.created",
       metadata: { channel: "engineering" },
       rawPayload: { text: "hello" },
     });
-    assert.equal(appendResult.appended, 1);
 
     const pollA = await service.pollSubscription(subscriptionA.subscriptionId);
     const pollB = await service.pollSubscription(subscriptionB.subscriptionId);
 
     assert.equal(pollA.inboxItemsCreated, 1);
     assert.equal(pollB.inboxItemsCreated, 1);
-    assert.equal(service.listInboxItems(subscriptionA.inboxId).length, 1);
-    assert.equal(service.listInboxItems(subscriptionB.inboxId).length, 1);
-    await service.stop();
-    assert.equal(store.listActivations().length, 2);
-    assert.equal(store.listSources().length, 1);
+    assert.equal(service.listInboxItems(alpha.agentId).length, 1);
+    assert.equal(service.listInboxItems(beta.agentId).length, 1);
   } finally {
     await service.stop();
     store.close();
@@ -98,15 +145,16 @@ test("shared source can route one stream event to multiple agent inboxes", async
 });
 
 test("custom source can act as a programmable event bus source", async () => {
-  const { store, service, dir } = await makeAsyncService();
+  const { store, service, dir } = await makeService();
   try {
+    const alpha = await registerTmuxAgent(service, "3");
     const source = await service.registerSource({
       sourceType: "custom",
       sourceKey: "project-alpha",
       config: {},
     });
     const subscription = await service.registerSubscription({
-      agentId: "alpha",
+      agentId: alpha.agentId,
       sourceId: source.sourceId,
       matchRules: { channel: "engineering" },
       startPolicy: "earliest",
@@ -121,9 +169,10 @@ test("custom source can act as a programmable event bus source", async () => {
     assert.equal(appendResult.appended, 1);
 
     const pollResult = await service.pollSubscription(subscription.subscriptionId);
+    const items = service.listInboxItems(alpha.agentId);
     assert.equal(pollResult.inboxItemsCreated, 1);
-    assert.equal(service.listInboxItems(subscription.inboxId).length, 1);
-    assert.equal(service.listInboxItems(subscription.inboxId)[0].sourceNativeId, "custom-evt-1");
+    assert.equal(items.length, 1);
+    assert.equal(items[0].sourceNativeId, "custom-evt-1");
   } finally {
     await service.stop();
     store.close();
@@ -132,25 +181,24 @@ test("custom source can act as a programmable event bus source", async () => {
 });
 
 test("watchInbox receives inserted items without auto-acking them", async () => {
-  const { store, service, dir } = await makeAsyncService();
+  const { store, service, dir } = await makeService();
   try {
+    const alpha = await registerTmuxAgent(service, "4");
     const source = await service.registerSource({
       sourceType: "fixture",
       sourceKey: "watch-demo",
       config: {},
     });
     const subscription = await service.registerSubscription({
-      agentId: "alpha",
+      agentId: alpha.agentId,
       sourceId: source.sourceId,
       startPolicy: "earliest",
     });
 
-    const seenEvents: InboxWatchEvent[] = [];
-    const session = service.watchInbox(subscription.inboxId, {}, (event) => {
-      seenEvents.push(event);
+    const seenEvents: string[] = [];
+    const session = service.watchInbox(alpha.agentId, {}, (event) => {
+      seenEvents.push(event.event);
     });
-
-    assert.equal(session.initialItems.length, 0);
     session.start();
 
     await service.appendSourceEvent({
@@ -160,12 +208,11 @@ test("watchInbox receives inserted items without auto-acking them", async () => 
       metadata: {},
       rawPayload: { text: "watch me" },
     });
-    const poll = await service.pollSubscription(subscription.subscriptionId);
-    assert.equal(poll.inboxItemsCreated, 1);
-    assert.equal(seenEvents.length, 1);
-    assert.equal(seenEvents[0].event, "items");
 
-    const items = service.listInboxItems(subscription.inboxId);
+    const poll = await service.pollSubscription(subscription.subscriptionId);
+    const items = service.listInboxItems(alpha.agentId);
+    assert.equal(poll.inboxItemsCreated, 1);
+    assert.deepEqual(seenEvents, ["items"]);
     assert.equal(items.length, 1);
     assert.equal(items[0].ackedAt, null);
 
@@ -177,645 +224,85 @@ test("watchInbox receives inserted items without auto-acking them", async () => 
   }
 });
 
-test("stream dedupe and consumer offsets prevent duplicate inbox inserts", async () => {
-  const { store, service, dir } = await makeAsyncService();
-  try {
-    const source = await service.registerSource({
-      sourceType: "fixture",
-      sourceKey: "demo",
-      config: {},
-    });
-    const subscription = await service.registerSubscription({
-      agentId: "alpha",
-      sourceId: source.sourceId,
-      matchRules: {},
-      startPolicy: "earliest",
-    });
-
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
-      sourceNativeId: "evt-1",
-      eventVariant: "message.created",
-      metadata: {},
-      rawPayload: {},
-    });
-    const second = await service.appendSourceEvent({
-      sourceId: source.sourceId,
-      sourceNativeId: "evt-1",
-      eventVariant: "message.created",
-      metadata: {},
-      rawPayload: {},
-    });
-    assert.equal(second.appended, 0);
-    assert.equal(second.deduped, 1);
-
-    const firstPoll = await service.pollSubscription(subscription.subscriptionId);
-    const secondPoll = await service.pollSubscription(subscription.subscriptionId);
-
-    assert.equal(firstPoll.inboxItemsCreated, 1);
-    assert.equal(secondPoll.inboxItemsCreated, 0);
-    assert.equal(service.listInboxItems(subscription.inboxId).length, 1);
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("sqlite event bus keeps independent offsets per subscription", async () => {
-  const { store, service, dir } = await makeAsyncService();
-  try {
-    const source = await service.registerSource({
-      sourceType: "fixture",
-      sourceKey: "demo",
-      config: {},
-    });
-    const early = await service.registerSubscription({
-      agentId: "alpha",
-      sourceId: source.sourceId,
-      startPolicy: "earliest",
-    });
-
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
-      sourceNativeId: "evt-1",
-      eventVariant: "message.created",
-      metadata: {},
-      rawPayload: {},
-    });
-
-    const latest = await service.registerSubscription({
-      agentId: "beta",
-      sourceId: source.sourceId,
-      startPolicy: "latest",
-    });
-
-    const pollEarly = await service.pollSubscription(early.subscriptionId);
-    const pollLatest = await service.pollSubscription(latest.subscriptionId);
-
-    assert.equal(pollEarly.inboxItemsCreated, 1);
-    assert.equal(pollLatest.inboxItemsCreated, 0);
-
-    const backend = new SqliteEventBusBackend(store);
-    const earlyLag = await backend.getConsumerLag({ subscriptionId: early.subscriptionId });
-    const latestLag = await backend.getConsumerLag({ subscriptionId: latest.subscriptionId });
-    assert.equal(earlyLag.pendingEvents, 0);
-    assert.equal(latestLag.pendingEvents, 0);
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("delivery requests are recorded with provider metadata", async () => {
-  const { store, service, dir } = await makeAsyncService();
-  try {
-    const result = await service.sendDelivery({
-      provider: "fixture",
-      surface: "chat",
-      targetRef: "room-1",
-      kind: "reply",
-      payload: { text: "hello" },
-    });
-    assert.equal(result.status, "accepted");
-    assert.equal(store.listDeliveries().length, 1);
-    assert.equal(store.listDeliveries()[0].targetRef, "room-1");
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("registerSubscription rejects unsupported activation modes", async () => {
-  const { store, service, dir } = await makeAsyncService();
-  try {
-    const source = await service.registerSource({
-      sourceType: "fixture",
-      sourceKey: "demo",
-      config: {},
-    });
-
-    await assert.rejects(
-      () => service.registerSubscription({
-        agentId: "alpha",
-        sourceId: source.sourceId,
-        activationMode: "push_everything" as never,
-      }),
-      /unsupported activation mode: push_everything/,
-    );
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("service can list relationships and reset subscription lag", async () => {
-  const { store, service, dir } = await makeAsyncService();
-  try {
-    const source = await service.registerSource({
-      sourceType: "custom",
-      sourceKey: "project-alpha",
-      config: {},
-    });
-    const inbox = service.ensureInboxByCaller("shared_alpha", "alpha");
-    const subscription = await service.registerSubscription({
-      agentId: "alpha",
-      sourceId: source.sourceId,
-      inboxId: inbox.inboxId,
-      matchRules: { channel: "engineering" },
-      startPolicy: "latest",
-    });
-
-    await service.appendSourceEventByCaller(source.sourceId, {
-      sourceNativeId: "evt-1",
-      eventVariant: "message.created",
-      metadata: { channel: "engineering" },
-      rawPayload: { text: "hello" },
-    });
-
-    const listed = service.listSubscriptions({ sourceId: source.sourceId, agentId: "alpha", inboxId: inbox.inboxId });
-    assert.equal(listed.length, 1);
-    assert.equal(listed[0].subscriptionId, subscription.subscriptionId);
-
-    const lagBefore = await service.getSubscriptionLag(subscription.subscriptionId) as { pendingEvents: number };
-    assert.equal(lagBefore.pendingEvents, 1);
-
-    const reset = await service.resetSubscription({
-      subscriptionId: subscription.subscriptionId,
-      startPolicy: "earliest",
-    });
-    assert.equal((reset.consumer as { nextOffset: number }).nextOffset, 1);
-
-    const lagAfter = await service.getSubscriptionLag(subscription.subscriptionId) as { pendingEvents: number };
-    assert.equal(lagAfter.pendingEvents, 1);
-
-    const inboxDetails = service.getInboxDetails(inbox.inboxId);
-    assert.equal((inboxDetails.itemCounts as { total: number }).total, 0);
-
-    const poll = await service.pollSubscription(subscription.subscriptionId);
-    assert.equal(poll.inboxItemsCreated, 1);
-
-    const shown = await service.getSubscriptionDetails(subscription.subscriptionId);
-    assert.equal((shown.source as SubscriptionSource).sourceId, source.sourceId);
-    assert.equal((shown.inbox as { inboxId: string }).inboxId, inbox.inboxId);
-
-    const acked = service.ackAllInboxItems(inbox.inboxId);
-    assert.equal(acked.acked, 1);
-    assert.equal(service.listInboxItems(inbox.inboxId, { includeAcked: false }).length, 0);
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("manual append is rejected for adapter-managed sources", async () => {
-  const { store, service, dir } = await makeAsyncService();
-  try {
-    const githubSource: SubscriptionSource = {
-      sourceId: "src_github_manual_append",
-      sourceType: "github_repo",
-      sourceKey: "holon-run/agentinbox",
-      configRef: null,
-      config: { owner: "holon-run", repo: "agentinbox" },
-      status: "active",
-      checkpoint: null,
-      createdAt: nowIso(),
-      updatedAt: nowIso(),
-    };
-    store.insertSource(githubSource);
-
-    await assert.rejects(
-      () => service.appendSourceEventByCaller(githubSource.sourceId, {
-        sourceNativeId: "evt-1",
-        eventVariant: "message.created",
-        metadata: {},
-        rawPayload: {},
-      }),
-      /manual append is not supported for source type: github_repo/,
-    );
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("legacy interest/mailbox schema migrates to subscriptions/inboxes", async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-migrate-test-"));
-  const dbPath = path.join(dir, "agentinbox.sqlite");
-  const SQL = await initSqlJs({
-    locateFile: (file: string) => require.resolve(`sql.js/dist/${file}`),
-  });
-  const legacy = new SQL.Database();
-  legacy.exec(`
-    create table sources (
-      source_id text primary key,
-      source_type text not null,
-      source_key text not null,
-      config_ref text,
-      config_json text not null,
-      status text not null,
-      checkpoint text,
-      created_at text not null,
-      updated_at text not null,
-      unique(source_type, source_key)
-    );
-    create table interests (
-      interest_id text primary key,
-      agent_id text not null,
-      source_id text not null,
-      mailbox_id text not null,
-      match_rules_json text not null,
-      activation_target text,
-      created_at text not null
-    );
-    create table inbox_items (
-      item_id text primary key,
-      source_id text not null,
-      source_native_id text not null,
-      event_variant text not null,
-      mailbox_id text not null,
-      occurred_at text not null,
-      metadata_json text not null,
-      raw_payload_json text not null,
-      delivery_handle_json text,
-      acked_at text,
-      unique(source_id, source_native_id, event_variant, mailbox_id)
-    );
-    create table activations (
-      activation_id text primary key,
-      agent_id text not null,
-      mailbox_id text not null,
-      new_item_count integer not null,
-      summary text not null,
-      created_at text not null,
-      delivered_at text
-    );
-    create table deliveries (
-      delivery_id text primary key,
-      provider text not null,
-      surface text not null,
-      target_ref text not null,
-      thread_ref text,
-      reply_mode text,
-      kind text not null,
-      payload_json text not null,
-      status text not null,
-      created_at text not null
-    );
-  `);
-  legacy.run(
-    `
-    insert into sources (
-      source_id, source_type, source_key, config_ref, config_json, status, checkpoint, created_at, updated_at
-    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `,
-    ["src_legacy", "fixture", "demo", null, "{}", "active", null, "2026-04-05T00:00:00.000Z", "2026-04-05T00:00:00.000Z"],
-  );
-  legacy.run(
-    `
-    insert into interests (
-      interest_id, agent_id, source_id, mailbox_id, match_rules_json, activation_target, created_at
-    ) values (?, ?, ?, ?, ?, ?, ?)
-  `,
-    ["int_legacy", "alpha", "src_legacy", "mbx_alpha", "{}", null, "2026-04-05T00:00:00.000Z"],
-  );
-  legacy.run(
-    `
-    insert into inbox_items (
-      item_id, source_id, source_native_id, event_variant, mailbox_id, occurred_at,
-      metadata_json, raw_payload_json, delivery_handle_json, acked_at
-    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `,
-    ["item_legacy", "src_legacy", "evt-1", "message.created", "mbx_alpha", "2026-04-05T00:00:00.000Z", "{}", "{}", null, null],
-  );
-  legacy.run(
-    `
-    insert into activations (
-      activation_id, agent_id, mailbox_id, new_item_count, summary, created_at, delivered_at
-    ) values (?, ?, ?, ?, ?, ?, ?)
-  `,
-    ["act_legacy", "alpha", "mbx_alpha", 1, "fixture:demo:message.created", "2026-04-05T00:00:00.000Z", null],
-  );
-  fs.writeFileSync(dbPath, Buffer.from(legacy.export()));
-  legacy.close();
-
-  const store = await AgentInboxStore.open(dbPath);
-  try {
-    const subscriptions = store.listSubscriptions();
-    const inboxes = store.listInboxes();
-    const inboxItems = store.listInboxItems("mbx_alpha");
-    const activations = store.listActivations();
-    const streams = store.listStreams();
-    const consumers = store.listConsumers();
-
-    assert.equal(subscriptions.length, 1);
-    assert.equal(subscriptions[0].subscriptionId, "int_legacy");
-    assert.equal(subscriptions[0].inboxId, "mbx_alpha");
-    assert.equal(subscriptions[0].activationMode, "activation_only");
-    assert.equal(inboxes.length, 1);
-    assert.equal(inboxes[0].inboxId, "mbx_alpha");
-    assert.equal(inboxItems.length, 1);
-    assert.equal(activations.length, 1);
-    assert.equal(activations[0].inboxId, "mbx_alpha");
-    assert.equal(streams.length, 1);
-    assert.equal(consumers.length, 1);
-  } finally {
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("activations are aggregated within the inbox window", async () => {
+test("webhook and terminal targets share ack-gated notification flow", async () => {
   const dispatcher = new RecordingActivationDispatcher();
-  const { store, service, dir } = await makeAsyncService({
-    dispatcher,
-    activationWindowMs: 40,
-    activationMaxItems: 20,
-  });
-  try {
-    const source = await service.registerSource({
-      sourceType: "fixture",
-      sourceKey: "demo",
-      config: {},
-    });
-    const subscription = await service.registerSubscription({
-      agentId: "alpha",
-      sourceId: source.sourceId,
-      matchRules: {},
-      activationTarget: "http://louke.local/activate?agent=alpha",
-      startPolicy: "earliest",
-    });
-
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
-      sourceNativeId: "evt-1",
-      eventVariant: "message.created",
-      metadata: {},
-      rawPayload: {},
-    });
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
-      sourceNativeId: "evt-2",
-      eventVariant: "message.created",
-      metadata: {},
-      rawPayload: {},
-    });
-
-    const poll = await service.pollSubscription(subscription.subscriptionId);
-    assert.equal(poll.inboxItemsCreated, 2);
-    assert.equal(dispatcher.calls.length, 0);
-
-    await new Promise((resolve) => setTimeout(resolve, 80));
-
-    assert.equal(dispatcher.calls.length, 1);
-    const activation = dispatcher.calls[0].activation;
-    assert.equal(activation.kind, "agentinbox.activation");
-    assert.equal(activation.agentId, "alpha");
-    assert.equal(activation.inboxId, "inbox_alpha");
-    assert.deepEqual(activation.subscriptionIds, [subscription.subscriptionId]);
-    assert.deepEqual(activation.sourceIds, [source.sourceId]);
-    assert.equal(activation.newItemCount, 2);
-    assert.equal(activation.items, undefined);
-    assert.match(activation.summary, /2 new items in inbox_alpha/);
-    assert.equal(store.listActivations().length, 1);
-    assert.equal(store.listActivations()[0].newItemCount, 2);
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("activations flush immediately when the inbox count threshold is reached", async () => {
-  const dispatcher = new RecordingActivationDispatcher();
-  const { store, service, dir } = await makeAsyncService({
-    dispatcher,
-    activationWindowMs: 500,
-    activationMaxItems: 2,
-  });
-  try {
-    const source = await service.registerSource({
-      sourceType: "fixture",
-      sourceKey: "demo",
-      config: {},
-    });
-    const subscription = await service.registerSubscription({
-      agentId: "alpha",
-      sourceId: source.sourceId,
-      matchRules: {},
-      activationTarget: "http://louke.local/activate?agent=alpha",
-      startPolicy: "earliest",
-    });
-
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
-      sourceNativeId: "evt-1",
-      eventVariant: "message.created",
-      metadata: {},
-      rawPayload: {},
-    });
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
-      sourceNativeId: "evt-2",
-      eventVariant: "message.created",
-      metadata: {},
-      rawPayload: {},
-    });
-
-    const poll = await service.pollSubscription(subscription.subscriptionId);
-    assert.equal(poll.inboxItemsCreated, 2);
-
-    await new Promise((resolve) => setTimeout(resolve, 20));
-
-    assert.equal(dispatcher.calls.length, 1);
-    assert.equal(dispatcher.calls[0].activation.newItemCount, 2);
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("activation_with_items includes inbox item snapshots in the webhook body", async () => {
-  const dispatcher = new RecordingActivationDispatcher();
-  const { store, service, dir } = await makeAsyncService({
-    dispatcher,
-    activationWindowMs: 40,
-    activationMaxItems: 20,
-  });
-  try {
-    const source = await service.registerSource({
-      sourceType: "fixture",
-      sourceKey: "demo",
-      config: {},
-    });
-    const subscription = await service.registerSubscription({
-      agentId: "alpha",
-      sourceId: source.sourceId,
-      matchRules: { channel: "engineering" },
-      activationTarget: "http://louke.local/activate?agent=alpha",
-      activationMode: "activation_with_items",
-      startPolicy: "earliest",
-    });
-
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
-      sourceNativeId: "evt-1",
-      eventVariant: "message.created",
-      metadata: { channel: "engineering", priority: "high" },
-      rawPayload: { text: "hello" },
-    });
-
-    const poll = await service.pollSubscription(subscription.subscriptionId);
-    assert.equal(poll.inboxItemsCreated, 1);
-
-    await new Promise((resolve) => setTimeout(resolve, 80));
-
-    assert.equal(dispatcher.calls.length, 1);
-    const activation = dispatcher.calls[0].activation;
-    assert.equal(activation.newItemCount, 1);
-    assert.ok(activation.items);
-    assert.equal(activation.items.length, 1);
-    assert.equal(activation.items[0].sourceNativeId, "evt-1");
-    assert.equal(activation.items[0].metadata.channel, "engineering");
-    assert.equal(activation.items[0].rawPayload.text, "hello");
-    assert.equal(store.listActivations().length, 1);
-    assert.equal(store.listActivations()[0].items?.length, 1);
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("terminal targets can be registered and attached to subscriptions", async () => {
-  const { store, service, dir } = await makeAsyncService();
-  try {
-    const target = service.registerTerminalTarget({
-      runtimeKind: "codex",
-      runtimeSessionId: "thread-123",
-      backend: "tmux",
-      tmuxPaneId: "%42",
-      tty: "/dev/ttys042",
-      termProgram: "tmux",
-    });
-    assert.equal(target.backend, "tmux");
-    assert.equal(target.tmuxPaneId, "%42");
-    assert.equal(target.runtimeKind, "codex");
-    assert.equal(target.runtimeSessionId, "thread-123");
-    assert.match(target.agentId, /^agent_codex_/);
-
-    const duplicate = service.registerTerminalTarget({
-      runtimeKind: "codex",
-      runtimeSessionId: "thread-123",
-      backend: "tmux",
-      tmuxPaneId: "%42",
-      tty: "/dev/ttys042",
-      termProgram: "tmux",
-    });
-    assert.equal(duplicate.targetId, target.targetId);
-
-    const source = await service.registerSource({
-      sourceType: "custom",
-      sourceKey: "project-alpha",
-      config: {},
-    });
-    const subscription = await service.registerSubscription({
-      agentId: target.agentId,
-      sourceId: source.sourceId,
-      terminalTargetId: target.targetId,
-    });
-    const details = await service.getSubscriptionDetails(subscription.subscriptionId);
-    assert.equal((details.terminalTarget as TerminalTarget).targetId, target.targetId);
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("terminal notifications are gated by ack and retried after lease expiry", async () => {
   const terminalDispatcher = new RecordingTerminalDispatcher();
-  const { store, service, dir } = await makeAsyncService({
+  const { store, service, dir } = await makeService({
+    dispatcher,
     terminalDispatcher,
     activationWindowMs: 20,
     activationMaxItems: 20,
   });
   try {
-    const target = service.registerTerminalTarget({
-      runtimeKind: "codex",
-      runtimeSessionId: "thread-lease",
+    const registered = service.registerAgent({
       backend: "tmux",
-      tmuxPaneId: "%7",
-      notifyLeaseMs: 30,
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-gated",
+      tmuxPaneId: "%42",
+      notifyLeaseMs: 100,
+    });
+    service.addWebhookActivationTarget(registered.agent.agentId, {
+      url: "http://127.0.0.1:9999/webhook",
+      activationMode: "activation_with_items",
+      notifyLeaseMs: 100,
     });
     const source = await service.registerSource({
-      sourceType: "fixture",
-      sourceKey: "terminal-demo",
+      sourceType: "custom",
+      sourceKey: "custom-gated",
       config: {},
     });
     const subscription = await service.registerSubscription({
-      agentId: target.agentId,
+      agentId: registered.agent.agentId,
       sourceId: source.sourceId,
-      terminalTargetId: target.targetId,
       startPolicy: "earliest",
     });
 
-    await service.start();
-
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
+    await service.appendSourceEventByCaller(source.sourceId, {
       sourceNativeId: "evt-1",
       eventVariant: "message.created",
       metadata: {},
       rawPayload: {},
     });
     await service.pollSubscription(subscription.subscriptionId);
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    await sleep(40);
 
+    assert.equal(dispatcher.calls.length, 1);
     assert.equal(terminalDispatcher.calls.length, 1);
-    assert.match(terminalDispatcher.calls[0].prompt, new RegExp(subscription.inboxId));
 
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
+    await service.appendSourceEventByCaller(source.sourceId, {
       sourceNativeId: "evt-2",
       eventVariant: "message.created",
       metadata: {},
       rawPayload: {},
     });
     await service.pollSubscription(subscription.subscriptionId);
-    await new Promise((resolve) => setTimeout(resolve, 40));
+    await sleep(40);
 
+    assert.equal(dispatcher.calls.length, 1);
     assert.equal(terminalDispatcher.calls.length, 1);
-    assert.equal(store.listTerminalDispatchStatesForInbox(subscription.inboxId)[0]?.status, "dirty");
 
-    const currentItems = service.listInboxItems(subscription.inboxId, { includeAcked: false });
-    service.ackInboxItems(subscription.inboxId, [currentItems[0].itemId]);
-    await new Promise((resolve) => setTimeout(resolve, 40));
+    const ack = service.ackAllInboxItems(registered.agent.agentId);
+    assert.equal(ack.acked, 2);
 
-    assert.equal(terminalDispatcher.calls.length, 2);
-
-    await service.appendSourceEvent({
-      sourceId: source.sourceId,
+    await service.appendSourceEventByCaller(source.sourceId, {
       sourceNativeId: "evt-3",
       eventVariant: "message.created",
       metadata: {},
       rawPayload: {},
     });
     await service.pollSubscription(subscription.subscriptionId);
-    await new Promise((resolve) => setTimeout(resolve, 40));
+    await sleep(40);
 
+    assert.equal(dispatcher.calls.length, 2);
     assert.equal(terminalDispatcher.calls.length, 2);
-    await new Promise((resolve) => setTimeout(resolve, 2500));
-    assert.equal(terminalDispatcher.calls.length, 3);
+    assert.equal(store.listActivationDispatchStatesForAgent(registered.agent.agentId).length, 2);
   } finally {
     await service.stop();
     store.close();
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -5,15 +5,15 @@ import path from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
 import { spawnSync } from "node:child_process";
-import { AgentInboxStore } from "../src/store";
-import { AgentInboxService } from "../src/service";
 import { AdapterRegistry } from "../src/adapters";
-import { createServer } from "../src/http";
 import { AgentInboxClient } from "../src/client";
 import { startControlServer } from "../src/control_server";
+import { createServer } from "../src/http";
 import { DEFAULT_AGENTINBOX_PORT, resolveClientTransport, resolveServeConfig } from "../src/paths";
-import { Activation, InboxItem, RegisterSourceInput, RegisterSubscriptionInput, SubscriptionPollResult, SubscriptionSource } from "../src/model";
-import { nowIso } from "../src/util";
+import { Activation, InboxItem, RegisterSourceInput, SubscriptionPollResult } from "../src/model";
+import { AgentInboxService } from "../src/service";
+import { AgentInboxStore } from "../src/store";
+import { TerminalDispatcher } from "../src/terminal";
 
 test("cli version and help subcommands print text output", () => {
   const repoDir = path.resolve(__dirname, "..");
@@ -36,20 +36,6 @@ test("cli version and help subcommands print text output", () => {
   assert.equal(inboxHelp.status, 0);
   assert.match(helpInbox.stdout, /agentinbox inbox/);
   assert.equal(helpInbox.stdout, inboxHelp.stdout);
-
-  const helpVersion = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "help", "version"], {
-    cwd: repoDir,
-    encoding: "utf8",
-  });
-  const versionHelp = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "version", "--help"], {
-    cwd: repoDir,
-    encoding: "utf8",
-  });
-  assert.equal(helpVersion.status, 0);
-  assert.equal(versionHelp.status, 0);
-  assert.match(helpVersion.stdout, /agentinbox version/);
-  assert.match(helpVersion.stdout, /--version, -v/);
-  assert.equal(helpVersion.stdout, versionHelp.stdout);
 });
 
 test("resolveServeConfig derives home, db, and socket defaults from AGENTINBOX_HOME", () => {
@@ -111,7 +97,10 @@ test("unix socket control plane replaces stale socket files and serves requests"
   const store = await AgentInboxStore.open(dbPath);
   let service: AgentInboxService;
   const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
   const server = createServer(service);
 
   try {
@@ -139,7 +128,7 @@ test("unix socket control plane replaces stale socket files and serves requests"
   }
 });
 
-test("e2e control plane can register fixture source, consume a subscription, and send aggregated activation webhook", async () => {
+test("e2e control plane can register an agent, route events, watch inbox, and send aggregated activation webhook", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-e2e-home-"));
   const socketPath = path.join(homeDir, "agentinbox.sock");
   const dbPath = path.join(homeDir, "agentinbox.sqlite");
@@ -147,16 +136,13 @@ test("e2e control plane can register fixture source, consume a subscription, and
   const store = await AgentInboxStore.open(dbPath);
   let service: AgentInboxService;
   const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
-  service = new AgentInboxService(
-    store,
-    adapters,
-    undefined,
-    undefined,
-    {
-      windowMs: 40,
-      maxItems: 20,
-    },
-  );
+  service = new AgentInboxService(store, adapters, undefined, undefined, {
+    windowMs: 40,
+    maxItems: 20,
+  }, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
   const server = createServer(service);
 
   let resolveWebhook: ((activation: Activation) => void) | null = null;
@@ -187,7 +173,7 @@ test("e2e control plane can register fixture source, consume a subscription, and
       });
       const address = webhookServer.address();
       assert.ok(address && typeof address === "object");
-      const activationTarget = `http://127.0.0.1:${address.port}/louke/activate`;
+      const webhookUrl = `http://127.0.0.1:${address.port}/activate`;
 
       const client = new AgentInboxClient({
         kind: "socket",
@@ -195,33 +181,42 @@ test("e2e control plane can register fixture source, consume a subscription, and
         source: "flag",
       });
 
-      const sourceResponse = await client.request<{
-        sourceId: string;
-        sourceType: string;
-      }>("/sources/register", {
+      const agentResponse = await client.request<{
+        agent: { agentId: string };
+        terminalTarget: { targetId: string };
+      }>("/agents/register", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-e2e",
+        tmuxPaneId: "%99",
+        notifyLeaseMs: 200,
+      });
+      assert.equal(agentResponse.statusCode, 200);
+      const agentId = agentResponse.data.agent.agentId;
+
+      const targetResponse = await client.request<{ targetId: string }>(`/agents/${encodeURIComponent(agentId)}/targets`, {
+        kind: "webhook",
+        url: webhookUrl,
+        activationMode: "activation_only",
+      });
+      assert.equal(targetResponse.statusCode, 200);
+
+      const sourceResponse = await client.request<{ sourceId: string }>("/sources/register", {
         sourceType: "fixture",
         sourceKey: "e2e-demo",
         config: {},
       } satisfies RegisterSourceInput);
       assert.equal(sourceResponse.statusCode, 200);
 
-      const subscriptionResponse = await client.request<{
-        subscriptionId: string;
-        inboxId: string;
-        agentId: string;
-      }>("/subscriptions/register", {
-        agentId: "alpha",
+      const subscriptionResponse = await client.request<{ subscriptionId: string }>("/subscriptions/register", {
+        agentId,
         sourceId: sourceResponse.data.sourceId,
         matchRules: { channel: "engineering" },
-        activationTarget,
         startPolicy: "earliest",
-      } satisfies RegisterSubscriptionInput);
+      });
       assert.equal(subscriptionResponse.statusCode, 200);
 
-      const appendResponse = await client.request<{
-        appended: number;
-        deduped: number;
-      }>("/fixtures/emit", {
+      const appendResponse = await client.request<{ appended: number }>("/fixtures/emit", {
         sourceId: sourceResponse.data.sourceId,
         sourceNativeId: "evt-e2e-1",
         eventVariant: "message.created",
@@ -240,476 +235,30 @@ test("e2e control plane can register fixture source, consume a subscription, and
       assert.equal(pollResponse.data.inboxItemsCreated, 1);
 
       const activation = await waitFor(webhookReceived, 1_000, "timed out waiting for activation webhook");
-      assert.equal(activation.kind, "agentinbox.activation");
-      assert.equal(activation.agentId, "alpha");
-      assert.equal(activation.inboxId, subscriptionResponse.data.inboxId);
-      assert.deepEqual(activation.subscriptionIds, [subscriptionResponse.data.subscriptionId]);
-      assert.deepEqual(activation.sourceIds, [sourceResponse.data.sourceId]);
+      assert.equal(activation.agentId, agentId);
+      assert.equal(activation.targetKind, "webhook");
       assert.equal(activation.newItemCount, 1);
-      assert.equal(activation.items, undefined);
-      assert.match(activation.summary, /1 new item/);
 
       const inboxResponse = await client.request<{ items: InboxItem[] }>(
-        `/inboxes/${subscriptionResponse.data.inboxId}/items`,
+        `/agents/${encodeURIComponent(agentId)}/inbox/items`,
         undefined,
         "GET",
       );
       assert.equal(inboxResponse.statusCode, 200);
       assert.equal(inboxResponse.data.items.length, 1);
-      assert.equal(inboxResponse.data.items[0].sourceNativeId, "evt-e2e-1");
-      assert.equal(inboxResponse.data.items[0].metadata.channel, "engineering");
-    } finally {
-      webhookServer.closeAllConnections?.();
-      await new Promise<void>((resolve) => webhookServer.close(() => resolve()));
-      await started.close();
-    }
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(homeDir, { recursive: true, force: true });
-  }
-});
 
-test("e2e control plane can append events through a custom source", async () => {
-  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-custom-source-home-"));
-  const socketPath = path.join(homeDir, "agentinbox.sock");
-  const dbPath = path.join(homeDir, "agentinbox.sqlite");
-
-  const store = await AgentInboxStore.open(dbPath);
-  let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
-  const server = createServer(service);
-
-  try {
-    const started = await startControlServer(server, {
-      kind: "socket",
-      socketPath,
-    });
-    try {
-      const client = new AgentInboxClient({
-        kind: "socket",
-        socketPath,
-        source: "flag",
-      });
-
-      const sourceResponse = await client.request<{ sourceId: string; sourceType: string }>("/sources/register", {
-        sourceType: "custom",
-        sourceKey: "project-alpha",
-        config: {},
-      } satisfies RegisterSourceInput);
-      assert.equal(sourceResponse.statusCode, 200);
-      assert.equal(sourceResponse.data.sourceType, "custom");
-
-      const subscriptionResponse = await client.request<{ subscriptionId: string; inboxId: string }>(
-        "/subscriptions/register",
-        {
-          agentId: "alpha",
-          sourceId: sourceResponse.data.sourceId,
-          matchRules: { channel: "engineering" },
-          startPolicy: "earliest",
-        } satisfies RegisterSubscriptionInput,
-      );
-      assert.equal(subscriptionResponse.statusCode, 200);
-
-      const appendResponse = await client.request<{ appended: number; deduped: number }>(
-        `/sources/${encodeURIComponent(sourceResponse.data.sourceId)}/events`,
-        {
-          sourceNativeId: "custom-evt-1",
-          eventVariant: "message.created",
-          metadata: { channel: "engineering" },
-          rawPayload: { text: "hello from custom source" },
-        },
-      );
-      assert.equal(appendResponse.statusCode, 200);
-      assert.equal(appendResponse.data.appended, 1);
-
-      const pollResponse = await client.request<SubscriptionPollResult>(
-        `/subscriptions/${subscriptionResponse.data.subscriptionId}/poll`,
+      const ackResponse = await client.request<{ acked: number }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/ack-all`,
         {},
       );
-      assert.equal(pollResponse.statusCode, 200);
-      assert.equal(pollResponse.data.inboxItemsCreated, 1);
+      assert.equal(ackResponse.statusCode, 200);
+      assert.equal(ackResponse.data.acked, 1);
 
-      const inboxResponse = await client.request<{ items: InboxItem[] }>(
-        `/inboxes/${subscriptionResponse.data.inboxId}/items`,
-        undefined,
-        "GET",
-      );
-      assert.equal(inboxResponse.statusCode, 200);
-      assert.equal(inboxResponse.data.items.length, 1);
-      assert.equal(inboxResponse.data.items[0].sourceNativeId, "custom-evt-1");
     } finally {
       await started.close();
     }
   } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(homeDir, { recursive: true, force: true });
-  }
-});
-
-test("e2e control plane watch streams backlog and future inbox items over socket SSE", async () => {
-  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-watch-home-"));
-  const socketPath = path.join(homeDir, "agentinbox.sock");
-  const dbPath = path.join(homeDir, "agentinbox.sqlite");
-
-  const store = await AgentInboxStore.open(dbPath);
-  let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
-  const server = createServer(service);
-
-  try {
-    const started = await startControlServer(server, {
-      kind: "socket",
-      socketPath,
-    });
-    try {
-      const client = new AgentInboxClient({
-        kind: "socket",
-        socketPath,
-        source: "flag",
-      });
-
-      const sourceResponse = await client.request<{ sourceId: string }>("/sources/register", {
-        sourceType: "fixture",
-        sourceKey: "watch-demo",
-        config: {},
-      } satisfies RegisterSourceInput);
-      assert.equal(sourceResponse.statusCode, 200);
-
-      const subscriptionResponse = await client.request<{ subscriptionId: string; inboxId: string }>(
-        "/subscriptions/register",
-        {
-          agentId: "alpha",
-          sourceId: sourceResponse.data.sourceId,
-          startPolicy: "earliest",
-        } satisfies RegisterSubscriptionInput,
-      );
-      assert.equal(subscriptionResponse.statusCode, 200);
-
-      await client.request("/fixtures/emit", {
-        sourceId: sourceResponse.data.sourceId,
-        sourceNativeId: "evt-watch-1",
-        eventVariant: "message.created",
-        metadata: { channel: "engineering" },
-        rawPayload: { text: "first" },
-      });
-      await client.request<SubscriptionPollResult>(
-        `/subscriptions/${subscriptionResponse.data.subscriptionId}/poll`,
-        {},
-      );
-
-      const watch = client.watchInbox(subscriptionResponse.data.inboxId, {
-        heartbeatMs: 25,
-      })[Symbol.asyncIterator]();
-
-      const firstEvent = await waitForWatchItems(watch, 1_000, "timed out waiting for backlog watch event");
-      assert.equal(firstEvent.items.length, 1);
-      assert.equal(firstEvent.items[0].sourceNativeId, "evt-watch-1");
-      assert.equal(firstEvent.items[0].ackedAt, null);
-
-      await client.request("/fixtures/emit", {
-        sourceId: sourceResponse.data.sourceId,
-        sourceNativeId: "evt-watch-2",
-        eventVariant: "message.created",
-        metadata: { channel: "engineering" },
-        rawPayload: { text: "second" },
-      });
-      await client.request<SubscriptionPollResult>(
-        `/subscriptions/${subscriptionResponse.data.subscriptionId}/poll`,
-        {},
-      );
-
-      const secondEvent = await waitForWatchItems(watch, 1_000, "timed out waiting for future watch event");
-      assert.equal(secondEvent.items.length, 1);
-      assert.equal(secondEvent.items[0].sourceNativeId, "evt-watch-2");
-
-      await watch.return?.();
-    } finally {
-      await started.close();
-    }
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(homeDir, { recursive: true, force: true });
-  }
-});
-
-test("inbox reads return 404 when after_item_id is unknown", async () => {
-  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-watch-invalid-home-"));
-  const socketPath = path.join(homeDir, "agentinbox.sock");
-  const dbPath = path.join(homeDir, "agentinbox.sqlite");
-
-  const store = await AgentInboxStore.open(dbPath);
-  let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
-  const server = createServer(service);
-
-  try {
-    const started = await startControlServer(server, {
-      kind: "socket",
-      socketPath,
-    });
-    try {
-      const client = new AgentInboxClient({
-        kind: "socket",
-        socketPath,
-        source: "flag",
-      });
-      const sourceResponse = await client.request<{ sourceId: string }>("/sources/register", {
-        sourceType: "fixture",
-        sourceKey: "watch-invalid",
-        config: {},
-      } satisfies RegisterSourceInput);
-      const subscriptionResponse = await client.request<{ inboxId: string }>("/subscriptions/register", {
-        agentId: "alpha",
-        sourceId: sourceResponse.data.sourceId,
-      } satisfies RegisterSubscriptionInput);
-      const response = await client.request<{ error: string }>(
-        `/inboxes/${encodeURIComponent(subscriptionResponse.data.inboxId)}/items?after_item_id=missing`,
-        undefined,
-        "GET",
-      );
-      assert.equal(response.statusCode, 404);
-      assert.match(response.data.error, /unknown inbox item/);
-    } finally {
-      await started.close();
-    }
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(homeDir, { recursive: true, force: true });
-  }
-});
-
-test("manual append endpoint rejects adapter-managed sources", async () => {
-  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-manual-append-home-"));
-  const socketPath = path.join(homeDir, "agentinbox.sock");
-  const dbPath = path.join(homeDir, "agentinbox.sqlite");
-
-  const store = await AgentInboxStore.open(dbPath);
-  const githubSource: SubscriptionSource = {
-    sourceId: "src_github_manual_append",
-    sourceType: "github_repo",
-    sourceKey: "holon-run/agentinbox",
-    configRef: null,
-    config: { owner: "holon-run", repo: "agentinbox" },
-    status: "active",
-    checkpoint: null,
-    createdAt: nowIso(),
-    updatedAt: nowIso(),
-  };
-  store.insertSource(githubSource);
-  let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
-  const server = createServer(service);
-
-  try {
-    const started = await startControlServer(server, {
-      kind: "socket",
-      socketPath,
-    });
-    try {
-      const client = new AgentInboxClient({
-        kind: "socket",
-        socketPath,
-        source: "flag",
-      });
-      const response = await client.request<{ error: string }>(
-        `/sources/${encodeURIComponent(githubSource.sourceId)}/events`,
-        {
-          sourceNativeId: "evt-1",
-          eventVariant: "message.created",
-          metadata: {},
-          rawPayload: {},
-        },
-      );
-      assert.equal(response.statusCode, 400);
-      assert.match(response.data.error, /manual append is not supported for source type: github_repo/);
-    } finally {
-      await started.close();
-    }
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(homeDir, { recursive: true, force: true });
-  }
-});
-
-test("sources/events validates string ids and delivery handle shape", async () => {
-  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-sev-"));
-  const socketPath = path.join(homeDir, "agentinbox.sock");
-  const dbPath = path.join(homeDir, "agentinbox.sqlite");
-
-  const store = await AgentInboxStore.open(dbPath);
-  let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
-  const server = createServer(service);
-
-  try {
-    const started = await startControlServer(server, {
-      kind: "socket",
-      socketPath,
-    });
-    try {
-      const client = new AgentInboxClient({
-        kind: "socket",
-        socketPath,
-        source: "flag",
-      });
-      const sourceResponse = await client.request<SubscriptionSource>("/sources/register", {
-        sourceType: "custom",
-        sourceKey: "validate-demo",
-      } satisfies RegisterSourceInput);
-      assert.equal(sourceResponse.statusCode, 200);
-
-      const invalidId = await client.request<{ error: string }>(`/sources/${sourceResponse.data.sourceId}/events`, {
-        sourceNativeId: { bad: true },
-        eventVariant: "message.created",
-      });
-      assert.equal(invalidId.statusCode, 400);
-      assert.match(invalidId.data.error, /sources\/events requires sourceNativeId/);
-
-      const invalidDeliveryHandle = await client.request<{ error: string }>(`/sources/${sourceResponse.data.sourceId}/events`, {
-        sourceNativeId: "evt-1",
-        eventVariant: "message.created",
-        deliveryHandle: { provider: "github" },
-      });
-      assert.equal(invalidDeliveryHandle.statusCode, 400);
-      assert.match(invalidDeliveryHandle.data.error, /deliveryHandle requires provider, surface, and targetRef/);
-    } finally {
-      await started.close();
-    }
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(homeDir, { recursive: true, force: true });
-  }
-});
-
-test("control plane exposes source, subscription, and inbox management endpoints", async () => {
-  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-mgmt-"));
-  const socketPath = path.join(homeDir, "agentinbox.sock");
-  const dbPath = path.join(homeDir, "agentinbox.sqlite");
-
-  const store = await AgentInboxStore.open(dbPath);
-  let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
-  const server = createServer(service);
-
-  try {
-    const started = await startControlServer(server, {
-      kind: "socket",
-      socketPath,
-    });
-    try {
-      const client = new AgentInboxClient({
-        kind: "socket",
-        socketPath,
-        source: "flag",
-      });
-      const source = await client.request<SubscriptionSource>("/sources/register", {
-        sourceType: "custom",
-        sourceKey: "mgmt-demo",
-      } satisfies RegisterSourceInput);
-      assert.equal(source.statusCode, 200);
-
-      const ensured = await client.request<{ inboxId: string; ownerAgentId: string }>("/inboxes/ensure", {
-        inboxId: "shared_alpha",
-        agentId: "alpha",
-      });
-      assert.equal(ensured.statusCode, 200);
-      assert.equal(ensured.data.inboxId, "shared_alpha");
-
-      const subscription = await client.request<{ subscriptionId: string; inboxId: string }>("/subscriptions/register", {
-        agentId: "alpha",
-        sourceId: source.data.sourceId,
-        inboxId: "shared_alpha",
-        matchRules: { channel: "engineering" },
-        startPolicy: "latest",
-      } satisfies RegisterSubscriptionInput);
-      assert.equal(subscription.statusCode, 200);
-
-      const sources = await client.request<{ sources: SubscriptionSource[] }>("/sources", undefined, "GET");
-      assert.equal(sources.statusCode, 200);
-      assert.equal(sources.data.sources.length, 1);
-
-      const sourceDetails = await client.request<{ source: SubscriptionSource; subscriptions: Array<{ subscriptionId: string }> }>(
-        `/sources/${source.data.sourceId}`,
-        undefined,
-        "GET",
-      );
-      assert.equal(sourceDetails.statusCode, 200);
-      assert.equal(sourceDetails.data.subscriptions.length, 1);
-
-      await client.request(`/sources/${source.data.sourceId}/events`, {
-        sourceNativeId: "evt-1",
-        eventVariant: "message.created",
-        metadata: { channel: "engineering" },
-      });
-
-      const lagBefore = await client.request<{ pendingEvents: number }>(
-        `/subscriptions/${subscription.data.subscriptionId}/lag`,
-        undefined,
-        "GET",
-      );
-      assert.equal(lagBefore.statusCode, 200);
-      assert.equal(lagBefore.data.pendingEvents, 1);
-
-      const listed = await client.request<{ subscriptions: Array<{ subscriptionId: string }> }>(
-        `/subscriptions?source_id=${encodeURIComponent(source.data.sourceId)}&agent_id=alpha&inbox_id=shared_alpha`,
-        undefined,
-        "GET",
-      );
-      assert.equal(listed.statusCode, 200);
-      assert.equal(listed.data.subscriptions.length, 1);
-
-      const reset = await client.request<{ consumer: { nextOffset: number } }>(
-        `/subscriptions/${subscription.data.subscriptionId}/reset`,
-        { startPolicy: "earliest" },
-      );
-      assert.equal(reset.statusCode, 200);
-      assert.equal(reset.data.consumer.nextOffset, 1);
-
-      const poll = await client.request<SubscriptionPollResult>(
-        `/subscriptions/${subscription.data.subscriptionId}/poll`,
-        {},
-      );
-      assert.equal(poll.statusCode, 200);
-      assert.equal(poll.data.inboxItemsCreated, 1);
-
-      const subShow = await client.request<{ subscription: { inboxId: string }; lag: { pendingEvents: number } }>(
-        `/subscriptions/${subscription.data.subscriptionId}`,
-        undefined,
-        "GET",
-      );
-      assert.equal(subShow.statusCode, 200);
-      assert.equal(subShow.data.subscription.inboxId, "shared_alpha");
-      assert.equal(subShow.data.lag.pendingEvents, 0);
-
-      const inboxShow = await client.request<{
-        inbox: { inboxId: string; ownerAgentId: string };
-        subscriptions: Array<{ subscriptionId: string }>;
-        itemCounts: { total: number; unacked: number; acked: number };
-      }>(`/inboxes/shared_alpha`, undefined, "GET");
-      assert.equal(inboxShow.statusCode, 200);
-      assert.equal(inboxShow.data.inbox.ownerAgentId, "alpha");
-      assert.equal(inboxShow.data.subscriptions.length, 1);
-      assert.equal(inboxShow.data.itemCounts.unacked, 1);
-
-      const ackAll = await client.request<{ acked: number }>(`/inboxes/shared_alpha/ack-all`, {});
-      assert.equal(ackAll.statusCode, 200);
-      assert.equal(ackAll.data.acked, 1);
-    } finally {
-      await started.close();
-    }
-  } finally {
+    webhookServer.close();
     await service.stop();
     store.close();
     fs.rmSync(homeDir, { recursive: true, force: true });
@@ -718,31 +267,14 @@ test("control plane exposes source, subscription, and inbox management endpoints
 
 async function waitFor<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
   try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_, reject) => {
-        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
-      }),
-    ]);
+    return await Promise.race([promise, timeout]);
   } finally {
     if (timer) {
       clearTimeout(timer);
-    }
-  }
-}
-
-async function waitForWatchItems(
-  iterator: AsyncIterator<unknown>,
-  timeoutMs: number,
-  message: string,
-): Promise<{ event: "items"; inboxId: string; items: InboxItem[] }> {
-  while (true) {
-    const next = await waitFor(iterator.next(), timeoutMs, message);
-    assert.equal(next.done, false);
-    const value = next.value as { event: string; inboxId: string; items?: InboxItem[] };
-    if (value.event === "items") {
-      return value as { event: "items"; inboxId: string; items: InboxItem[] };
     }
   }
 }

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -8,6 +8,7 @@ import { AgentInboxService } from "../src/service";
 import { AdapterRegistry } from "../src/adapters";
 import { AppendSourceEventInput, DeliveryAttempt, SubscriptionSource } from "../src/model";
 import { nowIso } from "../src/util";
+import { TerminalDispatcher } from "../src/terminal";
 import {
   FeishuDeliveryAdapter,
   FeishuSourceRuntime,
@@ -82,7 +83,10 @@ async function makeService(): Promise<{ store: AgentInboxStore; service: AgentIn
   const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
   let service: AgentInboxService;
   const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
   return { store, service, dir };
 }
 
@@ -150,8 +154,14 @@ test("feishu source runtime appends stream events and subscriptions materialize 
       updatedAt: nowIso(),
     };
     store.insertSource(source);
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "feishu-thread",
+      tmuxPaneId: "%203",
+    });
     const subscription = await service.registerSubscription({
-      agentId: "alpha",
+      agentId: agent.agent.agentId,
       sourceId: source.sourceId,
       matchRules: { mentions: ["Alpha"] },
       startPolicy: "earliest",
@@ -189,8 +199,8 @@ test("feishu source runtime appends stream events and subscriptions materialize 
     const subscriptionResult = await service.pollSubscription(subscription.subscriptionId);
     assert.equal(sourceResult.appended, 1);
     assert.equal(subscriptionResult.inboxItemsCreated, 1);
-    assert.equal(service.listInboxItems(subscription.inboxId).length, 1);
-    assert.equal(service.listInboxItems(subscription.inboxId)[0]?.deliveryHandle?.surface, "message_reply");
+    assert.equal(service.listInboxItems(subscription.agentId).length, 1);
+    assert.equal(service.listInboxItems(subscription.agentId)[0]?.deliveryHandle?.surface, "message_reply");
   } finally {
     await service.stop();
     store.close();

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -9,6 +9,7 @@ import { AdapterRegistry } from "../src/adapters";
 import { GithubDeliveryAdapter, GithubSourceRuntime, GithubUxcClient, normalizeGithubRepoEvent, type UxcLikeClient } from "../src/sources/github";
 import { AppendSourceEventInput, DeliveryAttempt, SubscriptionSource } from "../src/model";
 import { nowIso } from "../src/util";
+import { TerminalDispatcher } from "../src/terminal";
 
 class FakeUxcClient implements UxcLikeClient {
   public started: Array<Record<string, unknown>> = [];
@@ -73,7 +74,10 @@ async function makeService(): Promise<{ store: AgentInboxStore; service: AgentIn
   const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
   let service: AgentInboxService;
   const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
   return { store, service, adapters, dir };
 }
 
@@ -138,8 +142,14 @@ test("github source runtime appends stream events and subscriptions materialize 
       updatedAt: nowIso(),
     };
     store.insertSource(source);
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "github-thread",
+      tmuxPaneId: "%201",
+    });
     const subscription = await service.registerSubscription({
-      agentId: "alpha",
+      agentId: agent.agent.agentId,
       sourceId: source.sourceId,
       matchRules: { mentions: ["alpha"] },
       startPolicy: "earliest",
@@ -167,7 +177,7 @@ test("github source runtime appends stream events and subscriptions materialize 
     const subscriptionResult = await service.pollSubscription(subscription.subscriptionId);
     assert.equal(sourceResult.appended, 1);
     assert.equal(subscriptionResult.inboxItemsCreated, 1);
-    assert.equal(service.listInboxItems(subscription.inboxId).length, 1);
+    assert.equal(service.listInboxItems(subscription.agentId).length, 1);
   } finally {
     await service.stop();
     store.close();

--- a/test/github_ci.test.ts
+++ b/test/github_ci.test.ts
@@ -9,6 +9,7 @@ import { AdapterRegistry } from "../src/adapters";
 import { AppendSourceEventInput, SubscriptionSource } from "../src/model";
 import { nowIso } from "../src/util";
 import { GithubActionsUxcClient, GithubCiSourceRuntime, normalizeGithubWorkflowRunEvent } from "../src/sources/github_ci";
+import { TerminalDispatcher } from "../src/terminal";
 
 class FakeGithubActionsClient {
   public calls: Array<Record<string, unknown>> = [];
@@ -34,7 +35,10 @@ async function makeService(): Promise<{ store: AgentInboxStore; service: AgentIn
   const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
   let service: AgentInboxService;
   const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input));
-  service = new AgentInboxService(store, adapters);
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
   return { store, service, adapters, dir };
 }
 
@@ -120,8 +124,14 @@ test("github_repo_ci source runtime appends workflow run events and subscription
       updatedAt: nowIso(),
     };
     store.insertSource(source);
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "github-ci-thread",
+      tmuxPaneId: "%202",
+    });
     const subscription = await service.registerSubscription({
-      agentId: "alpha",
+      agentId: agent.agent.agentId,
       sourceId: source.sourceId,
       matchRules: { conclusion: "failure", headBranch: "main" },
       startPolicy: "earliest",
@@ -167,7 +177,7 @@ test("github_repo_ci source runtime appends workflow run events and subscription
     await runtime.ensureSource(source);
     const sourceResult = await runtime.pollSource(source.sourceId);
     const subscriptionResult = await service.pollSubscription(subscription.subscriptionId);
-    const items = service.listInboxItems(subscription.inboxId);
+    const items = service.listInboxItems(subscription.agentId);
 
     assert.equal(fake.calls[0]?.operation, "get:/repos/{owner}/{repo}/actions/runs");
     assert.equal(sourceResult.appended, 2);

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { assignedAgentIdFromContext, detectTerminalContext, TerminalDispatcher } from "../src/terminal";
-import { TerminalTarget } from "../src/model";
+import { TerminalActivationTarget } from "../src/model";
 
 test("detectTerminalContext derives codex runtime and iTerm2 session", () => {
   const detected = detectTerminalContext({
@@ -57,18 +57,19 @@ test("TerminalDispatcher uses osascript for iTerm2 targets", async () => {
     };
   });
 
-  const target: TerminalTarget = {
-    targetId: "term_1",
+  const target: TerminalActivationTarget = {
+    targetId: "tgt_1",
     agentId: "agent_codex_abc",
+    kind: "terminal",
+    mode: "agent_prompt",
+    notifyLeaseMs: 600000,
     runtimeKind: "codex",
     runtimeSessionId: "thread-1",
     backend: "iterm2",
-    mode: "agent_prompt",
     tmuxPaneId: null,
     tty: null,
     termProgram: "iTerm.app",
     itermSessionId: "4B4CB6B2-A73B-4420-94A7-BD2CA216A285",
-    notifyLeaseMs: 600000,
     createdAt: "2026-04-07T00:00:00.000Z",
     updatedAt: "2026-04-07T00:00:00.000Z",
     lastSeenAt: "2026-04-07T00:00:00.000Z",


### PR DESCRIPTION
## Summary
- make Agent the public identity and owner of activation targets
- move inbox commands to agent-based routing and keep one inbox per agent
- unify webhook and terminal notifications behind shared activation targets and dispatch state

## Verification
- npm run build
- npm test