### PR TITLE
docs: improve onboarding and skill-first setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentInbox
 
-`AgentInbox` is the local event subscription and delivery service for agents.
+`AgentInbox` is the local event inbox and activation service for agents.
 
 It connects external and local event sources, stores them as durable streams,
 routes them by subscription, and lets agents read, watch, acknowledge, and
@@ -24,15 +24,15 @@ In practice, that means `AgentInbox` can:
   are implemented
 - GitHub repo, GitHub repo CI, Feishu bot, and local event ingress source
   adapters are implemented
-- CLI and source model are still evolving, especially around onboarding,
-  filtering, and source naming
+- filtering and source model are still evolving
+- first-run onboarding is currently skill-first rather than wizard-first
 
 ## Install
 
 Requires:
 
 - Node.js 20 or newer
-- a local `uxc` daemon if you want to use GitHub or Feishu adapters
+- `uxc` 0.13.3 or newer if you want to use GitHub or Feishu adapters
 
 Install globally:
 
@@ -53,6 +53,21 @@ npm install
 npm run build
 node dist/src/cli.js --help
 ```
+
+## Recommended Onboarding
+
+If you are using Codex or Claude Code, start with the bundled AgentInbox skill:
+
+- repo copy: [`skills/agentinbox/SKILL.md`](./skills/agentinbox/SKILL.md)
+- docs site copy: `https://agentinbox.holon.run/skills/agentinbox/SKILL`
+
+That skill is the recommended onboarding path. It can guide the agent through:
+
+- checking or installing `agentinbox`
+- checking or installing `uxc`
+- importing GitHub auth from the local `gh` CLI via `uxc auth credential import github --from gh`
+- registering the current terminal session as an agent
+- adding GitHub sources and standing subscriptions using the docs-site examples
 
 ## Quick Start
 
@@ -90,7 +105,10 @@ Public docs live in the mdorigin site under [`docs/site`](./docs/site).
 
 - docs site: `https://agentinbox.holon.run`
 - docs home: [`docs/site/README.md`](./docs/site/README.md)
+- onboarding with the agent skill: [`docs/site/guides/onboarding-with-agent-skill.md`](./docs/site/guides/onboarding-with-agent-skill.md)
 - getting started: [`docs/site/guides/getting-started.md`](./docs/site/guides/getting-started.md)
+- review workflows: [`docs/site/guides/review-workflows.md`](./docs/site/guides/review-workflows.md)
+- skill docs: [`docs/site/skills/README.md`](./docs/site/skills/README.md)
 - CLI reference: [`docs/site/reference/cli.md`](./docs/site/reference/cli.md)
 - source types: [`docs/site/reference/source-types.md`](./docs/site/reference/source-types.md)
 - architecture: [`docs/site/concepts/architecture.md`](./docs/site/concepts/architecture.md)

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -9,7 +9,10 @@ webhook targets.
 
 ## Start Here
 
+- [Onboarding With The AgentInbox Skill](./guides/onboarding-with-agent-skill.md)
 - [Getting Started](./guides/getting-started.md)
+- [Review Workflows](./guides/review-workflows.md)
+- [Skills](./skills/)
 - [CLI Reference](./reference/cli.md)
 - [Source Types](./reference/source-types.md)
 
@@ -30,8 +33,8 @@ webhook targets.
   targets are implemented
 - GitHub repo, GitHub repo CI, Feishu bot, and local event ingress source
   adapters are implemented
-- CLI and source model are still evolving, especially around filtering,
-  onboarding, and naming
+- CLI and source model are still evolving, especially around filtering and naming
+- onboarding is currently best handled through the bundled AgentInbox skill
 
 ## Recommended Runtime Modes
 
@@ -53,6 +56,9 @@ webhook targets.
   <!-- mdorigin:index kind=directory -->
 
 - [RFCs](./rfcs/)
+  <!-- mdorigin:index kind=directory -->
+
+- [Skills](./skills/)
   <!-- mdorigin:index kind=directory -->
 
 <!-- INDEX:END -->

--- a/docs/site/guides/README.md
+++ b/docs/site/guides/README.md
@@ -1,11 +1,21 @@
 # Guides
 
+- [Onboarding With The AgentInbox Skill](./onboarding-with-agent-skill.md)
 - [Getting Started](./getting-started.md)
+- [Review Workflows](./review-workflows.md)
 
 <!-- INDEX:START -->
 
 - [Getting Started](./getting-started.md)
   This guide shows the shortest path from install to a working local agent session.
+  <!-- mdorigin:index kind=article -->
+
+- [Onboarding With The AgentInbox Skill](./onboarding-with-agent-skill.md)
+  If you are already using Codex or Claude Code, the recommended onboarding path is to hand the bundled `AgentInbox` skill to the agent and let it configure the local workflow for you.
+  <!-- mdorigin:index kind=article -->
+
+- [Review Workflows](./review-workflows.md)
+  This guide describes a practical `AgentInbox` workflow for a review-focused agent.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -3,10 +3,14 @@
 This guide shows the shortest path from install to a working local agent
 session.
 
