### PR TITLE
feat: allow caller-supplied agent ids on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Register the current terminal session:
 
 ```bash
 agentinbox agent register
+agentinbox agent register --agent-id agent-alpha
 ```
 
 Create a local source and publish an event:

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -51,6 +51,7 @@ Register the current terminal session as an agent:
 
 ```bash
 agentinbox agent register
+agentinbox agent register --agent-id agent-alpha
 ```
 
 This detects the current runtime and terminal context, assigns or restores an

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -26,7 +26,7 @@ agentinbox daemon status
 ## Agent
 
 ```bash
-agentinbox agent register
+agentinbox agent register [--agent-id ID] [--force-rebind]
 agentinbox agent list
 agentinbox agent show <agent_id>
 agentinbox agent remove <agent_id>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,6 +117,8 @@ async function main(): Promise<void> {
   if (command === "agent" && normalized[1] === "register") {
     const detected = detectTerminalContext(process.env);
     await printRemote(client, "/agents/register", {
+      agentId: takeFlagValue(normalized, "--agent-id") ?? null,
+      forceRebind: normalized.includes("--force-rebind"),
       backend: detected.backend,
       runtimeKind: detected.runtimeKind,
       runtimeSessionId: detected.runtimeSessionId ?? null,
@@ -590,7 +592,7 @@ Usage:
     agent: `agentinbox agent
 
 Usage:
-  agentinbox agent register [--notify-lease-ms N]
+  agentinbox agent register [--agent-id ID] [--force-rebind] [--notify-lease-ms N]
   agentinbox agent list
   agentinbox agent show <agentId>
   agentinbox agent remove <agentId>

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -28,7 +28,7 @@ export interface DaemonStatusResult {
   transport: ClientTransport;
 }
 
