### PR TITLE
feat: deploy docs site with Cloudflare

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,0 +1,54 @@
+name: Docs Site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/site/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'wrangler.jsonc'
+      - '.github/workflows/docs-site.yml'
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 22
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy Docs Site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build directory indexes
+        run: npm run docs:index
+
+      - name: Build Cloudflare bundle
+        run: npm run docs:build
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site-cloudflare
+          path: dist/cloudflare
+
+      - name: Deploy to Cloudflare Workers
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler@4 deploy --config wrangler.jsonc

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ agentinbox subscription remove <subscription_id>
 
 ## Docs
 
-Public docs now live under [`docs/site`](./docs/site) and are structured for
-`mdorigin`.
+Public docs live in the mdorigin site under [`docs/site`](./docs/site).
 
+- docs site: `https://agentinbox.holon.run`
 - docs home: [`docs/site/README.md`](./docs/site/README.md)
 - getting started: [`docs/site/guides/getting-started.md`](./docs/site/guides/getting-started.md)
 - CLI reference: [`docs/site/reference/cli.md`](./docs/site/reference/cli.md)
@@ -101,6 +101,13 @@ Preview the docs site locally:
 
 ```bash
 npm run docs:dev
+```
+
+Build the Cloudflare deploy bundle:
+
+```bash
+npm run docs:index
+npm run docs:build
 ```
 
 ## Development

--- a/docs/site/mdorigin.config.json
+++ b/docs/site/mdorigin.config.json
@@ -1,8 +1,36 @@
 {
   "siteTitle": "AgentInbox Docs",
   "siteDescription": "Documentation for AgentInbox, the local event subscription and delivery service for agents.",
+  "siteUrl": "https://agentinbox.holon.run",
   "showHomeIndex": false,
   "showSummary": true,
+  "topNav": [
+    {
+      "label": "Getting Started",
+      "href": "/guides/getting-started/"
+    },
+    {
+      "label": "Guides",
+      "href": "/guides/"
+    },
+    {
+      "label": "Reference",
+      "href": "/reference/"
+    },
+    {
+      "label": "Concepts",
+      "href": "/concepts/"
+    },
+    {
+      "label": "RFCs",
+      "href": "/rfcs/"
+    },
+    {
+      "label": "GitHub",
+      "href": "https://github.com/holon-run/agentinbox"
+    }
+  ],
+  "footerText": "AgentInbox documentation site.",
   "socialLinks": [
     {
       "icon": "github",
@@ -13,6 +41,11 @@
       "icon": "npm",
       "label": "npm",
       "href": "https://www.npmjs.com/package/@holon-run/agentinbox"
+    },
+    {
+      "icon": "home",
+      "label": "Docs",
+      "href": "https://agentinbox.holon.run"
     }
   ],
   "editLink": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,11 @@
     "build": "tsc -p tsconfig.json",
     "dev": "node --watch --loader ts-node/esm src/cli.ts",
     "docs:dev": "mdorigin dev --root docs/site",
+    "docs:search": "mdorigin build search --root docs/site",
     "docs:index": "mdorigin build index --root docs/site",
-    "docs:build:cloudflare": "npm run docs:index && mdorigin build cloudflare --root docs/site",
+    "docs:build": "npm run docs:search && mdorigin build cloudflare --root docs/site --search dist/search",
+    "docs:build:cloudflare": "npm run docs:build",
+    "docs:deploy": "npm run docs:index && npm run docs:build && npx wrangler@4 deploy --config wrangler.jsonc",
     "prepack": "npm run build",
     "test": "node --require ts-node/register --test test/*.test.ts"
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "agentinbox",
+  "main": "dist/cloudflare/worker.mjs",
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "dist/cloudflare/assets"
+  },
+  "compatibility_date": "2026-04-09",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": true
+}


### PR DESCRIPTION
## Summary
- add a Cloudflare Workers docs-site deployment workflow modeled after `uxc`
- add `wrangler.jsonc` and docs build/deploy scripts for the mdorigin site
- point the docs config and README at `https://agentinbox.holon.run`

## Validation
- npm run docs:index
- npm run docs:build