+If you are using Codex or Claude Code, start with
+[Onboarding With The AgentInbox Skill](./onboarding-with-agent-skill.md). That
+is the preferred first-run path.
+
 ## Prerequisites
 
 - Node.js 20 or newer
-- `uxc` if you want to use GitHub or Feishu source adapters
+- `uxc` 0.13.3 or newer if you want to use GitHub or Feishu source adapters
 
 Install `AgentInbox` globally:
 
@@ -56,6 +60,13 @@ agentinbox agent register --agent-id agent-alpha
 
 This detects the current runtime and terminal context, assigns or restores an
 `agentId`, creates the agent inbox, and attaches a terminal activation target.
+
+If you already use `gh` for GitHub authentication, import it into `uxc` before
+adding GitHub-backed sources:
+
+```bash
+uxc auth credential import github --from gh
+```
 
 ## Local Event Flow
 

--- a/docs/site/guides/onboarding-with-agent-skill.md
+++ b/docs/site/guides/onboarding-with-agent-skill.md
@@ -1,0 +1,73 @@
+# Onboarding With The AgentInbox Skill
+
+If you are already using Codex or Claude Code, the recommended onboarding path
+is to hand the bundled `AgentInbox` skill to the agent and let it configure the
+local workflow for you.
+
+This is the preferred path for first-run setup. It avoids pushing the user
+through raw `source add`, `subscription add`, and `uxc` auth commands before the
+agent is ready.
+
+## What The Skill Should Do
+
+The bundled skill lives at:
+
+- [`skills/agentinbox/SKILL.md`](../../../skills/agentinbox/SKILL.md)
+- [`/skills/agentinbox/SKILL`](../skills/agentinbox/SKILL.md)
+
+When used for onboarding, the skill should:
+
+1. verify `agentinbox` is available in `PATH`
+2. start or verify the local daemon
+3. verify `uxc` is available
+4. verify GitHub auth is usable
+5. if `gh` is already authenticated, import that token into `uxc`
+6. register the current terminal session as an agent
+7. use the docs-site examples to add standing GitHub subscriptions
+
+## Recommended Checks
+
+The agent should verify:
+
+```bash
+agentinbox --version
+agentinbox daemon status
+uxc --version
+gh auth status
+```
+
+If the daemon is not running:
+
+```bash
+agentinbox daemon start
+```
+
+If GitHub auth should be reused from `gh`:
+
+```bash
+uxc auth credential import github --from gh
+```
+
+This requires `uxc` 0.13.3 or newer.
+
+## After Auth
+
+Once `uxc` can access GitHub and the current terminal session is registered, the
+agent can move directly into real usage:
+
+- add `github_repo` or `github_repo_ci` sources
+- add standing subscriptions for review comments or CI failures
+- add task-specific subscriptions for a PR or branch
+- remove those subscriptions when the task is done
+
+See:
+
+- [Getting Started](./getting-started.md)
+- [Review Workflows](./review-workflows.md)
+- [CLI Reference](../reference/cli.md)
+
+## Why Skill-First
+
+`AgentInbox` onboarding is still evolving. The skill can absorb environment
+checks, `uxc` auth reuse, and per-agent workflow setup without forcing the user
+to manually learn every low-level CLI step first.

--- a/docs/site/guides/review-workflows.md
+++ b/docs/site/guides/review-workflows.md
@@ -1,0 +1,66 @@
+# Review Workflows
+
+This guide describes a practical `AgentInbox` workflow for a review-focused
+agent.
+
+The default recommendation is:
+
+- keep one standing agent for ongoing review work
+- add a small set of standing subscriptions
+- add task-specific subscriptions for a PR or branch when needed
+- remove the temporary subscriptions when the task is done
+
+## Standing Subscriptions
+
+Typical standing subscriptions for a review agent are:
+
+- GitHub review comments and PR discussion events
+- CI completions that require action, usually failures
+
+Keep these standing subscriptions low-noise. They should point the agent at real
+work, not every observable lifecycle event.
+
+## Task-Specific Subscriptions
+
+For a single PR or branch, add temporary subscriptions such as:
+
+- PR discussion events for `metadata.number == <pr_number>`
+- CI completion events for `metadata.headBranch == <branch>` and `metadata.status == "completed"`
+
+When the task is finished:
+
+```bash
+agentinbox subscription remove <subscriptionId>
+```
+
+This lets one long-lived agent follow many short-lived review tasks without
+creating a new agent session for each one.
+
+## Why Remove Matters
+
+Temporary review subscriptions should not become standing subscriptions by
+accident.
+
+Removing them after the task is done keeps:
+
+- the inbox quieter
+- notifications more relevant
+- future review prompts easier to interpret
+
+## Filter Design
+
+For review workflows, prefer structured metadata filters where possible:
+
+- `metadata.number`
+- `metadata.status`
+- `metadata.conclusion`
+- `metadata.headBranch`
+- `metadata.name`
+
+Use expression filters only when the shortcut form is not enough.
+
+See also:
+
+- [Getting Started](./getting-started.md)
+- [CLI Reference](../reference/cli.md)
+- [Event Filtering RFC](../rfcs/event-filtering.md)