-const START_TIMEOUT_MS = 5_000;
+const START_TIMEOUT_MS = 15_000;
 
 export async function ensureDaemonForClient(options: DaemonCliOptions = {}): Promise<ClientTransport> {
   const transport = resolveDaemonClientTransport(options);

--- a/src/http.ts
+++ b/src/http.ts
@@ -109,6 +109,8 @@ export function createServer(service: AgentInboxService): http.Server {
         const body = await readJson(req);
         const backend = parseRequiredString(body.backend, "agents/register requires backend");
         send(res, 200, service.registerAgent({
+          agentId: parseOptionalString(body.agentId) ?? null,
+          forceRebind: Boolean(body.forceRebind),
           backend: backend as never,
           runtimeKind: parseOptionalString(body.runtimeKind) as never,
           runtimeSessionId: parseOptionalString(body.runtimeSessionId),
@@ -405,6 +407,7 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("subscriptions/reset requires") ||
     message.startsWith("agents/register requires") ||
     message.startsWith("agents/targets requires") ||
+    message.startsWith("agent register conflict") ||
     message.startsWith("unsupported activation target kind") ||
     message.startsWith("unsupported lifecycle mode") ||
     message.startsWith("unsupported start policy") ||

--- a/src/http.ts
+++ b/src/http.ts
@@ -110,7 +110,7 @@ export function createServer(service: AgentInboxService): http.Server {
         const backend = parseRequiredString(body.backend, "agents/register requires backend");
         send(res, 200, service.registerAgent({
           agentId: parseOptionalString(body.agentId) ?? null,
-          forceRebind: Boolean(body.forceRebind),
+          forceRebind: parseOptionalBoolean(body.forceRebind) ?? false,
           backend: backend as never,
           runtimeKind: parseOptionalString(body.runtimeKind) as never,
           runtimeSessionId: parseOptionalString(body.runtimeSessionId),
@@ -390,6 +390,16 @@ function parseOptionalInteger(value: unknown): number | undefined {
   return parsed;
 }
 
+function parseOptionalBoolean(value: unknown): boolean | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(`expected boolean, received ${String(value)}`);
+  }
+  return value;
+}
+
 function parsePositiveInteger(value: unknown): number {
   const parsed = parseOptionalInteger(value);
   if (parsed == null || parsed <= 0) {
@@ -412,6 +422,7 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("unsupported lifecycle mode") ||
     message.startsWith("unsupported start policy") ||
     message.startsWith("unsupported terminal") ||
+    message.startsWith("expected boolean") ||
     message.startsWith("expected integer") ||
     message.startsWith("expected positive integer") ||
     message.startsWith("notifyLeaseMs must be a positive integer") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -176,6 +176,8 @@ export interface RegisterSourceInput {
 }
 
 export interface RegisterAgentInput {
+  agentId?: string | null;
+  forceRebind?: boolean;
   runtimeKind?: RuntimeKind | null;
   runtimeSessionId?: string | null;
   backend: TerminalBackend;

--- a/src/service.ts
+++ b/src/service.ts
@@ -200,7 +200,7 @@ export class AgentInboxService {
     validateTerminalRegistration(input);
 
     const runtimeKind = input.runtimeKind ?? "unknown";
-    const agentId = assignedAgentIdFromContext({
+    const agentId = input.agentId ?? assignedAgentIdFromContext({
       runtimeKind,
       runtimeSessionId: input.runtimeSessionId ?? null,
       backend: input.backend,
@@ -209,6 +209,7 @@ export class AgentInboxService {
       tty: input.tty ?? null,
     });
     const now = nowIso();
+    this.handleAgentRegistrationConflicts(agentId, input);
     const existingAgent = this.store.getAgent(agentId);
     const agent = existingAgent
       ? this.store.updateAgent(agentId, {
@@ -878,6 +879,36 @@ export class AgentInboxService {
     }
   }
 
+  private handleAgentRegistrationConflicts(agentId: string, input: RegisterAgentInput): void {
+    const currentTarget = findExistingTerminalActivationTarget(this.store, input);
+    if (currentTarget && currentTarget.agentId !== agentId) {
+      if (!input.forceRebind) {
+        throw new Error(
+          `agent register conflict: current terminal target ${currentTarget.targetId} is already bound to agent ${currentTarget.agentId}; retry with forceRebind to rebind`,
+        );
+      }
+      this.store.deleteActivationTarget(currentTarget.agentId, currentTarget.targetId);
+      this.reconcileAgentStatus(currentTarget.agentId);
+    }
+
+    const conflictingTargets = this.store
+      .listActivationTargetsForAgent(agentId)
+      .filter((target): target is TerminalActivationTarget => target.kind === "terminal")
+      .filter((target) => !isSameTerminalIdentity(target, input));
+
+    if (conflictingTargets.length > 0 && !input.forceRebind) {
+      throw new Error(
+        `agent register conflict: agent ${agentId} is already bound to terminal target ${conflictingTargets[0].targetId}; retry with forceRebind to rebind`,
+      );
+    }
+
+    if (input.forceRebind) {
+      for (const target of conflictingTargets) {
+        this.store.deleteActivationTarget(agentId, target.targetId);
+      }
+    }
+  }
+
   private upsertTerminalActivationTarget(agentId: string, input: RegisterAgentInput, now: string): TerminalActivationTarget {
     const existing = findExistingTerminalActivationTarget(this.store, input);
     if (existing) {
@@ -1448,6 +1479,24 @@ function findExistingTerminalActivationTarget(store: AgentInboxStore, input: Reg
     }
   }
   return null;
+}
+
+function isSameTerminalIdentity(target: TerminalActivationTarget, input: RegisterAgentInput): boolean {
+  if (input.runtimeSessionId && target.runtimeKind === (input.runtimeKind ?? "unknown") && target.runtimeSessionId === input.runtimeSessionId) {
+    return true;
+  }
+  if (input.backend === "tmux" && input.tmuxPaneId && target.backend === "tmux" && target.tmuxPaneId === input.tmuxPaneId) {
+    return true;
+  }
+  if (input.backend === "iterm2" && target.backend === "iterm2") {
+    if (input.itermSessionId && target.itermSessionId === input.itermSessionId) {
+      return true;
+    }
+    if (input.tty && target.tty === input.tty) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function uniqueSorted(values: string[]): string[] {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -113,6 +113,96 @@ test("agent register creates a stable agent, inbox, and terminal activation targ
   }
 });
 
+test("agent register accepts caller-supplied agent ids and upserts the same logical agent", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const first = service.registerAgent({
+      agentId: "agent-alpha",
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-agent-alpha",
+      tmuxPaneId: "%501",
+    });
+    const second = service.registerAgent({
+      agentId: "agent-alpha",
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-agent-alpha",
+      tmuxPaneId: "%501",
+    });
+
+    assert.equal(first.agent.agentId, "agent-alpha");
+    assert.equal(second.agent.agentId, "agent-alpha");
+    assert.equal(second.terminalTarget.targetId, first.terminalTarget.targetId);
+    assert.equal(store.listAgents().length, 1);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("agent register rejects caller-supplied agent id conflicts without force rebind", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    service.registerAgent({
+      agentId: "agent-alpha",
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-agent-alpha",
+      tmuxPaneId: "%502",
+    });
+
+    await assert.rejects(async () => {
+      service.registerAgent({
+        agentId: "agent-alpha",
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-agent-alpha-rebound",
+        tmuxPaneId: "%503",
+      });
+    }, /agent register conflict/);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("agent register force rebind moves the logical agent to the current terminal target", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const first = service.registerAgent({
+      agentId: "agent-alpha",
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-agent-alpha",
+      tmuxPaneId: "%504",
+    });
+
+    const rebound = service.registerAgent({
+      agentId: "agent-alpha",
+      forceRebind: true,
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-agent-alpha-rebound",
+      tmuxPaneId: "%505",
+    });
+
+    assert.equal(rebound.agent.agentId, "agent-alpha");
+    assert.equal(rebound.agent.runtimeSessionId, "thread-agent-alpha-rebound");
+    assert.notEqual(rebound.terminalTarget.targetId, first.terminalTarget.targetId);
+    const targets = service.listActivationTargets("agent-alpha");
+    assert.equal(targets.length, 1);
+    assert.equal(targets[0].kind, "terminal");
+    assert.equal(targets[0].kind === "terminal" ? targets[0].tmuxPaneId : null, "%505");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("shared source can route one stream event to multiple agent inboxes", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -607,6 +607,17 @@ test("control plane accepts caller-supplied agent ids and rejects conflicting re
       assert.equal(conflict.statusCode, 400);
       assert.match(conflict.data.error, /agent register conflict/);
 
+      const invalidForceRebind = await client.request<{ error: string }>("/agents/register", {
+        agentId: "agent-http-alpha",
+        forceRebind: "false",
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-alpha-rebound",
+        tmuxPaneId: "%602",
+      });
+      assert.equal(invalidForceRebind.statusCode, 400);
+      assert.match(invalidForceRebind.data.error, /expected boolean/);
+
       const rebound = await client.request<{ terminalTarget: { tmuxPaneId: string | null } }>("/agents/register", {
         agentId: "agent-http-alpha",
         forceRebind: true,

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -132,7 +132,7 @@ test("cli auto-starts the daemon for normal commands and daemon stop shuts it do
       cwd: repoDir,
       env,
       encoding: "utf8",
-      timeout: 15_000,
+      timeout: 25_000,
     });
     assert.equal(status.status, 0, status.stderr);
     const parsedStatus = JSON.parse(status.stdout) as { counts?: { agents?: number } };
@@ -142,7 +142,7 @@ test("cli auto-starts the daemon for normal commands and daemon stop shuts it do
       cwd: repoDir,
       env,
       encoding: "utf8",
-      timeout: 15_000,
+      timeout: 25_000,
     });
     assert.equal(daemonState.status, 0, daemonState.stderr);
     const parsedDaemon = JSON.parse(daemonState.stdout) as { running: boolean; pid: number | null };
@@ -153,7 +153,7 @@ test("cli auto-starts the daemon for normal commands and daemon stop shuts it do
       cwd: repoDir,
       env,
       encoding: "utf8",
-      timeout: 15_000,
+      timeout: 25_000,
     });
     assert.equal(stopped.status, 0, stopped.stderr);
     const parsedStopped = JSON.parse(stopped.stdout) as { running: boolean };
@@ -559,6 +559,64 @@ test("control plane can remove agents and gc stale offline agents", async () => 
       const gcResponse = await client.request<{ removedAgents: number } & { deleted?: number }>("/gc", {});
       assert.equal(gcResponse.statusCode, 200);
       assert.equal(gcResponse.data.removedAgents, 1);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane accepts caller-supplied agent ids and rejects conflicting rebinds without force", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-agent-id-"));
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const store = await AgentInboxStore.open(dbPath);
+  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }));
+  const service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  try {
+    await adapters.start();
+    await service.start();
+    const server = createServer(service);
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const first = await client.request<{ agent: { agentId: string } }>("/agents/register", {
+        agentId: "agent-http-alpha",
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-alpha",
+        tmuxPaneId: "%601",
+      });
+      assert.equal(first.statusCode, 200);
+      assert.equal(first.data.agent.agentId, "agent-http-alpha");
+
+      const conflict = await client.request<{ error: string }>("/agents/register", {
+        agentId: "agent-http-alpha",
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-alpha-rebound",
+        tmuxPaneId: "%602",
+      });
+      assert.equal(conflict.statusCode, 400);
+      assert.match(conflict.data.error, /agent register conflict/);
+
+      const rebound = await client.request<{ terminalTarget: { tmuxPaneId: string | null } }>("/agents/register", {
+        agentId: "agent-http-alpha",
+        forceRebind: true,
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-alpha-rebound",
+        tmuxPaneId: "%602",
+      });
+      assert.equal(rebound.statusCode, 200);
+      assert.equal(rebound.data.terminalTarget.tmuxPaneId, "%602");
     } finally {
       await started.close();
     }


### PR DESCRIPTION
## Summary
- allow callers to provide a stable logical `agentId` during registration
- reject conflicting terminal rebinds by default and require `--force-rebind` / `forceRebind` to move a logical agent
- document the new registration flow and cover it with service and control-plane tests

## Testing
- npm run build
- npm test

Closes #16