### PR TITLE
Add daemon auto-start for CLI commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -362,7 +362,9 @@ async function runServe(args: string[]): Promise<void> {
   await service.start();
   const controlServer = await startControlServer(server, serveConfig.transport);
   const daemonPaths = resolveDaemonPaths(process.env, takeFlagValue(args, "--home"));
-  writePidFile(daemonPaths.pidPath, process.pid);
+  if (serveConfig.transport.kind === "socket") {
+    writePidFile(daemonPaths.pidPath, process.pid);
+  }
   console.log(jsonResponse({
     ok: true,
     homeDir: serveConfig.homeDir,
@@ -375,7 +377,9 @@ async function runServe(args: string[]): Promise<void> {
       void adapters.stop();
       void service.stop();
       store.close();
-      removePidFile(daemonPaths.pidPath);
+      if (serveConfig.transport.kind === "socket") {
+        removePidFile(daemonPaths.pidPath);
+      }
       process.exit(0);
     });
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,8 +4,9 @@ import path from "node:path";
 import { AdapterRegistry } from "./adapters";
 import { AgentInboxClient } from "./client";
 import { startControlServer } from "./control_server";
+import { daemonStatus, ensureDaemonForClient, removePidFile, startDaemon, stopDaemon, writePidFile } from "./daemon";
 import { createServer } from "./http";
-import { resolveClientTransport, resolveServeConfig } from "./paths";
+import { resolveDaemonPaths, resolveServeConfig } from "./paths";
 import { AgentInboxService } from "./service";
 import { AgentInboxStore } from "./store";
 import { detectTerminalContext } from "./terminal";
@@ -39,7 +40,16 @@ async function main(): Promise<void> {
     return;
   }
 
-  const client = createClient(normalized);
+  if (command === "daemon") {
+    if (hasHelpFlag(normalized.slice(1))) {
+      printHelp(["daemon"]);
+      return;
+    }
+    await runDaemon(normalized.slice(1));
+    return;
+  }
+
+  const client = await createClient(normalized);
 
   if (command === "source" && normalized[1] === "add") {
     const [type, sourceKey] = normalized.slice(2, 4);
@@ -351,6 +361,8 @@ async function runServe(args: string[]): Promise<void> {
   await adapters.start();
   await service.start();
   const controlServer = await startControlServer(server, serveConfig.transport);
+  const daemonPaths = resolveDaemonPaths(process.env, takeFlagValue(args, "--home"));
+  writePidFile(daemonPaths.pidPath, process.pid);
   console.log(jsonResponse({
     ok: true,
     homeDir: serveConfig.homeDir,
@@ -363,6 +375,7 @@ async function runServe(args: string[]): Promise<void> {
       void adapters.stop();
       void service.stop();
       store.close();
+      removePidFile(daemonPaths.pidPath);
       process.exit(0);
     });
   };
@@ -370,13 +383,43 @@ async function runServe(args: string[]): Promise<void> {
   process.on("SIGTERM", shutdown);
 }
 
-function createClient(args: string[]): AgentInboxClient {
-  return new AgentInboxClient(resolveClientTransport({
+async function runDaemon(args: string[]): Promise<void> {
+  const action = args[0];
+  const options = {
     env: process.env,
     homeDirOverride: takeFlagValue(args, "--home"),
     socketPathOverride: takeFlagValue(args, "--socket"),
     baseUrlOverride: takeFlagValue(args, "--url"),
-  }));
+  };
+
+  if (action === "start") {
+    const result = await startDaemon(options);
+    console.log(jsonResponse(result));
+    return;
+  }
+  if (action === "stop") {
+    const result = await stopDaemon(options);
+    console.log(jsonResponse(result));
+    return;
+  }
+  if (action === "status") {
+    const result = await daemonStatus(options);
+    console.log(jsonResponse(result));
+    return;
+  }
+
+  throw new Error("usage: agentinbox daemon <start|stop|status>");
+}
+
+async function createClient(args: string[]): Promise<AgentInboxClient> {
+  const transport = await ensureDaemonForClient({
+    env: process.env,
+    homeDirOverride: takeFlagValue(args, "--home"),
+    socketPathOverride: takeFlagValue(args, "--socket"),
+    baseUrlOverride: takeFlagValue(args, "--url"),
+    noAutoStart: hasFlag(args, "--no-auto-start"),
+  });
+  return new AgentInboxClient(transport);
 }
 
 async function printRemote(
@@ -453,6 +496,7 @@ Usage:
 
 Commands:
   serve
+  daemon
   source
   agent
   subscription
@@ -467,6 +511,13 @@ Commands:
 Usage:
   agentinbox serve [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
   agentinbox serve --port 4747 [--state ~/.agentinbox/agentinbox.sqlite]
+`,
+    daemon: `agentinbox daemon
+
+Usage:
+  agentinbox daemon start [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
+  agentinbox daemon stop [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
+  agentinbox daemon status [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
 `,
     source: `agentinbox source
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,0 +1,278 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { AgentInboxClient } from "./client";
+import { resolveAgentInboxHome, resolveDaemonPaths, type ClientTransport } from "./paths";
+
+export interface DaemonCliOptions {
+  env?: NodeJS.ProcessEnv;
+  homeDirOverride?: string;
+  socketPathOverride?: string;
+  baseUrlOverride?: string;
+  noAutoStart?: boolean;
+}
+
+export interface DaemonStartResult {
+  started: boolean;
+  pid: number;
+  pidPath: string;
+  logPath: string;
+  transport: ClientTransport;
+}
+
+export interface DaemonStatusResult {
+  running: boolean;
+  pid: number | null;
+  pidPath: string;
+  logPath: string;
+  transport: ClientTransport;
+}
+
+const START_TIMEOUT_MS = 5_000;
+
+export async function ensureDaemonForClient(options: DaemonCliOptions = {}): Promise<ClientTransport> {
+  const transport = resolveDaemonClientTransport(options);
+
+  if (options.noAutoStart || transport.kind !== "socket") {
+    return transport;
+  }
+
+  if (await canReachHealthz(transport)) {
+    return transport;
+  }
+
+  await startDaemon(options);
+  return transport;
+}
+
+export async function startDaemon(options: DaemonCliOptions = {}): Promise<DaemonStartResult> {
+  const env = options.env ?? process.env;
+  const transport = resolveDaemonClientTransport(options);
+  if (transport.kind !== "socket") {
+    throw new Error("daemon start requires a local socket transport");
+  }
+
+  const homeDir = resolveAgentInboxHome(env, options.homeDirOverride);
+  const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
+  fs.mkdirSync(homeDir, { recursive: true });
+  cleanupStalePidFile(pidPath);
+
+  if (await canReachHealthz(transport)) {
+    const pid = readPidFile(pidPath);
+    return {
+      started: false,
+      pid: pid ?? -1,
+      pidPath,
+      logPath,
+      transport,
+    };
+  }
+
+  const child = spawn(process.execPath, daemonChildArgs(), {
+    cwd: process.cwd(),
+    env: {
+      ...env,
+      AGENTINBOX_HOME: homeDir,
+      AGENTINBOX_SOCKET: transport.socketPath,
+      AGENTINBOX_URL: "",
+    },
+    detached: true,
+    stdio: ["ignore", openLogFile(logPath), openLogFile(logPath)],
+  });
+  child.unref();
+  await waitForHealthz(transport, START_TIMEOUT_MS);
+  return {
+    started: true,
+    pid: child.pid ?? -1,
+    pidPath,
+    logPath,
+    transport,
+  };
+}
+
+export async function stopDaemon(options: DaemonCliOptions = {}): Promise<DaemonStatusResult> {
+  const env = options.env ?? process.env;
+  const transport = resolveDaemonClientTransport(options);
+  const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
+
+  const pid = readPidFile(pidPath);
+  if (pid != null && isProcessAlive(pid)) {
+    process.kill(pid, "SIGTERM");
+    await waitForProcessExit(pid, 3_000);
+  }
+
+  cleanupStalePidFile(pidPath, true);
+  if (transport.kind === "socket") {
+    cleanupFile(transport.socketPath);
+  }
+
+  return daemonStatus(options);
+}
+
+export async function daemonStatus(options: DaemonCliOptions = {}): Promise<DaemonStatusResult> {
+  const env = options.env ?? process.env;
+  const transport = resolveDaemonClientTransport(options);
+  const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
+  const pid = readPidFile(pidPath);
+  if (pid != null && !isProcessAlive(pid)) {
+    cleanupStalePidFile(pidPath, true);
+    if (transport.kind === "socket") {
+      cleanupFile(transport.socketPath);
+    }
+    return {
+      running: false,
+      pid: null,
+      pidPath,
+      logPath,
+      transport,
+    };
+  }
+
+  return {
+    running: await canReachHealthz(transport),
+    pid,
+    pidPath,
+    logPath,
+    transport,
+  };
+}
+
+export function writePidFile(pidPath: string, pid: number): void {
+  fs.mkdirSync(path.dirname(pidPath), { recursive: true });
+  fs.writeFileSync(pidPath, `${pid}\n`, "utf8");
+}
+
+export function removePidFile(pidPath: string): void {
+  cleanupFile(pidPath);
+}
+
+function daemonChildArgs(): string[] {
+  const execArgv = [...process.execArgv];
+  return [...execArgv, process.argv[1], "serve"];
+}
+
+function resolveDaemonClientTransport(options: DaemonCliOptions): ClientTransport {
+  const env = options.env ?? process.env;
+  const homeDir = resolveAgentInboxHome(env, options.homeDirOverride);
+
+  if (options.socketPathOverride && options.baseUrlOverride) {
+    throw new Error("client accepts either --socket or --url, not both");
+  }
+
+  if (options.socketPathOverride) {
+    return {
+      kind: "socket",
+      socketPath: path.resolve(options.socketPathOverride),
+      source: "flag",
+    };
+  }
+  if (options.baseUrlOverride) {
+    return {
+      kind: "url",
+      baseUrl: options.baseUrlOverride,
+      source: "flag",
+    };
+  }
+  if (env.AGENTINBOX_SOCKET) {
+    return {
+      kind: "socket",
+      socketPath: path.resolve(env.AGENTINBOX_SOCKET),
+      source: "env",
+    };
+  }
+  if (env.AGENTINBOX_URL) {
+    return {
+      kind: "url",
+      baseUrl: env.AGENTINBOX_URL,
+      source: "env",
+    };
+  }
+  return {
+    kind: "socket",
+    socketPath: path.join(homeDir, "agentinbox.sock"),
+    source: "default",
+  };
+}
+
+function openLogFile(logPath: string): number {
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  return fs.openSync(logPath, "a");
+}
+
+async function canReachHealthz(transport: ClientTransport): Promise<boolean> {
+  try {
+    const client = new AgentInboxClient(transport);
+    const response = await client.request<{ ok: boolean }>("/healthz", undefined, "GET");
+    return response.statusCode === 200 && response.data.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForHealthz(transport: ClientTransport, timeoutMs: number): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await canReachHealthz(transport)) {
+      return;
+    }
+    await sleep(100);
+  }
+  throw new Error("timed out waiting for AgentInbox daemon to become ready");
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (!isProcessAlive(pid)) {
+      return;
+    }
+    await sleep(100);
+  }
+}
+
+function cleanupStalePidFile(pidPath: string, force = false): void {
+  const pid = readPidFile(pidPath);
+  if (pid == null) {
+    cleanupFile(pidPath);
+    return;
+  }
+  if (force || !isProcessAlive(pid)) {
+    cleanupFile(pidPath);
+  }
+}
+
+function readPidFile(pidPath: string): number | null {
+  try {
+    const raw = fs.readFileSync(pidPath, "utf8").trim();
+    if (!raw) {
+      return null;
+    }
+    const pid = Number.parseInt(raw, 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function cleanupFile(filePath: string): void {
+  try {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  } catch {
+    // Best effort cleanup.
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -47,10 +47,7 @@ export async function ensureDaemonForClient(options: DaemonCliOptions = {}): Pro
 
 export async function startDaemon(options: DaemonCliOptions = {}): Promise<DaemonStartResult> {
   const env = options.env ?? process.env;
-  const transport = resolveDaemonClientTransport(options);
-  if (transport.kind !== "socket") {
-    throw new Error("daemon start requires a local socket transport");
-  }
+  const transport = requireSocketTransport(resolveDaemonClientTransport(options), "daemon start");
 
   const homeDir = resolveAgentInboxHome(env, options.homeDirOverride);
   const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
@@ -68,17 +65,23 @@ export async function startDaemon(options: DaemonCliOptions = {}): Promise<Daemo
     };
   }
 
-  const child = spawn(process.execPath, daemonChildArgs(), {
-    cwd: process.cwd(),
-    env: {
-      ...env,
-      AGENTINBOX_HOME: homeDir,
-      AGENTINBOX_SOCKET: transport.socketPath,
-      AGENTINBOX_URL: "",
-    },
-    detached: true,
-    stdio: ["ignore", openLogFile(logPath), openLogFile(logPath)],
-  });
+  const logFd = openLogFile(logPath);
+  let child;
+  try {
+    child = spawn(process.execPath, daemonChildArgs(), {
+      cwd: process.cwd(),
+      env: {
+        ...env,
+        AGENTINBOX_HOME: homeDir,
+        AGENTINBOX_SOCKET: transport.socketPath,
+        AGENTINBOX_URL: "",
+      },
+      detached: true,
+      stdio: ["ignore", logFd, logFd],
+    });
+  } finally {
+    fs.closeSync(logFd);
+  }
   child.unref();
   await waitForHealthz(transport, START_TIMEOUT_MS);
   return {
@@ -92,7 +95,7 @@ export async function startDaemon(options: DaemonCliOptions = {}): Promise<Daemo
 
 export async function stopDaemon(options: DaemonCliOptions = {}): Promise<DaemonStatusResult> {
   const env = options.env ?? process.env;
-  const transport = resolveDaemonClientTransport(options);
+  const transport = requireSocketTransport(resolveDaemonClientTransport(options), "daemon stop");
   const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
 
   const pid = readPidFile(pidPath);
@@ -102,23 +105,19 @@ export async function stopDaemon(options: DaemonCliOptions = {}): Promise<Daemon
   }
 
   cleanupStalePidFile(pidPath, true);
-  if (transport.kind === "socket") {
-    cleanupFile(transport.socketPath);
-  }
+  cleanupFile(transport.socketPath);
 
   return daemonStatus(options);
 }
 
 export async function daemonStatus(options: DaemonCliOptions = {}): Promise<DaemonStatusResult> {
   const env = options.env ?? process.env;
-  const transport = resolveDaemonClientTransport(options);
+  const transport = requireSocketTransport(resolveDaemonClientTransport(options), "daemon status");
   const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
   const pid = readPidFile(pidPath);
   if (pid != null && !isProcessAlive(pid)) {
     cleanupStalePidFile(pidPath, true);
-    if (transport.kind === "socket") {
-      cleanupFile(transport.socketPath);
-    }
+    cleanupFile(transport.socketPath);
     return {
       running: false,
       pid: null,
@@ -149,6 +148,16 @@ export function removePidFile(pidPath: string): void {
 function daemonChildArgs(): string[] {
   const execArgv = [...process.execArgv];
   return [...execArgv, process.argv[1], "serve"];
+}
+
+function requireSocketTransport(
+  transport: ClientTransport,
+  commandName: string,
+): Extract<ClientTransport, { kind: "socket" }> {
+  if (transport.kind !== "socket") {
+    throw new Error(`${commandName} requires a local socket transport`);
+  }
+  return transport;
 }
 
 function resolveDaemonClientTransport(options: DaemonCliOptions): ClientTransport {
@@ -228,6 +237,7 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>
     }
     await sleep(100);
   }
+  throw new Error(`timed out waiting for process ${pid} to exit`);
 }
 
 function cleanupStalePidFile(pidPath: string, force = false): void {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -34,6 +34,11 @@ export interface ResolvedServeConfig {
   warnings: string[];
 }
 
+export interface DaemonPaths {
+  pidPath: string;
+  logPath: string;
+}
+
 export function resolveAgentInboxHome(
   env: NodeJS.ProcessEnv = process.env,
   override?: string,
@@ -94,6 +99,17 @@ export function resolveServeConfig(input: ResolveServeConfigInput = {}): Resolve
       socketPath: resolveSocketPath(env, homeDir, input.socketPathOverride),
     },
     warnings: [],
+  };
+}
+
+export function resolveDaemonPaths(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDirOverride?: string,
+): DaemonPaths {
+  const homeDir = resolveAgentInboxHome(env, homeDirOverride);
+  return {
+    pidPath: path.join(homeDir, "agentinbox.pid"),
+    logPath: path.join(homeDir, "agentinbox.log"),
   };
 }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -96,6 +96,9 @@ export function assignedAgentIdFromContext(input: {
 export class TerminalDispatcher {
   constructor(
     private readonly execAsync: ExecFileAsyncLike = execFileAsync,
+    private readonly options: {
+      iterm2ApiPath?: string;
+    } = {},
   ) {}
 
   async dispatch(target: TerminalActivationTarget, prompt: string): Promise<void> {
@@ -108,7 +111,7 @@ export class TerminalDispatcher {
     }
 
     if (target.backend === "iterm2") {
-      await dispatchToIterm2(target, prompt, this.execAsync);
+      await dispatchToIterm2(target, prompt, this.execAsync, this.options.iterm2ApiPath);
       return;
     }
 
@@ -305,20 +308,24 @@ async function dispatchToIterm2(
   target: TerminalActivationTarget,
   prompt: string,
   execAsync: ExecFileAsyncLike,
+  iterm2ApiPath?: string,
 ): Promise<void> {
   const sessionId = normalizeOptionalString(target.itermSessionId);
   if (!sessionId) {
     throw new Error(`iTerm2 terminal target ${target.targetId} is missing itermSessionId`);
   }
 
-  const it2api = resolveIterm2ApiPath();
+  const it2api = resolveIterm2ApiPath(iterm2ApiPath);
   await execAsync(it2api, ["send-text", sessionId, prompt]);
   // Background Codex/Claude sessions only submit reliably when Return is sent
   // in a second call rather than concatenated to the original prompt payload.
   await execAsync(it2api, ["send-text", sessionId, "\r"]);
 }
 
-function resolveIterm2ApiPath(): string {
+function resolveIterm2ApiPath(override?: string): string {
+  if (override) {
+    return override;
+  }
   const candidates = [
     "/Applications/iTerm.app/Contents/Resources/it2api",
     "/Applications/iTerm.app/Contents/Resources/utilities/it2api",

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -8,8 +8,9 @@ import { spawnSync } from "node:child_process";
 import { AdapterRegistry } from "../src/adapters";
 import { AgentInboxClient } from "../src/client";
 import { startControlServer } from "../src/control_server";
+import { daemonStatus } from "../src/daemon";
 import { createServer } from "../src/http";
-import { DEFAULT_AGENTINBOX_PORT, resolveClientTransport, resolveServeConfig } from "../src/paths";
+import { DEFAULT_AGENTINBOX_PORT, resolveClientTransport, resolveDaemonPaths, resolveServeConfig } from "../src/paths";
 import { Activation, InboxItem, RegisterSourceInput, SubscriptionPollResult } from "../src/model";
 import { AgentInboxService } from "../src/service";
 import { AgentInboxStore } from "../src/store";
@@ -55,6 +56,18 @@ test("resolveServeConfig derives home, db, and socket defaults from AGENTINBOX_H
   });
 });
 
+test("resolveDaemonPaths derives pid and log files from AGENTINBOX_HOME", () => {
+  const homeDir = path.join(os.tmpdir(), `agentinbox-daemon-home-${Date.now()}`);
+  const paths = resolveDaemonPaths({
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+  });
+  assert.deepEqual(paths, {
+    pidPath: path.join(homeDir, "agentinbox.pid"),
+    logPath: path.join(homeDir, "agentinbox.log"),
+  });
+});
+
 test("resolveClientTransport prefers the default socket and otherwise falls back to localhost tcp", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-client-home-"));
   try {
@@ -83,6 +96,68 @@ test("resolveClientTransport prefers the default socket and otherwise falls back
       socketPath,
       source: "default",
     });
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("daemonStatus removes stale pid files", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-daemon-status-home-"));
+  const pidPath = path.join(homeDir, "agentinbox.pid");
+  fs.writeFileSync(pidPath, "999999\n", "utf8");
+  try {
+    const status = await daemonStatus({
+      env: {
+        ...process.env,
+        AGENTINBOX_HOME: homeDir,
+      },
+    });
+    assert.equal(status.running, false);
+    assert.equal(status.pid, null);
+    assert.equal(fs.existsSync(pidPath), false);
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli auto-starts the daemon for normal commands and daemon stop shuts it down", () => {
+  const repoDir = path.resolve(__dirname, "..");
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-autostart-home-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+  };
+  try {
+    const status = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "status"], {
+      cwd: repoDir,
+      env,
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    assert.equal(status.status, 0, status.stderr);
+    const parsedStatus = JSON.parse(status.stdout) as { counts?: { agents?: number } };
+    assert.equal(typeof parsedStatus.counts?.agents, "number");
+
+    const daemonState = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "daemon", "status"], {
+      cwd: repoDir,
+      env,
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    assert.equal(daemonState.status, 0, daemonState.stderr);
+    const parsedDaemon = JSON.parse(daemonState.stdout) as { running: boolean; pid: number | null };
+    assert.equal(parsedDaemon.running, true);
+    assert.ok(parsedDaemon.pid && parsedDaemon.pid > 0);
+
+    const stopped = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "daemon", "stop"], {
+      cwd: repoDir,
+      env,
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    assert.equal(stopped.status, 0, stopped.stderr);
+    const parsedStopped = JSON.parse(stopped.stdout) as { running: boolean };
+    assert.equal(parsedStopped.running, false);
   } finally {
     fs.rmSync(homeDir, { recursive: true, force: true });
   }

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -55,6 +55,8 @@ test("TerminalDispatcher uses two-step it2api submission for iTerm2 targets", as
       stdout: "sent\n",
       stderr: "",
     };
+  }, {
+    iterm2ApiPath: "/tmp/fake-it2api",
   });
 
   const target: TerminalActivationTarget = {


### PR DESCRIPTION
## Summary
- add daemon start/stop/status commands
- auto-start the local daemon for socket-backed CLI commands
- track pid/log files and clean up stale pid/socket state
- add CLI e2e coverage for auto-start and shutdown

## Verification
- npm run build
- npm test