### PR TITLE
feat: clarify local and remote source naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ agentinbox agent register --agent-id agent-alpha
 Create a local source and publish an event:
 
 ```bash
-agentinbox source add custom local-demo
+agentinbox source add local_event local-demo
 agentinbox subscription add <agent_id> <source_id>
-agentinbox source event <source_id> --native-id demo-1 --event custom.demo
+agentinbox source event <source_id> --native-id demo-1 --event local.demo
 agentinbox inbox read <agent_id>
 ```
 

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -62,11 +62,11 @@ This detects the current runtime and terminal context, assigns or restores an
 The shortest end-to-end flow is a local source:
 
 ```bash
-agentinbox source add custom local-demo
+agentinbox source add local_event local-demo
 agentinbox subscription add <agent_id> <source_id>
 agentinbox source event <source_id> \
   --native-id demo-1 \
-  --event custom.demo \
+  --event local.demo \
   --metadata-json '{"channel":"engineering"}' \
   --payload-json '{"text":"hello from a local producer"}'
 agentinbox inbox read <agent_id>

--- a/docs/site/reference/source-types.md
+++ b/docs/site/reference/source-types.md
@@ -3,12 +3,25 @@
 `AgentInbox` currently supports a mix of local and provider-specific source
 adapters.
 
-## `custom`
+## `local_event`
 
-`custom` is the local event ingress source.
+`local_event` is the local event ingress source.
 
 Use it when a local producer wants to append events directly into `AgentInbox`
 without building a provider-specific adapter first.
+
+## `remote_source`
+
+`remote_source` is a reserved product-facing name for future declarative
+external sources.
+
+It exists to distinguish future external source definitions from:
+
+- local event ingress
+- built-in provider-specific sources
+
+The name is intentional: it describes source semantics without exposing
+implementation details such as `uxc`.
 
 ## `github_repo`
 

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -69,15 +69,15 @@ agentinbox source show <sourceId>
 Common source creation patterns:
 
 ```bash
-agentinbox source add custom <sourceKey>
+agentinbox source add local_event <sourceKey>
 agentinbox source add github_repo <owner>/<repo> --config-json '{"owner":"holon-run","repo":"agentinbox","uxcAuth":"github-default","pollIntervalSecs":30}'
 agentinbox source add github_repo_ci <owner>/<repo> --config-json '{"owner":"holon-run","repo":"agentinbox","uxcAuth":"github-default","perPage":10}'
 ```
 
-For `custom` sources, append events explicitly:
+For `local_event` sources, append events explicitly:
 
 ```bash
