### PR TITLE
Finalize prelaunch API and source cleanup

### DIFF
--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -89,7 +89,7 @@ agentinbox inbox read <agent_id>
 agentinbox source add github_repo_ci holon-run/agentinbox \
   --config-json '{"owner":"holon-run","repo":"agentinbox","uxcAuth":"github-default","pollIntervalSecs":30}'
 agentinbox subscription add <agent_id> <source_id> \
-  --match-json '{"status":"completed","conclusion":"failure","headBranch":"main"}'
+  --filter-json '{"metadata":{"status":"completed","conclusion":"failure","headBranch":"main"}}'
 agentinbox source poll <source_id>
 ```
 

--- a/docs/site/reference/README.md
+++ b/docs/site/reference/README.md
@@ -1,12 +1,17 @@
 # Reference
 
 - [CLI](./cli.md)
+- [HTTP API](./http-api.md)
 - [Source Types](./source-types.md)
 
 <!-- INDEX:START -->
 
 - [CLI Reference](./cli.md)
   `AgentInbox` uses a local control-plane CLI around agents, sources, subscriptions, inboxes, activation targets, and daemon lifecycle.
+  <!-- mdorigin:index kind=article -->
+
+- [HTTP API](./http-api.md)
+  `AgentInbox` exposes a local control-plane HTTP API over either:
   <!-- mdorigin:index kind=article -->
 
 - [Source Types](./source-types.md)

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -38,6 +38,7 @@ agentinbox agent remove <agent_id>
 agentinbox source add <source_type> <source_key> [--config-json ...]
 agentinbox source list
 agentinbox source show <source_id>
+agentinbox source schema <source_type>
 agentinbox source poll <source_id>
 agentinbox source event <source_id> --native-id <id> --event <variant>
 ```
@@ -45,9 +46,10 @@ agentinbox source event <source_id> --native-id <id> --event <variant>
 ## Subscriptions
 
 ```bash
-agentinbox subscription add <agent_id> <source_id> [--match-json ...]
+agentinbox subscription add <agent_id> <source_id> [--filter-json ...]
 agentinbox subscription list
 agentinbox subscription show <subscription_id>
+agentinbox subscription remove <subscription_id>
 agentinbox subscription lag <subscription_id>
 agentinbox subscription reset <subscription_id> --start-policy latest
 ```
@@ -72,3 +74,7 @@ agentinbox inbox compact <agent_id>
 agentinbox gc
 agentinbox status
 ```
+
+## HTTP API
+
+See [HTTP API](./http-api.md) for the stable control-plane endpoints.

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -1,0 +1,76 @@
+# HTTP API
+
+`AgentInbox` exposes a local control-plane HTTP API over either:
+
+- a Unix domain socket
+- a loopback TCP port when started with `serve --port`
+
+The HTTP surface is now resource-oriented and is intended to remain stable
+going forward.
+
+## Meta
+
+- `GET /healthz`
+- `GET /status`
+- `POST /gc`
+
+## Sources
+
+- `GET /sources`
+- `POST /sources`
+- `GET /sources/{sourceId}`
+- `GET /source-types/{sourceType}/schema`
+- `POST /sources/{sourceId}/poll`
+- `POST /sources/{sourceId}/events`
+
+## Agents
+
+- `GET /agents`
+- `POST /agents`
+- `GET /agents/{agentId}`
+- `DELETE /agents/{agentId}`
+
+## Activation Targets
+
+- `GET /agents/{agentId}/targets`
+- `POST /agents/{agentId}/targets`
+- `DELETE /agents/{agentId}/targets/{targetId}`
+
+## Subscriptions
+
+- `GET /subscriptions`
+- `POST /subscriptions`
+- `GET /subscriptions/{subscriptionId}`
+- `DELETE /subscriptions/{subscriptionId}`
+- `POST /subscriptions/{subscriptionId}/poll`
+- `GET /subscriptions/{subscriptionId}/lag`
+- `POST /subscriptions/{subscriptionId}/reset`
+
+## Inbox
+
+- `GET /agents/{agentId}/inbox`
+- `GET /agents/{agentId}/inbox/items`
+- `GET /agents/{agentId}/inbox/watch`
+- `POST /agents/{agentId}/inbox/ack`
+- `POST /agents/{agentId}/inbox/compact`
+
+`POST /agents/{agentId}/inbox/ack` accepts exactly one of:
+
+```json
+{ "throughItemId": "item_..." }
+```
+
+```json
+{ "itemIds": ["item_..."] }
+```
+
+```json
+{ "all": true }
+```
+
+## Notes
+
+- `local_event` is the only source type that supports direct manual append through
+  `POST /sources/{sourceId}/events`.
+- `remote_source` is publicly reserved but registration is intentionally rejected
+  until the declarative runtime exists.

--- a/docs/site/reference/source-types.md
+++ b/docs/site/reference/source-types.md
@@ -23,6 +23,10 @@ It exists to distinguish future external source definitions from:
 The name is intentional: it describes source semantics without exposing
 implementation details such as `uxc`.
 
+`remote_source` is reserved but not yet supported at runtime. Registration
+currently returns a client error until the declarative external-source runtime
+exists.
+
 ## `github_repo`
 
 `github_repo` watches GitHub repository activity and is best suited for:

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -94,7 +94,7 @@ Add or inspect subscriptions:
 
 ```bash
 agentinbox subscription add <agentId> <sourceId>
