### PR TITLE
feat: support subscription removal and lifecycle metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ agentinbox source event <source_id> --native-id demo-1 --event custom.demo
 agentinbox inbox read <agent_id>
 ```
 
+Remove a task-specific subscription without deleting the whole agent:
+
+```bash
+agentinbox subscription remove <subscription_id>
+```
+
 ## Docs
 
 Public docs now live under [`docs/site`](./docs/site) and are structured for

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -120,6 +120,7 @@ export interface EventBusBackend {
   append(input: AppendEventsInput): Promise<AppendEventsResult>;
   ensureConsumer(input: EnsureConsumerInput): Promise<ConsumerRecord>;
   getConsumer(input: GetConsumerInput): Promise<ConsumerRecord | null>;
+  deleteConsumer(input: GetConsumerInput): Promise<{ removed: boolean }>;
   read(input: ReadEventsInput): Promise<ReadEventsResult>;
   commit(input: CommitOffsetInput): Promise<CommitOffsetResult>;
   reset(input: ResetConsumerInput): Promise<ConsumerRecord>;
@@ -194,6 +195,15 @@ export class SqliteEventBusBackend implements EventBusBackend {
       return this.store.getConsumerBySubscriptionId(input.subscriptionId);
     }
     throw new Error("getConsumer requires consumerId or subscriptionId");
+  }
+
+  async deleteConsumer(input: GetConsumerInput): Promise<{ removed: boolean }> {
+    const consumer = await this.getConsumer(input);
+    if (!consumer) {
+      return { removed: false };
+    }
+    this.store.deleteConsumer(consumer.consumerId);
+    return { removed: true };
   }
 
   async read(input: ReadEventsInput): Promise<ReadEventsResult> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -219,6 +219,15 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "subscription" && normalized[1] === "remove") {
+    const subscriptionId = normalized[2];
+    if (!subscriptionId) {
+      throw new Error("usage: agentinbox subscription remove <subscriptionId>");
+    }
+    await printRemote(client, `/subscriptions/${encodeURIComponent(subscriptionId)}`, undefined, "DELETE");
+    return;
+  }
+
   if (command === "subscription" && normalized[1] === "poll") {
     const subscriptionId = normalized[2];
     if (!subscriptionId) {
@@ -595,6 +604,7 @@ Usage:
   agentinbox subscription add <agentId> <sourceId> [--filter-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
   agentinbox subscription list [--source-id ID] [--agent-id ID]
   agentinbox subscription show <subscriptionId>
+  agentinbox subscription remove <subscriptionId>
   agentinbox subscription poll <subscriptionId>
   agentinbox subscription lag <subscriptionId>
   agentinbox subscription reset <subscriptionId> --start-policy latest|earliest|at_offset|at_time [--start-offset N] [--start-time ISO8601]

--- a/src/http.ts
+++ b/src/http.ts
@@ -406,6 +406,7 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("agents/register requires") ||
     message.startsWith("agents/targets requires") ||
     message.startsWith("unsupported activation target kind") ||
+    message.startsWith("unsupported lifecycle mode") ||
     message.startsWith("unsupported start policy") ||
     message.startsWith("unsupported terminal") ||
     message.startsWith("expected integer") ||

--- a/src/http.ts
+++ b/src/http.ts
@@ -182,6 +182,8 @@ export function createServer(service: AgentInboxService): http.Server {
           agentId: parseRequiredString(body.agentId, "subscriptions/register requires agentId"),
           sourceId: parseRequiredString(body.sourceId, "subscriptions/register requires sourceId"),
           filter: asObject(body.filter),
+          lifecycleMode: parseOptionalString(body.lifecycleMode) as never,
+          expiresAt: parseOptionalString(body.expiresAt) ?? null,
           startPolicy: parseOptionalString(body.startPolicy) as never,
           startOffset: parseOptionalInteger(body.startOffset),
           startTime: parseOptionalString(body.startTime) ?? undefined,
@@ -192,6 +194,10 @@ export function createServer(service: AgentInboxService): http.Server {
       const subscriptionMatch = url.pathname.match(/^\/subscriptions\/([^/]+)$/);
       if (req.method === "GET" && subscriptionMatch) {
         send(res, 200, await service.getSubscriptionDetails(decodeURIComponent(subscriptionMatch[1])));
+        return;
+      }
+      if (req.method === "DELETE" && subscriptionMatch) {
+        send(res, 200, await service.removeSubscription(decodeURIComponent(subscriptionMatch[1])));
         return;
       }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,7 @@
 export type SourceType = "fixture" | "custom" | "github_repo" | "github_repo_ci" | "feishu_bot";
 
 export type SubscriptionStartPolicy = "latest" | "earliest" | "at_offset" | "at_time";
+export type SubscriptionLifecycleMode = "standing" | "temporary";
 export type ActivationMode = "activation_only" | "activation_with_items";
 export type TerminalBackend = "tmux" | "iterm2";
 export type TerminalMode = "agent_prompt";
@@ -58,6 +59,8 @@ export interface Subscription {
   agentId: string;
   sourceId: string;
   filter: SubscriptionFilter;
+  lifecycleMode: SubscriptionLifecycleMode;
+  expiresAt?: string | null;
   startPolicy: SubscriptionStartPolicy;
   startOffset?: number | null;
   startTime?: string | null;
@@ -200,6 +203,8 @@ export interface RegisterSubscriptionInput {
   agentId: string;
   sourceId: string;
   filter?: SubscriptionFilter;
+  lifecycleMode?: SubscriptionLifecycleMode;
+  expiresAt?: string | null;
   startPolicy?: SubscriptionStartPolicy;
   startOffset?: number | null;
   startTime?: string | null;

--- a/src/service.ts
+++ b/src/service.ts
@@ -50,6 +50,7 @@ const DEFAULT_OFFLINE_AGENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_GC_INTERVAL_MS = 60 * 1000;
 const WEBHOOK_ACTIVATION_MODES = new Set<WebhookActivationTarget["mode"]>(["activation_only", "activation_with_items"]);
 const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
+const SUBSCRIPTION_LIFECYCLE_MODES = new Set<Subscription["lifecycleMode"]>(["standing", "temporary"]);
 
 interface ActivationPolicy {
   windowMs?: number;
@@ -355,11 +356,17 @@ export class AgentInboxService {
       throw new Error(`unknown source: ${input.sourceId}`);
     }
     await validateSubscriptionFilter(input.filter ?? {});
+    const lifecycleMode = input.lifecycleMode ?? "standing";
+    if (!SUBSCRIPTION_LIFECYCLE_MODES.has(lifecycleMode)) {
+      throw new Error(`unsupported lifecycle mode: ${lifecycleMode}`);
+    }
     const subscription: Subscription = {
       subscriptionId: generateId("sub"),
       agentId: input.agentId,
       sourceId: input.sourceId,
       filter: input.filter ?? {},
+      lifecycleMode,
+      expiresAt: input.expiresAt ?? null,
       startPolicy: input.startPolicy ?? "latest",
       startOffset: input.startOffset ?? null,
       startTime: input.startTime ?? null,
@@ -378,6 +385,14 @@ export class AgentInboxService {
       startTime: subscription.startTime ?? null,
     });
     return subscription;
+  }
+
+  async removeSubscription(subscriptionId: string): Promise<{ removed: boolean; subscriptionId: string }> {
+    const subscription = this.getSubscription(subscriptionId);
+    await this.backend.deleteConsumer({ subscriptionId });
+    this.store.deleteSubscription(subscriptionId);
+    this.clearSubscriptionRuntimeState(subscription);
+    return { removed: true, subscriptionId };
   }
 
   listSubscriptions(filters?: {
@@ -952,6 +967,31 @@ export class AgentInboxService {
         buffer.timer = null;
       }
       void this.flushNotificationBuffer(key);
+    }
+  }
+
+  private clearSubscriptionRuntimeState(subscription: Subscription): void {
+    for (const [key, buffer] of this.notificationBuffers.entries()) {
+      const retained = buffer.pending.filter((entry) => entry.subscriptionId !== subscription.subscriptionId);
+      if (retained.length === buffer.pending.length) {
+        continue;
+      }
+      buffer.pending = retained;
+      if (buffer.pending.length === 0) {
+        if (buffer.timer) {
+          clearTimeout(buffer.timer);
+          buffer.timer = null;
+        }
+        this.notificationBuffers.delete(key);
+      }
+    }
+
+    const states = this.store.listActivationDispatchStatesForAgent(subscription.agentId);
+    for (const state of states) {
+      // Dispatch state is stored per target rather than per subscription.
+      // Once a subscription is removed, we cannot safely attribute notified
+      // lease state back to a specific subscription, so drop it conservatively.
+      this.store.deleteActivationDispatchState(state.agentId, state.targetId);
     }
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -986,11 +986,17 @@ export class AgentInboxService {
       }
     }
 
+    const remainingSubscriptions = this.store.listSubscriptionsForAgent(subscription.agentId);
     const states = this.store.listActivationDispatchStatesForAgent(subscription.agentId);
     for (const state of states) {
+      const directlyReferencesRemovedSubscription = state.pendingSubscriptionIds.includes(subscription.subscriptionId);
+      if (!directlyReferencesRemovedSubscription && remainingSubscriptions.length > 0) {
+        continue;
+      }
       // Dispatch state is stored per target rather than per subscription.
-      // Once a subscription is removed, we cannot safely attribute notified
-      // lease state back to a specific subscription, so drop it conservatively.
+      // Drop states that still directly reference the removed subscription.
+      // If the agent has no subscriptions left, also clear any residual lease
+      // state so future subscriptions do not inherit a stale notified window.
       this.store.deleteActivationDispatchState(state.agentId, state.targetId);
     }
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,7 +29,7 @@ import {
 } from "./model";
 import { generateId, nowIso } from "./util";
 
-const SCHEMA_VERSION = 10;
+const SCHEMA_VERSION = 11;
 type SqlBindParams = unknown[];
 
 function parseJson<T>(value: string | null): T {
@@ -157,6 +157,8 @@ export class AgentInboxStore {
         agent_id text not null,
         source_id text not null,
         filter_json text not null,
+        lifecycle_mode text not null,
+        expires_at text,
         start_policy text not null,
         start_offset integer,
         start_time text,
@@ -524,14 +526,16 @@ export class AgentInboxStore {
     this.db.run(
       `
       insert into subscriptions (
-        subscription_id, agent_id, source_id, filter_json, start_policy, start_offset, start_time, created_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?)
+        subscription_id, agent_id, source_id, filter_json, lifecycle_mode, expires_at, start_policy, start_offset, start_time, created_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         subscription.subscriptionId,
         subscription.agentId,
         subscription.sourceId,
         JSON.stringify(subscription.filter),
