### PR TITLE
Retry errored sources in background sync

### DIFF
--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -217,7 +217,7 @@ export class FeishuSourceRuntime {
   }
 
   private async syncAll(): Promise<void> {
-    const sources = this.store.listSources().filter((source) => source.sourceType === "feishu_bot" && source.status === "active");
+    const sources = this.store.listSources().filter((source) => source.sourceType === "feishu_bot");
     for (const source of sources) {
       try {
         await this.syncSource(source.sourceId);

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -222,7 +222,9 @@ export class FeishuSourceRuntime {
   }
 
   private async syncAll(): Promise<void> {
-    const sources = this.store.listSources().filter((source) => source.sourceType === "feishu_bot");
+    const sources = this.store
+      .listSources()
+      .filter((source) => source.sourceType === "feishu_bot" && source.status !== "paused");
     for (const source of sources) {
       try {
         await this.syncSource(source.sourceId);

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -13,6 +13,8 @@ const FEISHU_OPENAPI_ENDPOINT = "https://open.feishu.cn/open-apis";
 const FEISHU_IM_SCHEMA_URL =
   "https://raw.githubusercontent.com/holon-run/uxc/main/skills/feishu-openapi-skill/references/feishu-im.openapi.json";
 const DEFAULT_EVENT_TYPES = ["im.message.receive_v1"];
+const DEFAULT_SYNC_INTERVAL_SECS = 2;
+const MAX_ERROR_BACKOFF_MULTIPLIER = 8;
 
 export interface FeishuBotSourceConfig {
   endpoint?: string;
@@ -160,6 +162,8 @@ export class FeishuSourceRuntime {
   private readonly client: FeishuUxcClient;
   private interval: NodeJS.Timeout | null = null;
   private readonly inFlight = new Set<string>();
+  private readonly errorCounts = new Map<string, number>();
+  private readonly nextRetryAt = new Map<string, number>();
 
   constructor(
     private readonly store: AgentInboxStore,
@@ -213,6 +217,7 @@ export class FeishuSourceRuntime {
   status(): Record<string, unknown> {
     return {
       activeSourceIds: Array.from(this.inFlight.values()).sort(),
+      erroredSourceIds: Array.from(this.errorCounts.keys()).sort(),
     };
   }
 
@@ -245,6 +250,19 @@ export class FeishuSourceRuntime {
         throw new Error(`unknown source: ${sourceId}`);
       }
       const config = parseFeishuSourceConfig(source);
+      if (source.status === "error") {
+        const retryAt = this.nextRetryAt.get(sourceId) ?? 0;
+        if (Date.now() < retryAt) {
+          return {
+            sourceId,
+            sourceType: "feishu_bot",
+            appended: 0,
+            deduped: 0,
+            eventsRead: 0,
+            note: "error backoff not elapsed",
+          };
+        }
+      }
       let checkpoint = parseFeishuCheckpoint(source.checkpoint);
       const subscription = await this.client.ensureLongConnectionSubscription(config, checkpoint);
       if (subscription.job_id !== checkpoint.uxcJobId) {
@@ -277,6 +295,8 @@ export class FeishuSourceRuntime {
           lastError: null,
         }),
       });
+      this.errorCounts.delete(sourceId);
+      this.nextRetryAt.delete(sourceId);
 
       return {
         sourceId,
@@ -290,6 +310,12 @@ export class FeishuSourceRuntime {
       const source = this.store.getSource(sourceId);
       if (source) {
         const checkpoint = parseFeishuCheckpoint(source.checkpoint);
+        const nextErrorCount = (this.errorCounts.get(sourceId) ?? 0) + 1;
+        this.errorCounts.set(sourceId, nextErrorCount);
+        this.nextRetryAt.set(
+          sourceId,
+          Date.now() + computeErrorBackoffMs(DEFAULT_SYNC_INTERVAL_SECS, nextErrorCount),
+        );
         this.store.updateSourceRuntime(sourceId, {
           status: "error",
           checkpoint: JSON.stringify({
@@ -303,6 +329,12 @@ export class FeishuSourceRuntime {
       this.inFlight.delete(sourceId);
     }
   }
+}
+
+function computeErrorBackoffMs(syncIntervalSecs: number, errorCount: number): number {
+  const baseMs = Math.max(1, syncIntervalSecs) * 1000;
+  const multiplier = Math.min(2 ** Math.max(0, errorCount - 1), MAX_ERROR_BACKOFF_MULTIPLIER);
+  return baseMs * multiplier;
 }
 
 export class FeishuDeliveryAdapter {

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -16,6 +16,7 @@ const DEFAULT_EVENT_TYPES = [
   "PullRequestEvent",
   "PullRequestReviewCommentEvent",
 ];
+const MAX_ERROR_BACKOFF_MULTIPLIER = 8;
 
 export interface GithubSourceConfig {
   owner: string;
@@ -153,6 +154,8 @@ export class GithubSourceRuntime {
   private readonly client: GithubUxcClient;
   private interval: NodeJS.Timeout | null = null;
   private readonly inFlight = new Set<string>();
+  private readonly errorCounts = new Map<string, number>();
+  private readonly nextRetryAt = new Map<string, number>();
 
   constructor(
     private readonly store: AgentInboxStore,
@@ -206,6 +209,7 @@ export class GithubSourceRuntime {
   status(): Record<string, unknown> {
     return {
       activeSourceIds: Array.from(this.inFlight.values()).sort(),
+      erroredSourceIds: Array.from(this.errorCounts.keys()).sort(),
     };
   }
 
@@ -238,6 +242,19 @@ export class GithubSourceRuntime {
         throw new Error(`unknown source: ${sourceId}`);
       }
       const config = parseGithubSourceConfig(source);
+      if (source.status === "error") {
+        const retryAt = this.nextRetryAt.get(sourceId) ?? 0;
+        if (Date.now() < retryAt) {
+          return {
+            sourceId,
+            sourceType: "github_repo",
+            appended: 0,
+            deduped: 0,
+            eventsRead: 0,
+            note: "error backoff not elapsed",
+          };
+        }
+      }
       let checkpoint = parseGithubCheckpoint(source.checkpoint);
       const subscription = await this.client.ensureRepoEventsSubscription(config, checkpoint);
       if (subscription.job_id !== checkpoint.uxcJobId) {
@@ -270,6 +287,8 @@ export class GithubSourceRuntime {
           lastError: null,
         }),
       });
+      this.errorCounts.delete(sourceId);
+      this.nextRetryAt.delete(sourceId);
 
       return {
         sourceId,
@@ -283,6 +302,13 @@ export class GithubSourceRuntime {
       const source = this.store.getSource(sourceId);
       if (source) {
         const checkpoint = parseGithubCheckpoint(source.checkpoint);
+        const config = parseGithubSourceConfig(source);
+        const nextErrorCount = (this.errorCounts.get(sourceId) ?? 0) + 1;
+        this.errorCounts.set(sourceId, nextErrorCount);
+        this.nextRetryAt.set(
+          sourceId,
+          Date.now() + computeErrorBackoffMs(config.pollIntervalSecs ?? 30, nextErrorCount),
+        );
         this.store.updateSourceRuntime(sourceId, {
           status: "error",
           checkpoint: JSON.stringify({
@@ -296,6 +322,12 @@ export class GithubSourceRuntime {
       this.inFlight.delete(sourceId);
     }
   }
+}
+
+function computeErrorBackoffMs(pollIntervalSecs: number, errorCount: number): number {
+  const baseMs = Math.max(1, pollIntervalSecs) * 1000;
+  const multiplier = Math.min(2 ** Math.max(0, errorCount - 1), MAX_ERROR_BACKOFF_MULTIPLIER);
+  return baseMs * multiplier;
 }
 
 export class GithubDeliveryAdapter {

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -214,7 +214,9 @@ export class GithubSourceRuntime {
   }
 
   private async syncAll(): Promise<void> {
-    const sources = this.store.listSources().filter((source) => source.sourceType === "github_repo");
+    const sources = this.store
+      .listSources()
+      .filter((source) => source.sourceType === "github_repo" && source.status !== "paused");
     for (const source of sources) {
       try {
         await this.syncSource(source.sourceId);

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -210,7 +210,7 @@ export class GithubSourceRuntime {
   }
 
   private async syncAll(): Promise<void> {
-    const sources = this.store.listSources().filter((source) => source.sourceType === "github_repo" && source.status === "active");
+    const sources = this.store.listSources().filter((source) => source.sourceType === "github_repo");
     for (const source of sources) {
       try {
         await this.syncSource(source.sourceId);

--- a/src/sources/github_ci.ts
+++ b/src/sources/github_ci.ts
@@ -130,7 +130,9 @@ export class GithubCiSourceRuntime {
   }
 
   private async syncAll(): Promise<void> {
-    const sources = this.store.listSources().filter((source) => source.sourceType === "github_repo_ci");
+    const sources = this.store
+      .listSources()
+      .filter((source) => source.sourceType === "github_repo_ci" && source.status !== "paused");
     for (const source of sources) {
       try {
         await this.syncSource(source.sourceId, false);

--- a/src/sources/github_ci.ts
+++ b/src/sources/github_ci.ts
@@ -6,6 +6,7 @@ const GITHUB_ENDPOINT = "https://api.github.com";
 const DEFAULT_POLL_INTERVAL_SECS = 30;
 const DEFAULT_PER_PAGE = 20;
 const MAX_SEEN_KEYS = 512;
+const MAX_ERROR_BACKOFF_MULTIPLIER = 8;
 
 export interface GithubCiSourceConfig {
   owner: string;
@@ -74,6 +75,8 @@ export class GithubCiSourceRuntime {
   private interval: NodeJS.Timeout | null = null;
   private readonly inFlight = new Set<string>();
   private readonly lastPollAt = new Map<string, number>();
+  private readonly errorCounts = new Map<string, number>();
+  private readonly nextRetryAt = new Map<string, number>();
 
   constructor(
     private readonly store: AgentInboxStore,
@@ -122,6 +125,7 @@ export class GithubCiSourceRuntime {
   status(): Record<string, unknown> {
     return {
       activeSourceIds: Array.from(this.inFlight.values()).sort(),
+      erroredSourceIds: Array.from(this.errorCounts.keys()).sort(),
     };
   }
 
@@ -155,6 +159,17 @@ export class GithubCiSourceRuntime {
       }
       const config = parseGithubCiSourceConfig(source);
       if (!force) {
+        const retryAt = this.nextRetryAt.get(sourceId) ?? 0;
+        if (Date.now() < retryAt) {
+          return {
+            sourceId,
+            sourceType: "github_repo_ci",
+            appended: 0,
+            deduped: 0,
+            eventsRead: 0,
+            note: "error backoff not elapsed",
+          };
+        }
         const lastPollAt = this.lastPollAt.get(sourceId) ?? 0;
         const pollIntervalMs = (config.pollIntervalSecs ?? DEFAULT_POLL_INTERVAL_SECS) * 1000;
         if (Date.now() - lastPollAt < pollIntervalMs) {
@@ -208,6 +223,8 @@ export class GithubCiSourceRuntime {
           lastError: undefined,
         } satisfies GithubCiSourceCheckpoint),
       });
+      this.errorCounts.delete(sourceId);
+      this.nextRetryAt.delete(sourceId);
 
       return {
         sourceId,
@@ -221,6 +238,13 @@ export class GithubCiSourceRuntime {
       const source = this.store.getSource(sourceId);
       if (source) {
         const checkpoint = parseGithubCiCheckpoint(source.checkpoint);
+        const config = parseGithubCiSourceConfig(source);
+        const nextErrorCount = (this.errorCounts.get(sourceId) ?? 0) + 1;
+        this.errorCounts.set(sourceId, nextErrorCount);
+        this.nextRetryAt.set(
+          sourceId,
+          Date.now() + computeErrorBackoffMs(config.pollIntervalSecs ?? DEFAULT_POLL_INTERVAL_SECS, nextErrorCount),
+        );
         this.store.updateSourceRuntime(sourceId, {
           status: "error",
           checkpoint: JSON.stringify({
@@ -234,6 +258,12 @@ export class GithubCiSourceRuntime {
       this.inFlight.delete(sourceId);
     }
   }
+}
+
+function computeErrorBackoffMs(pollIntervalSecs: number, errorCount: number): number {
+  const baseMs = Math.max(1, pollIntervalSecs) * 1000;
+  const multiplier = Math.min(2 ** Math.max(0, errorCount - 1), MAX_ERROR_BACKOFF_MULTIPLIER);
+  return baseMs * multiplier;
 }
 
 export function normalizeGithubWorkflowRunEvent(

--- a/src/sources/github_ci.ts
+++ b/src/sources/github_ci.ts
@@ -126,7 +126,7 @@ export class GithubCiSourceRuntime {
   }
 
   private async syncAll(): Promise<void> {
-    const sources = this.store.listSources().filter((source) => source.sourceType === "github_repo_ci" && source.status === "active");
+    const sources = this.store.listSources().filter((source) => source.sourceType === "github_repo_ci");
     for (const source of sources) {
       try {
         await this.syncSource(source.sourceId, false);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -96,6 +96,9 @@ export function assignedAgentIdFromContext(input: {
 export class TerminalDispatcher {
   constructor(
     private readonly execAsync: ExecFileAsyncLike = execFileAsync,
+    private readonly options: {
+      iterm2ApiPath?: string;
+    } = {},
   ) {}
 
   async dispatch(target: TerminalActivationTarget, prompt: string): Promise<void> {
@@ -108,7 +111,7 @@ export class TerminalDispatcher {
     }
 
     if (target.backend === "iterm2") {
-      await dispatchToIterm2(target, prompt, this.execAsync);
+      await dispatchToIterm2(target, prompt, this.execAsync, this.options.iterm2ApiPath);
       return;
     }
 
@@ -305,20 +308,24 @@ async function dispatchToIterm2(
   target: TerminalActivationTarget,
   prompt: string,
   execAsync: ExecFileAsyncLike,
+  iterm2ApiPath?: string,
 ): Promise<void> {
   const sessionId = normalizeOptionalString(target.itermSessionId);
   if (!sessionId) {
     throw new Error(`iTerm2 terminal target ${target.targetId} is missing itermSessionId`);
   }
 
-  const it2api = resolveIterm2ApiPath();
+  const it2api = resolveIterm2ApiPath(iterm2ApiPath);
   await execAsync(it2api, ["send-text", sessionId, prompt]);
   // Background Codex/Claude sessions only submit reliably when Return is sent
   // in a second call rather than concatenated to the original prompt payload.
   await execAsync(it2api, ["send-text", sessionId, "\r"]);
 }
 
-function resolveIterm2ApiPath(): string {
+function resolveIterm2ApiPath(override?: string): string {
+  if (override) {
+    return override;
+  }
   const candidates = [
     "/Applications/iTerm.app/Contents/Resources/it2api",
     "/Applications/iTerm.app/Contents/Resources/utilities/it2api",

--- a/test/github_ci.test.ts
+++ b/test/github_ci.test.ts
@@ -15,9 +15,19 @@ class FakeGithubActionsClient {
   public calls: Array<Record<string, unknown>> = [];
   public workflowRuns: unknown[] = [];
   public error: Error | null = null;
+  public listWorkflowRunsImpl: ((args: Record<string, unknown>) => Promise<unknown[]>) | null = null;
 
   async call(args: Record<string, unknown>) {
     this.calls.push(args);
+    if (this.listWorkflowRunsImpl) {
+      const workflowRuns = await this.listWorkflowRunsImpl(args);
+      return {
+        data: {
+          total_count: workflowRuns.length,
+          workflow_runs: workflowRuns,
+        },
+      };
+    }
     if (this.error) {
       throw this.error;
     }
@@ -219,6 +229,68 @@ test("github_repo_ci runtime start does not crash when GitHub polling fails", as
 
     await runtime.stop();
   } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("github_repo_ci runtime retries errored sources and recovers after a transient failure", async () => {
+  const { store, service, dir } = await makeService();
+  let runtime: GithubCiSourceRuntime | null = null;
+  try {
+    const fake = new FakeGithubActionsClient();
+    let callCount = 0;
+    fake.listWorkflowRunsImpl = async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error("temporary github timeout");
+      }
+      return [
+        {
+          id: 1003,
+          workflow_id: 10,
+          name: "ci",
+          display_title: "ci / retry",
+          status: "completed",
+          conclusion: "success",
+          event: "push",
+          head_sha: "sha-retry",
+          head_branch: "main",
+          run_number: 3,
+          run_attempt: 1,
+          html_url: "https://github.com/holon-run/agentinbox/actions/runs/1003",
+          created_at: "2026-04-06T10:02:00Z",
+          updated_at: "2026-04-06T10:02:20Z",
+          actor: { login: "jolestar" },
+        },
+      ];
+    };
+    runtime = new GithubCiSourceRuntime(store, async (input) => service.appendSourceEvent(input), new GithubActionsUxcClient(fake));
+    const source: SubscriptionSource = {
+      sourceId: "src_ci_retry",
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      configRef: null,
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default", perPage: 10 },
+      status: "active",
+      checkpoint: null,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    store.insertSource(source);
+
+    await runtime.start();
+    const errored = store.getSource(source.sourceId);
+    assert.equal(errored?.status, "error");
+    assert.match(String(errored?.checkpoint), /temporary github timeout/);
+
+    await runtime.pollSource(source.sourceId);
+    const recovered = store.getSource(source.sourceId);
+    assert.equal(recovered?.status, "active");
+    assert.ok(!String(recovered?.checkpoint).includes("temporary github timeout"));
+  } finally {
+    await runtime?.stop();
     await service.stop();
     store.close();
     fs.rmSync(dir, { recursive: true, force: true });

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -55,6 +55,8 @@ test("TerminalDispatcher uses two-step it2api submission for iTerm2 targets", as
       stdout: "sent\n",
       stderr: "",
     };
+  }, {
+    iterm2ApiPath: "/tmp/fake-it2api",
   });
 
   const target: TerminalActivationTarget = {


### PR DESCRIPTION
## Summary
- keep github, github CI, and feishu background runtimes retrying after transient source errors
- let successful polls automatically recover sources back to active
- add coverage for github_repo_ci recovering after a transient failure

## Verification
- npm run build
- npm test