-agentinbox subscription add <agentId> <sourceId> --match-json '{"headBranch":"main","conclusion":"failure"}'
+agentinbox subscription add <agentId> <sourceId> --filter-json '{"metadata":{"headBranch":"main","conclusion":"failure"}}'
 agentinbox subscription list --agent-id <agentId>
 agentinbox subscription show <subscriptionId>
 agentinbox subscription remove <subscriptionId>

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -49,13 +49,12 @@ class NoopDeliveryAdapter implements DeliveryAdapter {
 }
 
 export class AdapterRegistry {
-  private readonly fixtureSource = new NoopSourceAdapter("fixture");
   private readonly localEventSource = new NoopSourceAdapter("local_event");
   private readonly remoteSource = new NoopSourceAdapter("remote_source");
   private readonly feishuSource: FeishuSourceRuntime;
   private readonly githubSource: GithubSourceRuntime;
   private readonly githubCiSource: GithubCiSourceRuntime;
-  private readonly fixtureDelivery = new NoopDeliveryAdapter();
+  private readonly defaultDelivery = new NoopDeliveryAdapter();
   private readonly feishuDelivery = new FeishuDeliveryAdapter();
   private readonly githubDelivery = new GithubDeliveryAdapter();
 
@@ -66,9 +65,6 @@ export class AdapterRegistry {
   }
 
   sourceAdapterFor(type: SourceType): SourceAdapter {
-    if (type === "fixture") {
-      return this.fixtureSource;
-    }
     if (type === "local_event") {
       return this.localEventSource;
     }
@@ -84,20 +80,17 @@ export class AdapterRegistry {
     if (type === "feishu_bot") {
       return this.feishuSource;
     }
-    return this.fixtureSource;
+    return this.localEventSource;
   }
 
   deliveryAdapterFor(provider: string): DeliveryAdapter {
-    if (provider === "fixture") {
-      return this.fixtureDelivery;
-    }
     if (provider === "feishu") {
       return this.feishuDelivery;
     }
     if (provider === "github") {
       return this.githubDelivery;
     }
-    return this.fixtureDelivery;
+    return this.defaultDelivery;
   }
 
   async start(): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
     if (!type || !sourceKey) {
       throw new Error("usage: agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]");
     }
-    await printRemote(client, "/sources/register", {
+    await printRemote(client, "/sources", {
       sourceType: type,
       sourceKey,
       configRef: takeFlagValue(normalized, "--config-ref") ?? null,
@@ -116,7 +116,7 @@ async function main(): Promise<void> {
 
   if (command === "agent" && normalized[1] === "register") {
     const detected = detectTerminalContext(process.env);
-    await printRemote(client, "/agents/register", {
+    await printRemote(client, "/agents", {
       agentId: takeFlagValue(normalized, "--agent-id") ?? null,
       forceRebind: normalized.includes("--force-rebind"),
       backend: detected.backend,
@@ -192,7 +192,7 @@ async function main(): Promise<void> {
     if (!agentId || !sourceId) {
       throw new Error("usage: agentinbox subscription add <agentId> <sourceId> [--filter-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
     }
-    await printRemote(client, "/subscriptions/register", {
+    await printRemote(client, "/subscriptions", {
       agentId,
       sourceId,
       filter: parseJsonArg(takeFlagValue(normalized, "--filter-json")),
@@ -316,14 +316,10 @@ async function main(): Promise<void> {
     if (!agentId || modeCount !== 1) {
       throw new Error("usage: agentinbox inbox ack <agentId> (--through <itemId> | --item <itemId> | --all)");
     }
-    if (ackAll) {
-      await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox/ack-all`, {});
-      return;
-    }
     await printRemote(
       client,
       `/agents/${encodeURIComponent(agentId)}/inbox/ack`,
-      throughItemId ? { throughItemId } : { itemIds: [itemId] },
+      ackAll ? { all: true } : (throughItemId ? { throughItemId } : { itemIds: [itemId] }),
     );
     return;
   }
@@ -339,23 +335,6 @@ async function main(): Promise<void> {
 
   if (command === "gc") {
     await printRemote(client, "/gc", {});
-    return;
-  }
-
-  if (command === "fixture" && normalized[1] === "emit") {
-    const sourceId = normalized[2];
-    const sourceNativeId = takeFlagValue(normalized, "--native-id") ?? `fixture-${Date.now()}`;
-    const eventVariant = takeFlagValue(normalized, "--event") ?? "message";
-    if (!sourceId) {
-      throw new Error("usage: agentinbox fixture emit <sourceId> [--native-id ID] [--event EVENT] [--metadata-json JSON] [--payload-json JSON]");
-    }
-    await printRemote(client, "/fixtures/emit", {
-      sourceId,
-      sourceNativeId,
-      eventVariant,
-      metadata: parseJsonArg(takeFlagValue(normalized, "--metadata-json")),
-      rawPayload: parseJsonArg(takeFlagValue(normalized, "--payload-json")),
-    });
     return;
   }
 
@@ -560,10 +539,8 @@ Commands:
   subscription
   inbox
   gc
-  fixture
   deliver
   status
-  gc
   version
 `,
     serve: `agentinbox serve
@@ -620,11 +597,6 @@ Usage:
   agentinbox inbox watch <agentId> [--after-item ID] [--include-acked] [--heartbeat-ms N]
   agentinbox inbox ack <agentId> (--through <itemId> | --item <itemId> | --all)
   agentinbox inbox compact <agentId>
-`,
-    fixture: `agentinbox fixture
-
-Usage:
-  agentinbox fixture emit <sourceId> [--native-id ID] [--event EVENT] [--metadata-json JSON] [--payload-json JSON]
 `,
     deliver: `agentinbox deliver
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -60,7 +60,7 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
-      if (req.method === "POST" && url.pathname === "/sources/register") {
+      if (req.method === "POST" && url.pathname === "/sources") {
         send(res, 200, await service.registerSource(await readJson(req) as never));
         return;
       }
@@ -105,9 +105,9 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
-      if (req.method === "POST" && url.pathname === "/agents/register") {
+      if (req.method === "POST" && url.pathname === "/agents") {
         const body = await readJson(req);
-        const backend = parseRequiredString(body.backend, "agents/register requires backend");
+        const backend = parseRequiredString(body.backend, "agents requires backend");
         send(res, 200, service.registerAgent({
           agentId: parseOptionalString(body.agentId) ?? null,
           forceRebind: parseOptionalBoolean(body.forceRebind) ?? false,
@@ -178,11 +178,11 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
-      if (req.method === "POST" && url.pathname === "/subscriptions/register") {
+      if (req.method === "POST" && url.pathname === "/subscriptions") {
         const body = await readJson(req);
         send(res, 200, await service.registerSubscription({
-          agentId: parseRequiredString(body.agentId, "subscriptions/register requires agentId"),
-          sourceId: parseRequiredString(body.sourceId, "subscriptions/register requires sourceId"),
+          agentId: parseRequiredString(body.agentId, "subscriptions requires agentId"),
+          sourceId: parseRequiredString(body.sourceId, "subscriptions requires sourceId"),
           filter: asObject(body.filter),
           lifecycleMode: parseOptionalString(body.lifecycleMode) as never,
           expiresAt: parseOptionalString(body.expiresAt) ?? null,
@@ -224,22 +224,6 @@ export function createServer(service: AgentInboxService): http.Server {
           startPolicy: startPolicy as never,
           startOffset: parseOptionalInteger(body.startOffset),
           startTime: parseOptionalString(body.startTime) ?? null,
-        }));
-        return;
-      }
-
-      if (req.method === "POST" && url.pathname === "/fixtures/emit") {
-        const body = await readJson(req);
-        const sourceId = parseRequiredString(body.sourceId, "fixtures/emit requires sourceId");
-        const sourceNativeId = parseRequiredString(body.sourceNativeId, "fixtures/emit requires sourceNativeId");
-        const eventVariant = parseRequiredString(body.eventVariant, "fixtures/emit requires eventVariant");
-        send(res, 200, await service.appendFixtureEvent(sourceId, {
-          sourceNativeId,
-          eventVariant,
-          occurredAt: parseOptionalString(body.occurredAt),
-          metadata: asObject(body.metadata),
-          rawPayload: asObject(body.rawPayload),
-          deliveryHandle: parseOptionalDeliveryHandle(body.deliveryHandle),
         }));
         return;
       }
@@ -310,12 +294,6 @@ export function createServer(service: AgentInboxService): http.Server {
         return;
       }
 
-      const agentInboxAckAllMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/ack-all$/);
-      if (req.method === "POST" && agentInboxAckAllMatch) {
-        send(res, 200, service.ackAllInboxItems(decodeURIComponent(agentInboxAckAllMatch[1])));
-        return;
-      }
-
       const agentInboxCompactMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/compact$/);
       if (req.method === "POST" && agentInboxCompactMatch) {
         send(res, 200, service.compactInbox(decodeURIComponent(agentInboxCompactMatch[1])));
@@ -327,15 +305,17 @@ export function createServer(service: AgentInboxService): http.Server {
         const body = await readJson(req);
         const itemIds = Array.isArray(body.itemIds) ? body.itemIds.map((itemId) => String(itemId)) : [];
         const throughItemId = parseOptionalString(body.throughItemId);
-        if (throughItemId && itemIds.length > 0) {
-          send(res, 400, { error: "inbox/ack accepts either itemIds or throughItemId" });
+        const ackAll = parseOptionalBoolean(body.all) ?? false;
+        const modeCount = Number(itemIds.length > 0) + Number(Boolean(throughItemId)) + Number(ackAll);
+        if (modeCount !== 1) {
+          send(res, 400, { error: "inbox/ack accepts exactly one of itemIds, throughItemId, or all" });
           return;
         }
-        if (throughItemId) {
-          send(res, 200, service.ackInboxItemsThrough(decodeURIComponent(agentInboxAckMatch[1]), throughItemId));
-          return;
-        }
-        send(res, 200, service.ackInboxItems(decodeURIComponent(agentInboxAckMatch[1]), itemIds));
+        send(res, 200, service.ackInbox(decodeURIComponent(agentInboxAckMatch[1]), {
+          itemIds,
+          throughItemId: throughItemId ?? null,
+          all: ackAll,
+        }));
         return;
       }
 
@@ -411,12 +391,12 @@ function parsePositiveInteger(value: unknown): number {
 function isBadRequestError(message: string): boolean {
   return (
     message.startsWith("manual append is not supported") ||
-    message.startsWith("fixtures/emit requires") ||
     message.startsWith("sources/events requires") ||
     message.startsWith("deliveryHandle requires") ||
     message.startsWith("subscriptions/reset requires") ||
-    message.startsWith("agents/register requires") ||
+    message.startsWith("agents requires") ||
     message.startsWith("agents/targets requires") ||
+    message.startsWith("subscriptions requires") ||
     message.startsWith("agent register conflict") ||
     message.startsWith("unsupported activation target kind") ||
     message.startsWith("unsupported lifecycle mode") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-export type SourceType = "fixture" | "local_event" | "remote_source" | "github_repo" | "github_repo_ci" | "feishu_bot";
+export type SourceType = "local_event" | "remote_source" | "github_repo" | "github_repo_ci" | "feishu_bot";
 
 export type SubscriptionStartPolicy = "latest" | "earliest" | "at_offset" | "at_time";
 export type SubscriptionLifecycleMode = "standing" | "temporary";

--- a/src/service.ts
+++ b/src/service.ts
@@ -491,14 +491,6 @@ export class AgentInboxService {
     return this.appendSourceEvent({ ...input, sourceId });
   }
 
-  async appendFixtureEvent(sourceId: string, input: Omit<AppendSourceEventInput, "sourceId">): Promise<AppendSourceEventResult> {
-    const source = this.getSource(sourceId);
-    if (source.sourceType !== "fixture") {
-      throw new Error(`fixtures/emit requires fixture source, received: ${source.sourceType}`);
-    }
-    return this.appendSourceEvent({ ...input, sourceId });
-  }
-
   listInboxAgentIds(): string[] {
     return this.store.listInboxes().map((inbox) => inbox.ownerAgentId);
   }
@@ -621,6 +613,20 @@ export class AgentInboxService {
       void this.handleInboxAckEffects(agentId);
     }
     return { acked };
+  }
+
+  ackInbox(agentId: string, input: {
+    itemIds?: string[];
+    throughItemId?: string | null;
+    all?: boolean;
+  }): { acked: number } {
+    if (input.all) {
+      return this.ackAllInboxItems(agentId);
+    }
+    if (input.throughItemId) {
+      return this.ackInboxItemsThrough(agentId, input.throughItemId);
+    }
+    return this.ackInboxItems(agentId, input.itemIds ?? []);
   }
 
   compactInbox(agentId: string): { deleted: number; retentionMs: number } {

--- a/src/source_schema.ts
+++ b/src/source_schema.ts
@@ -1,15 +1,6 @@
 import { SourceSchema, SourceType } from "./model";
 
 const SOURCE_SCHEMAS: Record<SourceType, SourceSchema> = {
-  fixture: {
-    sourceType: "fixture",
-    metadataFields: [],
-    payloadExamples: [
-      { text: "hello from fixture" },
-    ],
-    eventVariantExamples: ["message.created"],
-    configFields: [],
-  },
   local_event: {
     sourceType: "local_event",
     metadataFields: [

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,7 +29,7 @@ import {
 } from "./model";
 import { generateId, nowIso } from "./util";
 
-const SCHEMA_VERSION = 11;
+const SCHEMA_VERSION = 12;
 type SqlBindParams = unknown[];
 
 function parseJson<T>(value: string | null): T {
@@ -367,15 +367,10 @@ export class AgentInboxStore {
   }
 
   getSourceByKey(sourceType: string, sourceKey: string): SubscriptionSource | null {
-    const row = sourceType === "local_event"
-      ? this.getOne(
-        "select * from sources where source_type in (?, ?) and source_key = ? order by case when source_type = ? then 0 else 1 end limit 1",
-        ["local_event", "custom", sourceKey, "local_event"],
-      )
-      : this.getOne(
-        "select * from sources where source_type = ? and source_key = ?",
-        [sourceType, sourceKey],
-      );
+    const row = this.getOne(
+      "select * from sources where source_type = ? and source_key = ?",
+      [sourceType, sourceKey],
+    );
     return row ? this.mapSource(row) : null;
   }
 
@@ -1362,12 +1357,9 @@ export class AgentInboxStore {
   }
 
   private mapSource(row: Record<string, unknown>): SubscriptionSource {
-    const sourceType = String(row.source_type) === "custom"
-      ? "local_event"
-      : row.source_type as SubscriptionSource["sourceType"];
     return {
       sourceId: String(row.source_id),
-      sourceType,
+      sourceType: row.source_type as SubscriptionSource["sourceType"],
       sourceKey: String(row.source_key),
       configRef: row.config_ref ? String(row.config_ref) : null,
       config: parseJson<Record<string, unknown>>(row.config_json as string),

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -209,7 +209,7 @@ test("shared source can route one stream event to multiple agent inboxes", async
     const alpha = await registerTmuxAgent(service, "1");
     const beta = await registerTmuxAgent(service, "2");
     const source = await service.registerSource({
-      sourceType: "fixture",
+      sourceType: "local_event",
       sourceKey: "demo",
       config: {},
     });
@@ -275,57 +275,6 @@ test("local_event source can act as a programmable event bus source", async () =
     assert.equal(pollResult.inboxItemsCreated, 1);
     assert.equal(items.length, 1);
     assert.equal(items[0].sourceNativeId, "local-evt-1");
-  } finally {
-    await service.stop();
-    store.close();
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("legacy custom sources are surfaced as local_event and still accept manual append", async () => {
-  const { store, service, dir } = await makeService();
-  try {
-    const alpha = await registerTmuxAgent(service, "legacy-custom");
-    const source = await service.registerSource({
-      sourceType: "local_event",
-      sourceKey: "legacy-custom-demo",
-      config: {},
-    });
-
-    ((store as unknown) as { db: { run(sql: string, params?: unknown[]): void } }).db.run(
-      "update sources set source_type = 'custom' where source_id = ?",
-      [source.sourceId],
-    );
-
-    const aliased = service.getSource(source.sourceId);
-    assert.equal(aliased.sourceType, "local_event");
-    const details = service.getSourceDetails(source.sourceId) as { source: { sourceType: string }; schema: { sourceType: string } };
-    assert.equal(details.source.sourceType, "local_event");
-    assert.equal(details.schema.sourceType, "local_event");
-
-    const same = await service.registerSource({
-      sourceType: "local_event",
-      sourceKey: "legacy-custom-demo",
-      config: {},
-    });
-    assert.equal(same.sourceId, source.sourceId);
-
-    await service.appendSourceEventByCaller(source.sourceId, {
-      sourceNativeId: "legacy-custom-evt-1",
-      eventVariant: "message.created",
-      metadata: { channel: "engineering" },
-      rawPayload: { text: "hello from legacy custom source" },
-    });
-
-    const subscription = await service.registerSubscription({
-      agentId: alpha.agentId,
-      sourceId: source.sourceId,
-      filter: { metadata: { channel: "engineering" } },
-      startPolicy: "earliest",
-    });
-    const pollResult = await service.pollSubscription(subscription.subscriptionId);
-    assert.equal(pollResult.inboxItemsCreated, 1);
-    assert.equal(service.listInboxItems(alpha.agentId)[0]?.sourceNativeId, "legacy-custom-evt-1");
   } finally {
     await service.stop();
     store.close();
@@ -554,7 +503,7 @@ test("watchInbox receives inserted items without auto-acking them", async () => 
   try {
     const alpha = await registerTmuxAgent(service, "4");
     const source = await service.registerSource({
-      sourceType: "fixture",
+      sourceType: "local_event",
       sourceKey: "watch-demo",
       config: {},
     });

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -259,7 +259,7 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       const agentResponse = await client.request<{
         agent: { agentId: string };
         terminalTarget: { targetId: string };
-      }>("/agents/register", {
+      }>("/agents", {
         backend: "tmux",
         runtimeKind: "codex",
         runtimeSessionId: "thread-e2e",
@@ -276,8 +276,8 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       });
       assert.equal(targetResponse.statusCode, 200);
 
-      const sourceResponse = await client.request<{ sourceId: string }>("/sources/register", {
-        sourceType: "fixture",
+      const sourceResponse = await client.request<{ sourceId: string }>("/sources", {
+        sourceType: "local_event",
         sourceKey: "e2e-demo",
         config: {},
       } satisfies RegisterSourceInput);
@@ -292,7 +292,7 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(schemaResponse.data.sourceType, "github_repo_ci");
       assert.ok(schemaResponse.data.metadataFields.length > 0);
 
-      const subscriptionResponse = await client.request<{ subscriptionId: string }>("/subscriptions/register", {
+      const subscriptionResponse = await client.request<{ subscriptionId: string }>("/subscriptions", {
         agentId,
         sourceId: sourceResponse.data.sourceId,
         filter: { metadata: { channel: "engineering" } },
@@ -300,13 +300,12 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       });
       assert.equal(subscriptionResponse.statusCode, 200);
 
-      const appendResponse = await client.request<{ appended: number }>("/fixtures/emit", {
-        sourceId: sourceResponse.data.sourceId,
+      const appendResponse = await client.request<{ appended: number }>(`/sources/${encodeURIComponent(sourceResponse.data.sourceId)}/events`, {
         sourceNativeId: "evt-e2e-1",
         eventVariant: "message.created",
         occurredAt: "2026-04-05T00:00:00Z",
         metadata: { channel: "engineering", subject: "hello" },
-        rawPayload: { text: "hello from fixture" },
+        rawPayload: { text: "hello from local event source" },
       });
       assert.equal(appendResponse.statusCode, 200);
       assert.equal(appendResponse.data.appended, 1);
@@ -370,7 +369,7 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(subscriptionsAfterDelete.statusCode, 200);
       assert.equal(subscriptionsAfterDelete.data.subscriptions.length, 0);
 
-      const invalidLifecycleResponse = await client.request<{ error: string }>("/subscriptions/register", {
+      const invalidLifecycleResponse = await client.request<{ error: string }>("/subscriptions", {
         agentId,
         sourceId: sourceResponse.data.sourceId,
         lifecycleMode: "ephemeral",
@@ -416,7 +415,7 @@ test("control plane exposes inbox compact and global gc endpoints", async () => 
       });
       const agentResponse = await client.request<{
         agent: { agentId: string };
-      }>("/agents/register", {
+      }>("/agents", {
         backend: "tmux",
         runtimeKind: "codex",
         runtimeSessionId: "thread-gc",
@@ -522,7 +521,7 @@ test("control plane can remove agents and gc stale offline agents", async () => 
       });
       const agentResponse = await client.request<{
         agent: { agentId: string };
-      }>("/agents/register", {
+      }>("/agents", {
         backend: "tmux",
         runtimeKind: "codex",
         runtimeSessionId: "thread-remove-http",
@@ -587,7 +586,7 @@ test("control plane accepts caller-supplied agent ids and rejects conflicting re
     const started = await startControlServer(server, { kind: "socket", socketPath });
     try {
       const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
-      const first = await client.request<{ agent: { agentId: string } }>("/agents/register", {
+      const first = await client.request<{ agent: { agentId: string } }>("/agents", {
         agentId: "agent-http-alpha",
         backend: "tmux",
         runtimeKind: "codex",
@@ -597,7 +596,7 @@ test("control plane accepts caller-supplied agent ids and rejects conflicting re
       assert.equal(first.statusCode, 200);
       assert.equal(first.data.agent.agentId, "agent-http-alpha");
 
-      const conflict = await client.request<{ error: string }>("/agents/register", {
+      const conflict = await client.request<{ error: string }>("/agents", {
         agentId: "agent-http-alpha",
         backend: "tmux",
         runtimeKind: "codex",
@@ -607,7 +606,7 @@ test("control plane accepts caller-supplied agent ids and rejects conflicting re
       assert.equal(conflict.statusCode, 400);
       assert.match(conflict.data.error, /agent register conflict/);
 
-      const invalidForceRebind = await client.request<{ error: string }>("/agents/register", {
+      const invalidForceRebind = await client.request<{ error: string }>("/agents", {
         agentId: "agent-http-alpha",
         forceRebind: "false",
         backend: "tmux",
@@ -618,7 +617,7 @@ test("control plane accepts caller-supplied agent ids and rejects conflicting re
       assert.equal(invalidForceRebind.statusCode, 400);
       assert.match(invalidForceRebind.data.error, /expected boolean/);
 
-      const rebound = await client.request<{ terminalTarget: { tmuxPaneId: string | null } }>("/agents/register", {
+      const rebound = await client.request<{ terminalTarget: { tmuxPaneId: string | null } }>("/agents", {
         agentId: "agent-http-alpha",
         forceRebind: true,
         backend: "tmux",
@@ -664,7 +663,7 @@ test("control plane rejects reserved remote_source registration", async () => {
         socketPath,
         source: "flag",
       });
-      const response = await client.request<{ error: string }>("/sources/register", {
+      const response = await client.request<{ error: string }>("/sources", {
         sourceType: "remote_source",
         sourceKey: "reserved-demo",
         config: {},

--- a/test/source_schema.test.ts
+++ b/test/source_schema.test.ts
@@ -17,5 +17,4 @@ test("getSourceSchema exposes lightweight schemas for local and reserved sources
   assert.equal(localEvent.sourceType, "local_event");
   assert.ok(localEvent.metadataFields.some((field) => field.name === "channel"));
   assert.equal(getSourceSchema("remote_source").sourceType, "remote_source");
-  assert.equal(getSourceSchema("fixture").sourceType, "fixture");
 });


### PR DESCRIPTION
Refs #22
Refs #34

## Summary
- remove fixture from the public API surface and drop legacy custom/local_event compatibility
- normalize HTTP create and inbox ack routes into the final stable shape
- align CLI and docs with the final public source and route model

## Validation
- npm test
- npm run build
- npm run docs:index
- npm run docs:build