+        subscription.lifecycleMode,
+        subscription.expiresAt ?? null,
         subscription.startPolicy,
         subscription.startOffset ?? null,
         subscription.startTime ?? null,
@@ -560,6 +564,16 @@ export class AgentInboxStore {
       [agentId],
     );
     return rows.map((row) => this.mapSubscription(row));
+  }
+
+  deleteSubscription(subscriptionId: string): Subscription | null {
+    const subscription = this.getSubscription(subscriptionId);
+    if (!subscription) {
+      return null;
+    }
+    this.db.run("delete from subscriptions where subscription_id = ?", [subscriptionId]);
+    this.persist();
+    return subscription;
   }
 
   getActivationTarget(targetId: string): ActivationTarget | null {
@@ -1221,6 +1235,14 @@ export class AgentInboxStore {
     return rows.map((row) => this.mapConsumer(row));
   }
 
+  deleteConsumer(consumerId: string): void {
+    this.inTransaction(() => {
+      this.db.run("delete from consumer_commits where consumer_id = ?", [consumerId]);
+      this.db.run("delete from consumers where consumer_id = ?", [consumerId]);
+    });
+    this.persist();
+  }
+
   updateConsumerOffset(consumerId: string, nextOffset: number, committedOffset: number): ConsumerRecord {
     const consumer = this.getConsumer(consumerId);
     if (!consumer) {
@@ -1375,6 +1397,8 @@ export class AgentInboxStore {
       agentId: String(row.agent_id),
       sourceId: String(row.source_id),
       filter: parseJson<SubscriptionFilter>(row.filter_json as string),
+      lifecycleMode: row.lifecycle_mode as Subscription["lifecycleMode"],
+      expiresAt: row.expires_at ? String(row.expires_at) : null,
       startPolicy: row.start_policy as SubscriptionStartPolicy,
       startOffset: row.start_offset != null ? Number(row.start_offset) : null,
       startTime: row.start_time ? String(row.start_time) : null,

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -191,6 +191,70 @@ test("custom source can act as a programmable event bus source", async () => {
   }
 });
 
+test("subscription remove deletes the subscription, its consumer, and transient runtime state", async () => {
+  const dispatcher = new RecordingActivationDispatcher();
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { store, service, dir } = await makeService({
+    dispatcher,
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-remove-sub",
+      tmuxPaneId: "%333",
+      notifyLeaseMs: 100,
+    });
+    service.addWebhookActivationTarget(registered.agent.agentId, {
+      url: "http://127.0.0.1:9999/webhook",
+      activationMode: "activation_with_items",
+      notifyLeaseMs: 100,
+    });
+    const source = await service.registerSource({
+      sourceType: "custom",
+      sourceKey: "remove-sub-demo",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      lifecycleMode: "temporary",
+      startPolicy: "earliest",
+    });
+
+    assert.equal(subscription.lifecycleMode, "temporary");
+    assert.equal(store.getConsumerBySubscriptionId(subscription.subscriptionId)?.subscriptionId, subscription.subscriptionId);
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-remove-sub-1",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(store.listActivationDispatchStatesForAgent(registered.agent.agentId).length > 0, true);
+    const removed = await service.removeSubscription(subscription.subscriptionId);
+    assert.equal(removed.removed, true);
+    assert.equal(store.getSubscription(subscription.subscriptionId), null);
+    assert.equal(store.getConsumerBySubscriptionId(subscription.subscriptionId), null);
+    assert.equal(store.listActivationDispatchStatesForAgent(registered.agent.agentId).length, 0);
+
+    await assert.rejects(
+      service.pollSubscription(subscription.subscriptionId),
+      /unknown subscription/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("subscription filter expr can match nested payload fields and exclude self-authored events", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -9,6 +9,7 @@ import { Activation, ActivationTarget, AppendSourceEventInput, Subscription, Ter
 import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
+import { nowIso } from "../src/util";
 
 class RecordingActivationDispatcher extends ActivationDispatcher {
   public readonly calls: Array<{ targetUrl: string; activation: Activation }> = [];
@@ -248,6 +249,62 @@ test("subscription remove deletes the subscription, its consumer, and transient 
       service.pollSubscription(subscription.subscriptionId),
       /unknown subscription/,
     );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("subscription remove preserves unrelated activation dispatch state", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-remove-sub-state",
+      tmuxPaneId: "%334",
+      notifyLeaseMs: 100,
+    });
+    const source = await service.registerSource({
+      sourceType: "custom",
+      sourceKey: "remove-sub-state-demo",
+      config: {},
+    });
+    const first = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      lifecycleMode: "standing",
+      startPolicy: "earliest",
+    });
+    const second = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      lifecycleMode: "temporary",
+      startPolicy: "earliest",
+    });
+
+    store.upsertActivationDispatchState({
+      agentId: registered.agent.agentId,
+      targetId: registered.terminalTarget.targetId,
+      status: "notified",
+      leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+      pendingNewItemCount: 1,
+      pendingSummary: "standing-subscription",
+      pendingSubscriptionIds: [first.subscriptionId],
+      pendingSourceIds: [source.sourceId],
+      updatedAt: nowIso(),
+    });
+
+    const removed = await service.removeSubscription(second.subscriptionId);
+    assert.equal(removed.removed, true);
+
+    const state = store.getActivationDispatchState(
+      registered.agent.agentId,
+      registered.terminalTarget.targetId,
+    );
+    assert.ok(state);
+    assert.deepEqual(state.pendingSubscriptionIds, [first.subscriptionId]);
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -354,6 +354,22 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(historyAfterAck.statusCode, 200);
       assert.equal(historyAfterAck.data.items.length, 1);
 
+      const removeSubscriptionResponse = await client.request<{ removed: boolean; subscriptionId: string }>(
+        `/subscriptions/${encodeURIComponent(subscriptionResponse.data.subscriptionId)}`,
+        undefined,
+        "DELETE",
+      );
+      assert.equal(removeSubscriptionResponse.statusCode, 200);
+      assert.equal(removeSubscriptionResponse.data.removed, true);
+
+      const subscriptionsAfterDelete = await client.request<{ subscriptions: Array<{ subscriptionId: string }> }>(
+        `/subscriptions?agent_id=${encodeURIComponent(agentId)}`,
+        undefined,
+        "GET",
+      );
+      assert.equal(subscriptionsAfterDelete.statusCode, 200);
+      assert.equal(subscriptionsAfterDelete.data.subscriptions.length, 0);
+
     } finally {
       await started.close();
     }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -370,6 +370,14 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(subscriptionsAfterDelete.statusCode, 200);
       assert.equal(subscriptionsAfterDelete.data.subscriptions.length, 0);
 
+      const invalidLifecycleResponse = await client.request<{ error: string }>("/subscriptions/register", {
+        agentId,
+        sourceId: sourceResponse.data.sourceId,
+        lifecycleMode: "ephemeral",
+      });
+      assert.equal(invalidLifecycleResponse.statusCode, 400);
+      assert.match(invalidLifecycleResponse.data.error, /unsupported lifecycle mode/);
+
     } finally {
       await started.close();
     }


### PR DESCRIPTION
## Summary
- add explicit subscription removal over CLI, HTTP, and service/store/backend layers
- delete the associated consumer when removing a subscription and clear transient subscription-related runtime state
- add minimal lifecycle metadata on subscriptions for future temporary/expiry support

## Details
- add `agentinbox subscription remove <subscriptionId>`
- add `DELETE /subscriptions/:id`
- add backend/store deletion support for subscription consumers
- add `lifecycleMode` and `expiresAt` fields to the subscription model and persistence schema, defaulting to standing subscriptions
- conservatively clear per-target activation dispatch state on subscription removal because lease state is not tracked per subscription
- update README and extend service/control-plane tests

## Verification
- `npm install`
- `npm run build`
- `npm test`

Closes #25
