### PR TITLE
Tighten first-release publishing flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,15 @@ jobs:
           npx agentinbox --version
           npx agentinbox --help
 
+      - name: Check whether npm version already exists
+        id: npm_version
+        run: |
+          if npm view "@holon-run/agentinbox@${{ steps.meta.outputs.version }}" version --json >/tmp/npm-version.json 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract release notes from changelog
         run: |
           python3 - <<'PY'
@@ -125,9 +134,13 @@ jobs:
           PY
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: steps.npm_version.outputs.exists != 'true'
         run: npm publish --provenance --access public --tag "${{ steps.meta.outputs.npm_tag }}"
+
+      - name: Skip npm publish because version already exists
+        if: steps.npm_version.outputs.exists == 'true'
+        run: |
+          echo "npm package @holon-run/agentinbox@${{ steps.meta.outputs.version }} already exists; skipping publish."
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/testcases/manual/release-checklist.md
+++ b/testcases/manual/release-checklist.md
@@ -9,8 +9,10 @@ Use this checklist before pushing a release tag such as `v0.1.0-beta.1` or
 - [package.json](../../package.json) version already matches the intended tag without the `v` prefix
 - [CHANGELOG.md](../../CHANGELOG.md) has a section for that exact version
 - CI on `main` is green
-- npm publish credentials are available as `NPM_TOKEN`
 - GitHub Actions `release` environment is configured and approved
+- npm trusted publisher is configured for `.github/workflows/release.yml`
+  - for the very first public release, this may not be possible yet because the
+    package does not exist on npm
 
 ## Automated Checks
 
@@ -52,7 +54,21 @@ Also verify:
 1. Update `package.json` version and add the matching `CHANGELOG.md` section in a PR.
 2. Merge the PR to `main`.
 3. Run the manual QA matrix.
-4. Create and push the release tag:
+4. If this is the first npm release for `@holon-run/agentinbox`, publish it manually from a trusted local machine:
+
+```bash
+npm publish --access public
+```
+
+Then configure npm trusted publishing for:
+
+- package: `@holon-run/agentinbox`
+- provider: GitHub Actions
+- repository: `holon-run/agentinbox`
+- workflow: `release.yml`
+- environment: `release`
+
+5. Create and push the release tag:
 
 ```bash
 git checkout main
@@ -61,8 +77,10 @@ git tag v0.1.0-beta.1
 git push origin v0.1.0-beta.1
 ```
 
-5. Wait for the `Release` GitHub Actions workflow to complete.
-6. Verify the npm package and GitHub Release page.
+6. Wait for the `Release` GitHub Actions workflow to complete.
+   - if the version was already published manually, the workflow should skip
+     `npm publish` and still create the GitHub Release
+7. Verify the npm package and GitHub Release page.
 
 ## Post-Release Checks
 


### PR DESCRIPTION
Closes #20
Refs #22

## Summary
- switch release workflow to trusted publishing without NPM_TOKEN
- skip npm publish when the tagged version already exists on npm
- document the first-release manual publish path in the internal release checklist

## Validation
- reviewed release workflow logic locally
- confirmed @holon-run/agentinbox is not yet published on npm
- confirmed npm trusted publisher configuration lives on package settings after first publish