-agentinbox source event <sourceId> --native-id evt_123 --event custom.demo --payload-json '{"message":"hello"}'
+agentinbox source event <sourceId> --native-id evt_123 --event local.demo --payload-json '{"message":"hello"}'
 ```
 
 ### 3. Subscribe the agent
@@ -192,7 +192,7 @@ Practical rule:
 
 When another local tool wants durable events:
 
-1. create a `custom` source
+1. create a `local_event` source
 2. append events with `source event`
 3. subscribe one or more agents
 4. let agents `watch` or receive activations

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -50,7 +50,8 @@ class NoopDeliveryAdapter implements DeliveryAdapter {
 
 export class AdapterRegistry {
   private readonly fixtureSource = new NoopSourceAdapter("fixture");
-  private readonly customSource = new NoopSourceAdapter("custom");
+  private readonly localEventSource = new NoopSourceAdapter("local_event");
+  private readonly remoteSource = new NoopSourceAdapter("remote_source");
   private readonly feishuSource: FeishuSourceRuntime;
   private readonly githubSource: GithubSourceRuntime;
   private readonly githubCiSource: GithubCiSourceRuntime;
@@ -68,8 +69,11 @@ export class AdapterRegistry {
     if (type === "fixture") {
       return this.fixtureSource;
     }
-    if (type === "custom") {
-      return this.customSource;
+    if (type === "local_event") {
+      return this.localEventSource;
+    }
+    if (type === "remote_source") {
+      return this.remoteSource;
     }
     if (type === "github_repo") {
       return this.githubSource;

--- a/src/http.ts
+++ b/src/http.ts
@@ -422,6 +422,7 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("unsupported lifecycle mode") ||
     message.startsWith("unsupported start policy") ||
     message.startsWith("unsupported terminal") ||
+    message.startsWith("source type is reserved and not yet supported") ||
     message.startsWith("expected boolean") ||
     message.startsWith("expected integer") ||
     message.startsWith("expected positive integer") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-export type SourceType = "fixture" | "custom" | "github_repo" | "github_repo_ci" | "feishu_bot";
+export type SourceType = "fixture" | "local_event" | "remote_source" | "github_repo" | "github_repo_ci" | "feishu_bot";
 
 export type SubscriptionStartPolicy = "latest" | "earliest" | "at_offset" | "at_time";
 export type SubscriptionLifecycleMode = "standing" | "temporary";

--- a/src/service.ts
+++ b/src/service.ts
@@ -147,6 +147,9 @@ export class AgentInboxService {
   }
 
   async registerSource(input: RegisterSourceInput): Promise<SubscriptionSource> {
+    if (input.sourceType === "remote_source") {
+      throw new Error("source type is reserved and not yet supported: remote_source");
+    }
     const existing = this.store.getSourceByKey(input.sourceType, input.sourceKey);
     if (existing) {
       return existing;

--- a/src/service.ts
+++ b/src/service.ts
@@ -482,7 +482,7 @@ export class AgentInboxService {
 
   async appendSourceEventByCaller(sourceId: string, input: Omit<AppendSourceEventInput, "sourceId">): Promise<AppendSourceEventResult> {
     const source = this.getSource(sourceId);
-    if (source.sourceType !== "custom") {
+    if (source.sourceType !== "local_event") {
       throw new Error(`manual append is not supported for source type: ${source.sourceType}`);
     }
     return this.appendSourceEvent({ ...input, sourceId });

--- a/src/source_schema.ts
+++ b/src/source_schema.ts
@@ -10,17 +10,26 @@ const SOURCE_SCHEMAS: Record<SourceType, SourceSchema> = {
     eventVariantExamples: ["message.created"],
     configFields: [],
   },
-  custom: {
-    sourceType: "custom",
+  local_event: {
+    sourceType: "local_event",
     metadataFields: [
-      { name: "channel", type: "string", description: "Producer-defined routing channel for local custom events." },
+      { name: "channel", type: "string", description: "Producer-defined routing channel for local event ingress." },
       { name: "subject", type: "string", description: "Producer-defined short summary or subject field." },
     ],
     payloadExamples: [
-      { text: "hello from custom source" },
+      { text: "hello from local event source" },
     ],
     eventVariantExamples: ["message.created"],
     configFields: [],
+  },
+  remote_source: {
+    sourceType: "remote_source",
+    metadataFields: [],
+    payloadExamples: [],
+    eventVariantExamples: [],
+    configFields: [
+      { name: "definition", type: "object", required: false, description: "Reserved for future declarative external source definitions." },
+    ],
   },
   github_repo: {
     sourceType: "github_repo",

--- a/src/store.ts
+++ b/src/store.ts
@@ -367,10 +367,15 @@ export class AgentInboxStore {
   }
 
   getSourceByKey(sourceType: string, sourceKey: string): SubscriptionSource | null {
-    const row = this.getOne(
-      "select * from sources where source_type = ? and source_key = ?",
-      [sourceType, sourceKey],
-    );
+    const row = sourceType === "local_event"
+      ? this.getOne(
+        "select * from sources where source_type in (?, ?) and source_key = ? order by case when source_type = ? then 0 else 1 end limit 1",
+        ["local_event", "custom", sourceKey, "local_event"],
+      )
+      : this.getOne(
+        "select * from sources where source_type = ? and source_key = ?",
+        [sourceType, sourceKey],
+      );
     return row ? this.mapSource(row) : null;
   }
 
@@ -1357,9 +1362,12 @@ export class AgentInboxStore {
   }
 
   private mapSource(row: Record<string, unknown>): SubscriptionSource {
+    const sourceType = String(row.source_type) === "custom"
+      ? "local_event"
+      : row.source_type as SubscriptionSource["sourceType"];
     return {
       sourceId: String(row.source_id),
-      sourceType: row.source_type as SubscriptionSource["sourceType"],
+      sourceType,
       sourceKey: String(row.source_key),
       configRef: row.config_ref ? String(row.config_ref) : null,
       config: parseJson<Record<string, unknown>>(row.config_json as string),

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -246,12 +246,12 @@ test("shared source can route one stream event to multiple agent inboxes", async
   }
 });
 
-test("custom source can act as a programmable event bus source", async () => {
+test("local_event source can act as a programmable event bus source", async () => {
   const { store, service, dir } = await makeService();
   try {
     const alpha = await registerTmuxAgent(service, "3");
     const source = await service.registerSource({
-      sourceType: "custom",
+      sourceType: "local_event",
       sourceKey: "project-alpha",
       config: {},
     });
@@ -263,10 +263,10 @@ test("custom source can act as a programmable event bus source", async () => {
     });
 
     const appendResult = await service.appendSourceEventByCaller(source.sourceId, {
-      sourceNativeId: "custom-evt-1",
+      sourceNativeId: "local-evt-1",
       eventVariant: "message.created",
       metadata: { channel: "engineering" },
-      rawPayload: { text: "hello from custom source" },
+      rawPayload: { text: "hello from local event source" },
     });
     assert.equal(appendResult.appended, 1);
 
@@ -274,7 +274,7 @@ test("custom source can act as a programmable event bus source", async () => {
     const items = service.listInboxItems(alpha.agentId);
     assert.equal(pollResult.inboxItemsCreated, 1);
     assert.equal(items.length, 1);
-    assert.equal(items[0].sourceNativeId, "custom-evt-1");
+    assert.equal(items[0].sourceNativeId, "local-evt-1");
   } finally {
     await service.stop();
     store.close();
@@ -305,7 +305,7 @@ test("subscription remove deletes the subscription, its consumer, and transient 
       notifyLeaseMs: 100,
     });
     const source = await service.registerSource({
-      sourceType: "custom",
+      sourceType: "local_event",
       sourceKey: "remove-sub-demo",
       config: {},
     });
@@ -357,7 +357,7 @@ test("subscription remove preserves unrelated activation dispatch state", async 
       notifyLeaseMs: 100,
     });
     const source = await service.registerSource({
-      sourceType: "custom",
+      sourceType: "local_event",
       sourceKey: "remove-sub-state-demo",
       config: {},
     });
@@ -407,7 +407,7 @@ test("subscription filter expr can match nested payload fields and exclude self-
   try {
     const alpha = await registerTmuxAgent(service, "expr");
     const source = await service.registerSource({
-      sourceType: "custom",
+      sourceType: "local_event",
       sourceKey: "expr-demo",
       config: {},
     });
@@ -458,7 +458,7 @@ test("registerSubscription rejects invalid filter expressions before persistence
   try {
     const alpha = await registerTmuxAgent(service, "invalid-expr");
     const source = await service.registerSource({
-      sourceType: "custom",
+      sourceType: "local_event",
       sourceKey: "invalid-expr-demo",
       config: {},
     });
@@ -529,7 +529,7 @@ test("inbox read defaults to unacked items and ack through clears a processed ba
   try {
     const alpha = await registerTmuxAgent(service, "5");
     const source = await service.registerSource({
-      sourceType: "custom",
+      sourceType: "local_event",
       sourceKey: "ack-through-demo",
       config: {},
     });
@@ -660,8 +660,8 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
       notifyLeaseMs: 100,
     });
     const source = await service.registerSource({
-      sourceType: "custom",
-      sourceKey: "custom-gated",
+      sourceType: "local_event",
+      sourceKey: "local-event-gated",
       config: {},
     });
     const subscription = await service.registerSubscription({
@@ -732,7 +732,7 @@ test("terminal target goes offline when dispatch fails and probe confirms disapp
       notifyLeaseMs: 100,
     });
     const source = await service.registerSource({
-      sourceType: "custom",
+      sourceType: "local_event",
       sourceKey: "offline-demo",
       config: {},
     });
@@ -774,7 +774,7 @@ test("agent remove cascades local runtime state but keeps shared sources", async
       notifyLeaseMs: 100,
     });
     const source = await service.registerSource({
-      sourceType: "custom",
+      sourceType: "local_event",
       sourceKey: "remove-demo",
       config: {},
     });
@@ -815,7 +815,7 @@ test("gc removes offline agents after ttl even with unacked inbox items", async 
       notifyLeaseMs: 100,
     });
     const source = await service.registerSource({
-      sourceType: "custom",
+      sourceType: "local_event",
       sourceKey: "gc-demo",
       config: {},
     });

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -282,6 +282,75 @@ test("local_event source can act as a programmable event bus source", async () =
   }
 });
 
+test("legacy custom sources are surfaced as local_event and still accept manual append", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "legacy-custom");
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "legacy-custom-demo",
+      config: {},
+    });
+
+    ((store as unknown) as { db: { run(sql: string, params?: unknown[]): void } }).db.run(
+      "update sources set source_type = 'custom' where source_id = ?",
+      [source.sourceId],
+    );
+
+    const aliased = service.getSource(source.sourceId);
+    assert.equal(aliased.sourceType, "local_event");
+    const details = service.getSourceDetails(source.sourceId) as { source: { sourceType: string }; schema: { sourceType: string } };
+    assert.equal(details.source.sourceType, "local_event");
+    assert.equal(details.schema.sourceType, "local_event");
+
+    const same = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "legacy-custom-demo",
+      config: {},
+    });
+    assert.equal(same.sourceId, source.sourceId);
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "legacy-custom-evt-1",
+      eventVariant: "message.created",
+      metadata: { channel: "engineering" },
+      rawPayload: { text: "hello from legacy custom source" },
+    });
+
+    const subscription = await service.registerSubscription({
+      agentId: alpha.agentId,
+      sourceId: source.sourceId,
+      filter: { metadata: { channel: "engineering" } },
+      startPolicy: "earliest",
+    });
+    const pollResult = await service.pollSubscription(subscription.subscriptionId);
+    assert.equal(pollResult.inboxItemsCreated, 1);
+    assert.equal(service.listInboxItems(alpha.agentId)[0]?.sourceNativeId, "legacy-custom-evt-1");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("remote_source registration is rejected until the runtime exists", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    await assert.rejects(
+      service.registerSource({
+        sourceType: "remote_source",
+        sourceKey: "reserved-demo",
+        config: {},
+      }),
+      /reserved and not yet supported/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("subscription remove deletes the subscription, its consumer, and transient runtime state", async () => {
   const dispatcher = new RecordingActivationDispatcher();
   const terminalDispatcher = new RecordingTerminalDispatcher();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -639,6 +639,48 @@ test("control plane accepts caller-supplied agent ids and rejects conflicting re
   }
 });
 
+test("control plane rejects reserved remote_source registration", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-remote-src-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const response = await client.request<{ error: string }>("/sources/register", {
+        sourceType: "remote_source",
+        sourceKey: "reserved-demo",
+        config: {},
+      });
+      assert.equal(response.statusCode, 400);
+      assert.match(response.data.error, /reserved and not yet supported/);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 async function waitFor<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: NodeJS.Timeout | null = null;
   const timeout = new Promise<never>((_, reject) => {

--- a/test/source_schema.test.ts
+++ b/test/source_schema.test.ts
@@ -12,9 +12,10 @@ test("getSourceSchema exposes github repo ci metadata and examples", () => {
   assert.ok(schema.configFields.some((field) => field.name === "branch"));
 });
 
-test("getSourceSchema exposes lightweight schemas for custom and fixture sources", () => {
-  const custom = getSourceSchema("custom");
-  assert.equal(custom.sourceType, "custom");
-  assert.ok(custom.metadataFields.some((field) => field.name === "channel"));
+test("getSourceSchema exposes lightweight schemas for local and reserved sources", () => {
+  const localEvent = getSourceSchema("local_event");
+  assert.equal(localEvent.sourceType, "local_event");
+  assert.ok(localEvent.metadataFields.some((field) => field.name === "channel"));
+  assert.equal(getSourceSchema("remote_source").sourceType, "remote_source");
   assert.equal(getSourceSchema("fixture").sourceType, "fixture");
 });


### PR DESCRIPTION
## Summary
- rename the local programmable ingress source from `custom` to `local_event` across the public model, docs, and tests
- reserve `remote_source` as the product-facing name for future declarative external sources
- update source schemas and reference docs to clarify the distinction between local ingress and future remote definitions

## Testing
- npm install
- npm run build
- npm test

Closes #18