### PR TITLE
Refine inbox read, ack, and retention

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -271,15 +271,35 @@ async function main(): Promise<void> {
   if (command === "inbox" && normalized[1] === "ack") {
     const agentId = normalized[2];
     const itemId = takeFlagValue(normalized, "--item");
+    const throughItemId = takeFlagValue(normalized, "--through");
     const ackAll = hasFlag(normalized, "--all");
-    if (!agentId || (ackAll && itemId) || (!ackAll && !itemId)) {
-      throw new Error("usage: agentinbox inbox ack <agentId> (--item <itemId> | --all)");
+    const modeCount = Number(Boolean(itemId)) + Number(Boolean(throughItemId)) + Number(ackAll);
+    if (!agentId || modeCount !== 1) {
+      throw new Error("usage: agentinbox inbox ack <agentId> (--through <itemId> | --item <itemId> | --all)");
     }
     if (ackAll) {
       await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox/ack-all`, {});
       return;
     }
-    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox/ack`, { itemIds: [itemId] });
+    await printRemote(
+      client,
+      `/agents/${encodeURIComponent(agentId)}/inbox/ack`,
+      throughItemId ? { throughItemId } : { itemIds: [itemId] },
+    );
+    return;
+  }
+
+  if (command === "inbox" && normalized[1] === "compact") {
+    const agentId = normalized[2];
+    if (!agentId) {
+      throw new Error("usage: agentinbox inbox compact <agentId>");
+    }
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox/compact`, {});
+    return;
+  }
+
+  if (command === "gc") {
+    await printRemote(client, "/gc", {});
     return;
   }
 
@@ -457,6 +477,7 @@ Commands:
   agent
   subscription
   inbox
+  gc
   fixture
   deliver
   status
@@ -504,7 +525,8 @@ Usage:
   agentinbox inbox show <agentId>
   agentinbox inbox read <agentId> [--after-item ID] [--include-acked]
   agentinbox inbox watch <agentId> [--after-item ID] [--include-acked] [--heartbeat-ms N]
-  agentinbox inbox ack <agentId> (--item <itemId> | --all)
+  agentinbox inbox ack <agentId> (--through <itemId> | --item <itemId> | --all)
+  agentinbox inbox compact <agentId>
 `,
     fixture: `agentinbox fixture
 
@@ -520,6 +542,11 @@ Usage:
 
 Usage:
   agentinbox status
+`,
+    gc: `agentinbox gc
+
+Usage:
+  agentinbox gc
 `,
     version: `agentinbox version
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -50,6 +50,11 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
+      if (req.method === "POST" && url.pathname === "/gc") {
+        send(res, 200, service.gcAckedInboxItems());
+        return;
+      }
+
       if (req.method === "GET" && url.pathname === "/sources") {
         send(res, 200, { sources: service.listSources() });
         return;
@@ -285,10 +290,25 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
+      const agentInboxCompactMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/compact$/);
+      if (req.method === "POST" && agentInboxCompactMatch) {
+        send(res, 200, service.compactInbox(decodeURIComponent(agentInboxCompactMatch[1])));
+        return;
+      }
+
       const agentInboxAckMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/ack$/);
       if (req.method === "POST" && agentInboxAckMatch) {
         const body = await readJson(req);
         const itemIds = Array.isArray(body.itemIds) ? body.itemIds.map((itemId) => String(itemId)) : [];
+        const throughItemId = parseOptionalString(body.throughItemId);
+        if (throughItemId && itemIds.length > 0) {
+          send(res, 400, { error: "inbox/ack accepts either itemIds or throughItemId" });
+          return;
+        }
+        if (throughItemId) {
+          send(res, 200, service.ackInboxItemsThrough(decodeURIComponent(agentInboxAckMatch[1]), throughItemId));
+          return;
+        }
         send(res, 200, service.ackInboxItems(decodeURIComponent(agentInboxAckMatch[1]), itemIds));
         return;
       }

--- a/src/service.ts
+++ b/src/service.ts
@@ -43,6 +43,8 @@ const DEFAULT_ACTIVATION_WINDOW_MS = 3_000;
 const DEFAULT_ACTIVATION_MAX_ITEMS = 20;
 const DEFAULT_NOTIFY_LEASE_MS = 10 * 60 * 1000;
 const DEFAULT_NOTIFY_RETRY_MS = 5_000;
+const DEFAULT_ACKED_RETENTION_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_GC_INTERVAL_MS = 60 * 1000;
 const WEBHOOK_ACTIVATION_MODES = new Set<WebhookActivationTarget["mode"]>(["activation_only", "activation_with_items"]);
 const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
 
@@ -79,10 +81,12 @@ export class AgentInboxService {
   private readonly inFlightSubscriptions = new Set<string>();
   private readonly activationWindowMs: number;
   private readonly activationMaxItems: number;
+  private readonly ackedRetentionMs: number;
   private readonly notificationBuffers = new Map<string, BufferedNotification>();
   private readonly inboxWatchers = new Map<string, Set<InboxWatcher>>();
   private syncInterval: NodeJS.Timeout | null = null;
   private stopping = false;
+  private lastGcAt = 0;
 
   constructor(
     private readonly store: AgentInboxStore,
@@ -96,6 +100,7 @@ export class AgentInboxService {
     this.backend = backend ?? new SqliteEventBusBackend(store);
     this.activationWindowMs = activationPolicy?.windowMs ?? DEFAULT_ACTIVATION_WINDOW_MS;
     this.activationMaxItems = activationPolicy?.maxItems ?? DEFAULT_ACTIVATION_MAX_ITEMS;
+    this.ackedRetentionMs = DEFAULT_ACKED_RETENTION_MS;
     this.terminalDispatcher = terminalDispatcher;
   }
 
@@ -110,9 +115,11 @@ export class AgentInboxService {
     this.syncInterval = setInterval(() => {
       void this.syncAllSubscriptions();
       void this.syncActivationDispatchStates();
+      void this.runAckedInboxGcIfDue();
     }, 2_000);
     await this.syncAllSubscriptions();
     await this.syncActivationDispatchStates();
+    await this.runAckedInboxGcIfDue(true);
   }
 
   async stop(): Promise<void> {
@@ -538,6 +545,15 @@ export class AgentInboxService {
     return { acked };
   }
 
+  ackInboxItemsThrough(agentId: string, itemId: string): { acked: number } {
+    const inbox = this.ensureInboxForAgent(agentId);
+    const acked = this.store.ackItemsThrough(inbox.inboxId, itemId, nowIso());
+    if (acked > 0) {
+      void this.handleInboxAckEffects(agentId);
+    }
+    return { acked };
+  }
+
   ackAllInboxItems(agentId: string): { acked: number } {
     const inbox = this.ensureInboxForAgent(agentId);
     const itemIds = this.store.listInboxItems(inbox.inboxId, { includeAcked: false }).map((item) => item.itemId);
@@ -546,6 +562,21 @@ export class AgentInboxService {
       void this.handleInboxAckEffects(agentId);
     }
     return { acked };
+  }
+
+  compactInbox(agentId: string): { deleted: number; retentionMs: number } {
+    const inbox = this.ensureInboxForAgent(agentId);
+    return {
+      deleted: this.store.deleteAckedInboxItems(inbox.inboxId, retentionCutoffIso(this.ackedRetentionMs)),
+      retentionMs: this.ackedRetentionMs,
+    };
+  }
+
+  gcAckedInboxItems(): { deleted: number; retentionMs: number } {
+    return {
+      deleted: this.store.deleteAckedInboxItemsGlobal(retentionCutoffIso(this.ackedRetentionMs)),
+      retentionMs: this.ackedRetentionMs,
+    };
   }
 
   async pollSource(sourceId: string): Promise<SourcePollResult> {
@@ -699,6 +730,10 @@ export class AgentInboxService {
 
   status(): Record<string, unknown> {
     return {
+      retention: {
+        ackedInboxItemsMs: this.ackedRetentionMs,
+        gcIntervalMs: DEFAULT_GC_INTERVAL_MS,
+      },
       counts: this.store.getCounts(),
       agents: this.store.listAgents(),
       sources: this.store.listSources(),
@@ -737,6 +772,15 @@ export class AgentInboxService {
       unacked,
       acked: total - unacked,
     };
+  }
+
+  private async runAckedInboxGcIfDue(force = false): Promise<void> {
+    const now = Date.now();
+    if (!force && now - this.lastGcAt < DEFAULT_GC_INTERVAL_MS) {
+      return;
+    }
+    this.lastGcAt = now;
+    this.gcAckedInboxItems();
   }
 
   private async ensureStreamForSource(source: SubscriptionSource) {
@@ -1074,6 +1118,10 @@ export class AgentInboxService {
       }
     }
   }
+}
+
+function retentionCutoffIso(retentionMs: number): string {
+  return new Date(Date.now() - retentionMs).toISOString();
 }
 
 function resolveDeliveryHandle(request: DeliveryRequest): DeliveryHandle {

--- a/src/store.ts
+++ b/src/store.ts
@@ -28,7 +28,7 @@ import {
 } from "./model";
 import { generateId, nowIso } from "./util";
 
-const SCHEMA_VERSION = 8;
+const SCHEMA_VERSION = 9;
 type SqlBindParams = unknown[];
 
 function parseJson<T>(value: string | null): T {
@@ -289,6 +289,12 @@ export class AgentInboxStore {
 
       create index if not exists idx_activation_dispatch_states_target
         on activation_dispatch_states(target_id, lease_expires_at);
+
+      create index if not exists idx_inbox_items_acked_at
+        on inbox_items(acked_at);
+
+      create index if not exists idx_inbox_items_inbox_acked_at
+        on inbox_items(inbox_id, acked_at);
 
       create index if not exists idx_stream_events_stream_offset
         on stream_events(stream_id, offset);

--- a/src/store.ts
+++ b/src/store.ts
@@ -770,7 +770,7 @@ export class AgentInboxStore {
   }
 
   listInboxItems(inboxId: string, options?: ListInboxItemsOptions): InboxItem[] {
-    const includeAcked = options?.includeAcked ?? true;
+    const includeAcked = options?.includeAcked ?? false;
     const filters = ["inbox_id = ?"];
     const params: Array<string | number | null> = [inboxId];
 
@@ -810,6 +810,64 @@ export class AgentInboxStore {
       );
       changes += this.changes();
     }
+    if (changes > 0) {
+      this.persist();
+    }
+    return changes;
+  }
+
+  ackItemsThrough(inboxId: string, itemId: string, ackedAt: string): number {
+    const anchor = this.getOne(
+      "select occurred_at, item_id from inbox_items where inbox_id = ? and item_id = ?",
+      [inboxId, itemId],
+    );
+    if (!anchor) {
+      throw new Error(`unknown inbox item: ${itemId}`);
+    }
+    this.db.run(
+      `
+      update inbox_items
+      set acked_at = ?
+      where inbox_id = ?
+        and acked_at is null
+        and ((occurred_at < ?) or (occurred_at = ? and item_id <= ?))
+    `,
+      [ackedAt, inboxId, String(anchor.occurred_at), String(anchor.occurred_at), String(anchor.item_id)],
+    );
+    const changes = this.changes();
+    if (changes > 0) {
+      this.persist();
+    }
+    return changes;
+  }
+
+  deleteAckedInboxItems(inboxId: string, olderThan: string): number {
+    this.db.run(
+      `
+      delete from inbox_items
+      where inbox_id = ?
+        and acked_at is not null
+        and acked_at < ?
+    `,
+      [inboxId, olderThan],
+    );
+    const changes = this.changes();
+    if (changes > 0) {
+      this.persist();
+    }
+    return changes;
+  }
+
+  deleteAckedInboxItemsGlobal(olderThan: string): number {
+    this.db.run(
+      `
+      delete from inbox_items
+      where acked_at is not null
+        and acked_at < ?
+    `,
+      [olderThan],
+    );
+    const changes = this.changes();
     if (changes > 0) {
       this.persist();
     }

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -239,12 +239,17 @@ test("inbox read defaults to unacked items and ack through clears a processed ba
       startPolicy: "earliest",
     });
 
-    for (const id of ["evt-1", "evt-2", "evt-3"]) {
+    for (const event of [
+      { id: "evt-1", occurredAt: "2026-04-01T00:00:00.000Z" },
+      { id: "evt-2", occurredAt: "2026-04-01T00:00:01.000Z" },
+      { id: "evt-3", occurredAt: "2026-04-01T00:00:02.000Z" },
+    ]) {
       await service.appendSourceEventByCaller(source.sourceId, {
-        sourceNativeId: id,
+        sourceNativeId: event.id,
         eventVariant: "message.created",
         metadata: {},
-        rawPayload: { text: id },
+        rawPayload: { text: event.id },
+        occurredAt: event.occurredAt,
       });
     }
 

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -224,6 +224,114 @@ test("watchInbox receives inserted items without auto-acking them", async () => 
   }
 });
 
+test("inbox read defaults to unacked items and ack through clears a processed batch", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "5");
+    const source = await service.registerSource({
+      sourceType: "custom",
+      sourceKey: "ack-through-demo",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: alpha.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    for (const id of ["evt-1", "evt-2", "evt-3"]) {
+      await service.appendSourceEventByCaller(source.sourceId, {
+        sourceNativeId: id,
+        eventVariant: "message.created",
+        metadata: {},
+        rawPayload: { text: id },
+      });
+    }
+
+    const poll = await service.pollSubscription(subscription.subscriptionId);
+    assert.equal(poll.inboxItemsCreated, 3);
+
+    const allItems = service.listInboxItems(alpha.agentId, { includeAcked: true });
+    assert.equal(allItems.length, 3);
+
+    const ack = service.ackInboxItemsThrough(alpha.agentId, allItems[1].itemId);
+    assert.equal(ack.acked, 2);
+
+    const unread = service.listInboxItems(alpha.agentId);
+    assert.equal(unread.length, 1);
+    assert.equal(unread[0].sourceNativeId, "evt-3");
+
+    const history = service.listInboxItems(alpha.agentId, { includeAcked: true });
+    assert.equal(history.filter((item) => item.ackedAt !== null).length, 2);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("compact and gc remove only acked inbox items older than retention", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "6");
+    const beta = await registerTmuxAgent(service, "7");
+    const alphaInboxId = (service.getInboxDetailsByAgent(alpha.agentId) as { inbox: { inboxId: string } }).inbox.inboxId;
+    const betaInboxId = (service.getInboxDetailsByAgent(beta.agentId) as { inbox: { inboxId: string } }).inbox.inboxId;
+    const oldAckedAt = new Date(Date.now() - (25 * 60 * 60 * 1000)).toISOString();
+
+    store.insertInboxItem({
+      itemId: "item-alpha-old",
+      sourceId: "src-old",
+      sourceNativeId: "evt-alpha-old",
+      eventVariant: "message.created",
+      inboxId: alphaInboxId,
+      occurredAt: "2026-04-01T00:00:00Z",
+      metadata: {},
+      rawPayload: {},
+      deliveryHandle: null,
+      ackedAt: oldAckedAt,
+    });
+    store.insertInboxItem({
+      itemId: "item-alpha-live",
+      sourceId: "src-live",
+      sourceNativeId: "evt-alpha-live",
+      eventVariant: "message.created",
+      inboxId: alphaInboxId,
+      occurredAt: "2026-04-01T00:00:01Z",
+      metadata: {},
+      rawPayload: {},
+      deliveryHandle: null,
+      ackedAt: null,
+    });
+    store.insertInboxItem({
+      itemId: "item-beta-old",
+      sourceId: "src-old",
+      sourceNativeId: "evt-beta-old",
+      eventVariant: "message.created",
+      inboxId: betaInboxId,
+      occurredAt: "2026-04-01T00:00:00Z",
+      metadata: {},
+      rawPayload: {},
+      deliveryHandle: null,
+      ackedAt: oldAckedAt,
+    });
+
+    const compact = service.compactInbox(alpha.agentId);
+    assert.equal(compact.deleted, 1);
+    assert.equal(service.listInboxItems(alpha.agentId, { includeAcked: true }).length, 1);
+    assert.equal(service.listInboxItems(beta.agentId, { includeAcked: true }).length, 1);
+
+    const gc = service.gcAckedInboxItems();
+    assert.equal(gc.deleted, 1);
+    assert.equal(service.listInboxItems(beta.agentId, { includeAcked: true }).length, 0);
+    assert.equal(service.listInboxItems(alpha.agentId).length, 1);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("webhook and terminal targets share ack-gated notification flow", async () => {
   const dispatcher = new RecordingActivationDispatcher();
   const terminalDispatcher = new RecordingTerminalDispatcher();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -281,6 +281,115 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
   }
 });
 
+test("control plane exposes inbox compact and global gc endpoints", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-gc-home-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+
+      const agentResponse = await client.request<{
+        agent: { agentId: string };
+      }>("/agents/register", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-gc",
+        tmuxPaneId: "%55",
+        notifyLeaseMs: 200,
+      });
+      assert.equal(agentResponse.statusCode, 200);
+      const agentId = agentResponse.data.agent.agentId;
+      const inboxId = `inbox_${agentId}`;
+      const oldAckedAt = new Date(Date.now() - (25 * 60 * 60 * 1000)).toISOString();
+
+      store.insertInboxItem({
+        itemId: "item-old",
+        sourceId: "src-old",
+        sourceNativeId: "evt-old",
+        eventVariant: "message.created",
+        inboxId,
+        occurredAt: "2026-04-01T00:00:00Z",
+        metadata: {},
+        rawPayload: {},
+        deliveryHandle: null,
+        ackedAt: oldAckedAt,
+      });
+      store.insertInboxItem({
+        itemId: "item-live",
+        sourceId: "src-live",
+        sourceNativeId: "evt-live",
+        eventVariant: "message.created",
+        inboxId,
+        occurredAt: "2026-04-01T00:00:01Z",
+        metadata: {},
+        rawPayload: {},
+        deliveryHandle: null,
+        ackedAt: null,
+      });
+
+      const compactResponse = await client.request<{ deleted: number; retentionMs: number }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/compact`,
+        {},
+      );
+      assert.equal(compactResponse.statusCode, 200);
+      assert.equal(compactResponse.data.deleted, 1);
+
+      const compactRead = await client.request<{ items: InboxItem[] }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/items?include_acked=true`,
+        undefined,
+        "GET",
+      );
+      assert.equal(compactRead.statusCode, 200);
+      assert.equal(compactRead.data.items.length, 1);
+
+      store.insertInboxItem({
+        itemId: "item-old-global",
+        sourceId: "src-old-global",
+        sourceNativeId: "evt-old-global",
+        eventVariant: "message.created",
+        inboxId,
+        occurredAt: "2026-04-01T00:00:02Z",
+        metadata: {},
+        rawPayload: {},
+        deliveryHandle: null,
+        ackedAt: oldAckedAt,
+      });
+
+      const gcResponse = await client.request<{ deleted: number; retentionMs: number }>(
+        "/gc",
+        {},
+      );
+      assert.equal(gcResponse.statusCode, 200);
+      assert.equal(gcResponse.data.deleted, 1);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 async function waitFor<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: NodeJS.Timeout | null = null;
   const timeout = new Promise<never>((_, reject) => {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -248,11 +248,27 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(inboxResponse.data.items.length, 1);
 
       const ackResponse = await client.request<{ acked: number }>(
-        `/agents/${encodeURIComponent(agentId)}/inbox/ack-all`,
-        {},
+        `/agents/${encodeURIComponent(agentId)}/inbox/ack`,
+        { throughItemId: inboxResponse.data.items[0].itemId },
       );
       assert.equal(ackResponse.statusCode, 200);
       assert.equal(ackResponse.data.acked, 1);
+
+      const unreadAfterAck = await client.request<{ items: InboxItem[] }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/items`,
+        undefined,
+        "GET",
+      );
+      assert.equal(unreadAfterAck.statusCode, 200);
+      assert.equal(unreadAfterAck.data.items.length, 0);
+
+      const historyAfterAck = await client.request<{ items: InboxItem[] }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/items?include_acked=true`,
+        undefined,
+        "GET",
+      );
+      assert.equal(historyAfterAck.statusCode, 200);
+      assert.equal(historyAfterAck.data.items.length, 1);
 
     } finally {
       await started.close();


### PR DESCRIPTION
## Summary
- make inbox read default to unacked items
- add ack-through semantics for batch processing
- add acked-item retention gc and inbox compact commands

## Verification
- npm run build
- npm test