--- a/docs/site/mdorigin.config.json
+++ b/docs/site/mdorigin.config.json
@@ -7,11 +7,15 @@
   "topNav": [
     {
       "label": "Getting Started",
-      "href": "/guides/getting-started/"
+      "href": "/guides/getting-started"
     },
     {
       "label": "Guides",
       "href": "/guides/"
+    },
+    {
+      "label": "Skills",
+      "href": "/skills/"
     },
     {
       "label": "Reference",

--- a/docs/site/skills/README.md
+++ b/docs/site/skills/README.md
@@ -1,0 +1,20 @@
+# Skills
+
+The docs site exposes selected repository skills so they can be handed directly
+to another agent.
+
+## Available Skills
+
+- [AgentInbox Skill](./agentinbox/SKILL.md)
+
+Use the `AgentInbox` skill when the goal is to onboard the current session,
+connect GitHub through `uxc`, register the current runtime, and operate inbox,
+source, and subscription workflows from the local daemon.
+
+<!-- INDEX:START -->
+
+- [agentinbox](./agentinbox/)
+  Use the local AgentInbox service to register the current agent session, manage sources and subscriptions, read/watch/ack the agent inbox, and inspect activation targets. Use when an agent needs durable local event subscriptions, terminal or webhook activations, or a programmable local event bus.
+  <!-- mdorigin:index kind=article -->
+
+<!-- INDEX:END -->

--- a/docs/site/skills/agentinbox
+++ b/docs/site/skills/agentinbox
@@ -1,0 +1,1 @@
+../../../skills/agentinbox

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@holon-run/uxc-daemon-client": "^0.13.1",
+        "@holon-run/uxc-daemon-client": "^0.13.3",
         "jexl": "^2.3.0",
         "sql.js": "^1.13.0"
       },
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@holon-run/uxc-daemon-client": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.13.1.tgz",
-      "integrity": "sha512-OuCwQJGLdjlMXIYRehY0EDVZCkifep8UpsqHDht1IS3DKbeUDN5aE0IRZpU0HjLSUNX7IA3qxnTA21TD7mXT6g==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.13.3.tgz",
+      "integrity": "sha512-WZMfJrqsK4RgWOhd881mXdT0RqXQ+OSffbfLz2AygqY0SEpnopOrGI1UlwwueAktqpTMMDGK7KQXWXvOhadEtQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -662,7 +662,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2427,7 +2426,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/holon-run/agentinbox.git"
   },
-  "homepage": "https://github.com/holon-run/agentinbox#readme",
+  "homepage": "https://agentinbox.holon.run",
   "bugs": {
     "url": "https://github.com/holon-run/agentinbox/issues"
   },
@@ -38,7 +38,7 @@
     "test": "node --require ts-node/register --test test/*.test.ts"
   },
   "dependencies": {
-    "@holon-run/uxc-daemon-client": "^0.13.1",
+    "@holon-run/uxc-daemon-client": "^0.13.3",
     "jexl": "^2.3.0",
     "sql.js": "^1.13.0"
   },

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -17,6 +17,36 @@ Use this skill when work should flow through the local `agentinbox` daemon inste
 - per-agent inbox read/watch/ack
 - activation targets such as terminal injection and webhooks
 
+## First-Run Onboarding
+
+If the user wants to start using `AgentInbox`, this skill should handle the
+onboarding flow directly instead of sending the user through a separate wizard.
+
+Recommended first-run sequence:
+
+1. verify `agentinbox` is installed
+2. verify the local daemon is running, or start it
+3. verify `uxc` is installed when GitHub or Feishu adapters are needed
+4. if GitHub access is needed and `gh auth status` is already authenticated, run:
+
+```bash
+uxc auth credential import github --from gh
+```
+
+5. register the current terminal session:
+
+```bash
+agentinbox agent register
+```
+
+6. use the docs examples to add the required standing subscriptions
+
+The preferred references are:
+
+- `https://agentinbox.holon.run/guides/onboarding-with-agent-skill`
+- `https://agentinbox.holon.run/guides/getting-started`
+- `https://agentinbox.holon.run/guides/review-workflows`
+
 ## Prerequisites
 
 - `agentinbox` is available in `PATH`
@@ -31,8 +61,18 @@ agentinbox status
 If `agentinbox status` fails, start the daemon first:
 
 ```bash
-agentinbox serve
+agentinbox daemon start
 ```
+
+If GitHub-backed adapters are needed, prefer:
+
+```bash
+uxc --version
+gh auth status
+uxc auth credential import github --from gh
+```
+
+This `gh` import path requires `uxc` 0.13.3 or newer.
 
 ## Core Workflow
 


### PR DESCRIPTION
## Summary
- make onboarding explicitly skill-first and document the `uxc` 0.13.3 `gh` token import path
- fix docs-site navigation for article routes and add a docs-site skills section with a symlink to the bundled skill
- improve README and docs to point users at the docs site and review workflow examples

## Issues
- closes #17
- closes #19
- refs #22

## Validation
- npm install
- npm run docs:index
- npm run docs:build
- npm test
