### PR TITLE
feat: adopt Drizzle for SQLite schema and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ Build docs directory indexes:
 npm run docs:index
 ```
 
+Generate new SQLite migrations after schema changes:
+
+```bash
+npm run db:migrations:generate
+```
+
+`AgentInbox` now upgrades SQLite state with versioned SQL migrations in
+`drizzle/migrations`. On upgrade with pending migrations, the daemon creates a
+local backup next to the DB file (for example,
+`~/.agentinbox/agentinbox.sqlite.backup-<timestamp>`).
+
 ## Release
 
 `AgentInbox` releases are tag-driven.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./drizzle/schema.ts",
+  out: "./drizzle/migrations",
+  strict: true,
+  verbose: true,
+});
+

--- a/drizzle/migrations/0000_initial.sql
+++ b/drizzle/migrations/0000_initial.sql
@@ -1,0 +1,206 @@
+create table if not exists sources (
+  source_id text primary key,
+  source_type text not null,
+  source_key text not null,
+  config_ref text,
+  config_json text not null,
+  status text not null,
+  checkpoint text,
+  created_at text not null,
+  updated_at text not null,
+  unique(source_type, source_key)
+);
+
+create table if not exists agents (
+  agent_id text primary key,
+  status text not null,
+  offline_since text,
+  runtime_kind text not null,
+  runtime_session_id text,
+  created_at text not null,
+  updated_at text not null,
+  last_seen_at text not null
+);
+
+create table if not exists inboxes (
+  inbox_id text primary key,
+  owner_agent_id text not null unique,
+  created_at text not null
+);
+
+create table if not exists subscriptions (
+  subscription_id text primary key,
+  agent_id text not null,
+  source_id text not null,
+  filter_json text not null,
+  lifecycle_mode text not null,
+  expires_at text,
+  start_policy text not null,
+  start_offset integer,
+  start_time text,
+  created_at text not null
+);
+
+create table if not exists activation_targets (
+  target_id text primary key,
+  agent_id text not null,
+  kind text not null,
+  status text not null,
+  offline_since text,
+  consecutive_failures integer not null,
+  last_delivered_at text,
+  last_error text,
+  mode text not null,
+  notify_lease_ms integer not null,
+  url text,
+  runtime_kind text,
+  runtime_session_id text,
+  backend text,
+  tmux_pane_id text,
+  tty text,
+  term_program text,
+  iterm_session_id text,
+  created_at text not null,
+  updated_at text not null,
+  last_seen_at text not null
+);
+
+create table if not exists activation_dispatch_states (
+  agent_id text not null,
+  target_id text not null,
+  status text not null,
+  lease_expires_at text,
+  pending_new_item_count integer not null,
+  pending_summary text,
+  pending_subscription_ids_json text not null,
+  pending_source_ids_json text not null,
+  updated_at text not null,
+  primary key (agent_id, target_id)
+);
+
+create table if not exists inbox_items (
+  item_id text primary key,
+  source_id text not null,
+  source_native_id text not null,
+  event_variant text not null,
+  inbox_id text not null,
+  occurred_at text not null,
+  metadata_json text not null,
+  raw_payload_json text not null,
+  delivery_handle_json text,
+  acked_at text,
+  unique(source_id, source_native_id, event_variant, inbox_id)
+);
+
+create table if not exists activations (
+  activation_id text primary key,
+  kind text not null,
+  agent_id text not null,
+  inbox_id text not null,
+  target_id text not null,
+  target_kind text not null,
+  subscription_ids_json text not null,
+  source_ids_json text not null,
+  new_item_count integer not null,
+  summary text not null,
+  items_json text,
+  created_at text not null,
+  delivered_at text
+);
+
+create table if not exists deliveries (
+  delivery_id text primary key,
+  provider text not null,
+  surface text not null,
+  target_ref text not null,
+  thread_ref text,
+  reply_mode text,
+  kind text not null,
+  payload_json text not null,
+  status text not null,
+  created_at text not null
+);
+
+create table if not exists streams (
+  stream_id text primary key,
+  source_id text not null unique,
+  stream_key text not null unique,
+  backend text not null,
+  created_at text not null
+);
+
+create table if not exists stream_events (
+  offset integer primary key autoincrement,
+  stream_event_id text not null unique,
+  stream_id text not null,
+  source_id text not null,
+  source_native_id text not null,
+  event_variant text not null,
+  occurred_at text not null,
+  metadata_json text not null,
+  raw_payload_json text not null,
+  delivery_handle_json text,
+  created_at text not null,
+  unique(stream_id, source_native_id, event_variant)
+);
+
+create table if not exists consumers (
+  consumer_id text primary key,
+  stream_id text not null,
+  subscription_id text not null unique,
+  consumer_key text not null unique,
+  start_policy text not null,
+  start_offset integer,
+  start_time text,
+  next_offset integer not null,
+  created_at text not null,
+  updated_at text not null
+);
+
+create table if not exists consumer_commits (
+  commit_id text primary key,
+  consumer_id text not null,
+  stream_id text not null,
+  committed_offset integer not null,
+  committed_at text not null
+);
+
+create unique index if not exists idx_activation_targets_terminal_tmux
+  on activation_targets(tmux_pane_id)
+  where kind = 'terminal' and tmux_pane_id is not null;
+
+create unique index if not exists idx_activation_targets_terminal_iterm
+  on activation_targets(iterm_session_id)
+  where kind = 'terminal' and iterm_session_id is not null;
+
+create unique index if not exists idx_activation_targets_runtime_session
+  on activation_targets(runtime_kind, runtime_session_id)
+  where kind = 'terminal' and runtime_session_id is not null;
+
+create index if not exists idx_activation_dispatch_states_target
+  on activation_dispatch_states(target_id, lease_expires_at);
+
+create index if not exists idx_inbox_items_acked_at
+  on inbox_items(acked_at);
+
+create index if not exists idx_inbox_items_inbox_acked_at
+  on inbox_items(inbox_id, acked_at);
+
+create index if not exists idx_agents_status_offline
+  on agents(status, offline_since);
+
+create index if not exists idx_activation_targets_agent_status
+  on activation_targets(agent_id, status);
+
+create index if not exists idx_stream_events_stream_offset
+  on stream_events(stream_id, offset);
+
+create index if not exists idx_stream_events_stream_occurred_at
+  on stream_events(stream_id, occurred_at);
+
+create index if not exists idx_consumers_stream
+  on consumers(stream_id);
+
+create index if not exists idx_consumer_commits_consumer
+  on consumer_commits(consumer_id, committed_offset);
+

--- a/drizzle/migrations/0001_inbox_items_source_occurred_at_idx.sql
+++ b/drizzle/migrations/0001_inbox_items_source_occurred_at_idx.sql
@@ -1,0 +1,3 @@
+create index if not exists idx_inbox_items_source_occurred_at
+  on inbox_items(source_id, occurred_at);
+

--- a/drizzle/migrations/meta/0001_snapshot.json
+++ b/drizzle/migrations/meta/0001_snapshot.json
@@ -1,0 +1,1181 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c2ffff6a-63ab-47d6-a017-32dcfcd66294",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "activation_dispatch_states": {
+      "name": "activation_dispatch_states",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_new_item_count": {
+          "name": "pending_new_item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_summary": {
+          "name": "pending_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_subscription_ids_json": {
+          "name": "pending_subscription_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_source_ids_json": {
+          "name": "pending_source_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_activation_dispatch_states_target": {
+          "name": "idx_activation_dispatch_states_target",
+          "columns": [
+            "target_id",
+            "lease_expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "activation_dispatch_states_agent_id_target_id_pk": {
+          "columns": [
+            "agent_id",
+            "target_id"
+          ],
+          "name": "activation_dispatch_states_agent_id_target_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activation_targets": {
+      "name": "activation_targets",
+      "columns": {
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offline_since": {
+          "name": "offline_since",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_delivered_at": {
+          "name": "last_delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notify_lease_ms": {
+          "name": "notify_lease_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_kind": {
+          "name": "runtime_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_session_id": {
+          "name": "runtime_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tmux_pane_id": {
+          "name": "tmux_pane_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tty": {
+          "name": "tty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "term_program": {
+          "name": "term_program",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "iterm_session_id": {
+          "name": "iterm_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_activation_targets_agent_status": {
+          "name": "idx_activation_targets_agent_status",
+          "columns": [
+            "agent_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activations": {
+      "name": "activations",
+      "columns": {
+        "activation_id": {
+          "name": "activation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subscription_ids_json": {
+          "name": "subscription_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ids_json": {
+          "name": "source_ids_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_item_count": {
+          "name": "new_item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "offline_since": {
+          "name": "offline_since",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_kind": {
+          "name": "runtime_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtime_session_id": {
+          "name": "runtime_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agents_status_offline": {
+          "name": "idx_agents_status_offline",
+          "columns": [
+            "status",
+            "offline_since"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "consumer_commits": {
+      "name": "consumer_commits",
+      "columns": {
+        "commit_id": {
+          "name": "commit_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumer_id": {
+          "name": "consumer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "committed_offset": {
+          "name": "committed_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_consumer_commits_consumer": {
+          "name": "idx_consumer_commits_consumer",
+          "columns": [
+            "consumer_id",
+            "committed_offset"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "consumers": {
+      "name": "consumers",
+      "columns": {
+        "consumer_id": {
+          "name": "consumer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumer_key": {
+          "name": "consumer_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_policy": {
+          "name": "start_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_offset": {
+          "name": "next_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_consumers_subscription_id": {
+          "name": "idx_consumers_subscription_id",
+          "columns": [
+            "subscription_id"
+          ],
+          "isUnique": true
+        },
+        "idx_consumers_consumer_key": {
+          "name": "idx_consumers_consumer_key",
+          "columns": [
+            "consumer_key"
+          ],
+          "isUnique": true
+        },
+        "idx_consumers_stream": {
+          "name": "idx_consumers_stream",
+          "columns": [
+            "stream_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deliveries": {
+      "name": "deliveries",
+      "columns": {
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_ref": {
+          "name": "target_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_ref": {
+          "name": "thread_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_mode": {
+          "name": "reply_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inbox_items": {
+      "name": "inbox_items",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_native_id": {
+          "name": "source_native_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_variant": {
+          "name": "event_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload_json": {
+          "name": "raw_payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_handle_json": {
+          "name": "delivery_handle_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_items_source_native_event_inbox": {
+          "name": "idx_inbox_items_source_native_event_inbox",
+          "columns": [
+            "source_id",
+            "source_native_id",
+            "event_variant",
+            "inbox_id"
+          ],
+          "isUnique": true
+        },
+        "idx_inbox_items_acked_at": {
+          "name": "idx_inbox_items_acked_at",
+          "columns": [
+            "acked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_inbox_items_inbox_acked_at": {
+          "name": "idx_inbox_items_inbox_acked_at",
+          "columns": [
+            "inbox_id",
+            "acked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_inbox_items_source_occurred_at": {
+          "name": "idx_inbox_items_source_occurred_at",
+          "columns": [
+            "source_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inboxes": {
+      "name": "inboxes",
+      "columns": {
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_agent_id": {
+          "name": "owner_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inboxes_owner_agent_id": {
+          "name": "idx_inboxes_owner_agent_id",
+          "columns": [
+            "owner_agent_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_ref": {
+          "name": "config_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sources_type_key": {
+          "name": "idx_sources_type_key",
+          "columns": [
+            "source_type",
+            "source_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stream_events": {
+      "name": "stream_events",
+      "columns": {
+        "offset": {
+          "name": "offset",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "stream_event_id": {
+          "name": "stream_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_native_id": {
+          "name": "source_native_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_variant": {
+          "name": "event_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_payload_json": {
+          "name": "raw_payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_handle_json": {
+          "name": "delivery_handle_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_stream_events_stream_event_id": {
+          "name": "idx_stream_events_stream_event_id",
+          "columns": [
+            "stream_event_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stream_events_stream_source_native_variant": {
+          "name": "idx_stream_events_stream_source_native_variant",
+          "columns": [
+            "stream_id",
+            "source_native_id",
+            "event_variant"
+          ],
+          "isUnique": true
+        },
+        "idx_stream_events_stream_offset": {
+          "name": "idx_stream_events_stream_offset",
+          "columns": [
+            "stream_id",
+            "offset"
+          ],
+          "isUnique": false
+        },
+        "idx_stream_events_stream_occurred_at": {
+          "name": "idx_stream_events_stream_occurred_at",
+          "columns": [
+            "stream_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "streams": {
+      "name": "streams",
+      "columns": {
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stream_key": {
+          "name": "stream_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_streams_source_id": {
+          "name": "idx_streams_source_id",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": true
+        },
+        "idx_streams_stream_key": {
+          "name": "idx_streams_stream_key",
+          "columns": [
+            "stream_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filter_json": {
+          "name": "filter_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lifecycle_mode": {
+          "name": "lifecycle_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_policy": {
+          "name": "start_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -1,0 +1,21 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1744128000000,
+      "tag": "0000_initial",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1744128060000,
+      "tag": "0001_inbox_items_source_occurred_at_idx",
+      "breakpoints": true
+    }
+  ]
+}
+

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -1,21 +1,20 @@
 {
-  "version": "7",
+  "version": "6",
   "dialect": "sqlite",
   "entries": [
     {
       "idx": 0,
-      "version": "7",
+      "version": "6",
       "when": 1744128000000,
       "tag": "0000_initial",
       "breakpoints": true
     },
     {
       "idx": 1,
-      "version": "7",
+      "version": "6",
       "when": 1744128060000,
       "tag": "0001_inbox_items_source_occurred_at_idx",
       "breakpoints": true
     }
   ]
 }
-

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,0 +1,167 @@
+import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+export const sources = sqliteTable("sources", {
+  sourceId: text("source_id").primaryKey(),
+  sourceType: text("source_type").notNull(),
+  sourceKey: text("source_key").notNull(),
+  configRef: text("config_ref"),
+  configJson: text("config_json").notNull(),
+  status: text("status").notNull(),
+  checkpoint: text("checkpoint"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+}, (table) => ({
+  sourceTypeKey: uniqueIndex("idx_sources_type_key").on(table.sourceType, table.sourceKey),
+}));
+
+export const agents = sqliteTable("agents", {
+  agentId: text("agent_id").primaryKey(),
+  status: text("status").notNull(),
+  offlineSince: text("offline_since"),
+  runtimeKind: text("runtime_kind").notNull(),
+  runtimeSessionId: text("runtime_session_id"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  lastSeenAt: text("last_seen_at").notNull(),
+});
+
+export const inboxes = sqliteTable("inboxes", {
+  inboxId: text("inbox_id").primaryKey(),
+  ownerAgentId: text("owner_agent_id").notNull(),
+  createdAt: text("created_at").notNull(),
+});
+
+export const subscriptions = sqliteTable("subscriptions", {
+  subscriptionId: text("subscription_id").primaryKey(),
+  agentId: text("agent_id").notNull(),
+  sourceId: text("source_id").notNull(),
+  filterJson: text("filter_json").notNull(),
+  lifecycleMode: text("lifecycle_mode").notNull(),
+  expiresAt: text("expires_at"),
+  startPolicy: text("start_policy").notNull(),
+  startOffset: integer("start_offset"),
+  startTime: text("start_time"),
+  createdAt: text("created_at").notNull(),
+});
+
+export const activationTargets = sqliteTable("activation_targets", {
+  targetId: text("target_id").primaryKey(),
+  agentId: text("agent_id").notNull(),
+  kind: text("kind").notNull(),
+  status: text("status").notNull(),
+  offlineSince: text("offline_since"),
+  consecutiveFailures: integer("consecutive_failures").notNull(),
+  lastDeliveredAt: text("last_delivered_at"),
+  lastError: text("last_error"),
+  mode: text("mode").notNull(),
+  notifyLeaseMs: integer("notify_lease_ms").notNull(),
+  url: text("url"),
+  runtimeKind: text("runtime_kind"),
+  runtimeSessionId: text("runtime_session_id"),
+  backend: text("backend"),
+  tmuxPaneId: text("tmux_pane_id"),
+  tty: text("tty"),
+  termProgram: text("term_program"),
+  itermSessionId: text("iterm_session_id"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  lastSeenAt: text("last_seen_at").notNull(),
+});
+
+export const activationDispatchStates = sqliteTable("activation_dispatch_states", {
+  agentId: text("agent_id").notNull(),
+  targetId: text("target_id").notNull(),
+  status: text("status").notNull(),
+  leaseExpiresAt: text("lease_expires_at"),
+  pendingNewItemCount: integer("pending_new_item_count").notNull(),
+  pendingSummary: text("pending_summary"),
+  pendingSubscriptionIdsJson: text("pending_subscription_ids_json").notNull(),
+  pendingSourceIdsJson: text("pending_source_ids_json").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const inboxItems = sqliteTable("inbox_items", {
+  itemId: text("item_id").primaryKey(),
+  sourceId: text("source_id").notNull(),
+  sourceNativeId: text("source_native_id").notNull(),
+  eventVariant: text("event_variant").notNull(),
+  inboxId: text("inbox_id").notNull(),
+  occurredAt: text("occurred_at").notNull(),
+  metadataJson: text("metadata_json").notNull(),
+  rawPayloadJson: text("raw_payload_json").notNull(),
+  deliveryHandleJson: text("delivery_handle_json"),
+  ackedAt: text("acked_at"),
+});
+
+export const activations = sqliteTable("activations", {
+  activationId: text("activation_id").primaryKey(),
+  kind: text("kind").notNull(),
+  agentId: text("agent_id").notNull(),
+  inboxId: text("inbox_id").notNull(),
+  targetId: text("target_id").notNull(),
+  targetKind: text("target_kind").notNull(),
+  subscriptionIdsJson: text("subscription_ids_json").notNull(),
+  sourceIdsJson: text("source_ids_json").notNull(),
+  newItemCount: integer("new_item_count").notNull(),
+  summary: text("summary").notNull(),
+  itemsJson: text("items_json"),
+  createdAt: text("created_at").notNull(),
+  deliveredAt: text("delivered_at"),
+});
+
+export const deliveries = sqliteTable("deliveries", {
+  deliveryId: text("delivery_id").primaryKey(),
+  provider: text("provider").notNull(),
+  surface: text("surface").notNull(),
+  targetRef: text("target_ref").notNull(),
+  threadRef: text("thread_ref"),
+  replyMode: text("reply_mode"),
+  kind: text("kind").notNull(),
+  payloadJson: text("payload_json").notNull(),
+  status: text("status").notNull(),
+  createdAt: text("created_at").notNull(),
+});
+
+export const streams = sqliteTable("streams", {
+  streamId: text("stream_id").primaryKey(),
+  sourceId: text("source_id").notNull(),
+  streamKey: text("stream_key").notNull(),
+  backend: text("backend").notNull(),
+  createdAt: text("created_at").notNull(),
+});
+
+export const streamEvents = sqliteTable("stream_events", {
+  offset: integer("offset").primaryKey({ autoIncrement: true }),
+  streamEventId: text("stream_event_id").notNull(),
+  streamId: text("stream_id").notNull(),
+  sourceId: text("source_id").notNull(),
+  sourceNativeId: text("source_native_id").notNull(),
+  eventVariant: text("event_variant").notNull(),
+  occurredAt: text("occurred_at").notNull(),
+  metadataJson: text("metadata_json").notNull(),
+  rawPayloadJson: text("raw_payload_json").notNull(),
+  deliveryHandleJson: text("delivery_handle_json"),
+  createdAt: text("created_at").notNull(),
+});
+
+export const consumers = sqliteTable("consumers", {
+  consumerId: text("consumer_id").primaryKey(),
+  streamId: text("stream_id").notNull(),
+  subscriptionId: text("subscription_id").notNull(),
+  consumerKey: text("consumer_key").notNull(),
+  startPolicy: text("start_policy").notNull(),
+  startOffset: integer("start_offset"),
+  startTime: text("start_time"),
+  nextOffset: integer("next_offset").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const consumerCommits = sqliteTable("consumer_commits", {
+  commitId: text("commit_id").primaryKey(),
+  consumerId: text("consumer_id").notNull(),
+  streamId: text("stream_id").notNull(),
+  committedOffset: integer("committed_offset").notNull(),
+  committedAt: text("committed_at").notNull(),
+});
+

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,4 +1,4 @@
-import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { index, integer, primaryKey, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const sources = sqliteTable("sources", {
   sourceId: text("source_id").primaryKey(),
@@ -23,13 +23,17 @@ export const agents = sqliteTable("agents", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
   lastSeenAt: text("last_seen_at").notNull(),
-});
+}, (table) => ({
+  statusOfflineIdx: index("idx_agents_status_offline").on(table.status, table.offlineSince),
+}));
 
 export const inboxes = sqliteTable("inboxes", {
   inboxId: text("inbox_id").primaryKey(),
   ownerAgentId: text("owner_agent_id").notNull(),
   createdAt: text("created_at").notNull(),
-});
+}, (table) => ({
+  ownerAgentIdUnique: uniqueIndex("idx_inboxes_owner_agent_id").on(table.ownerAgentId),
+}));
 
 export const subscriptions = sqliteTable("subscriptions", {
   subscriptionId: text("subscription_id").primaryKey(),
@@ -66,7 +70,9 @@ export const activationTargets = sqliteTable("activation_targets", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
   lastSeenAt: text("last_seen_at").notNull(),
-});
+}, (table) => ({
+  agentStatusIdx: index("idx_activation_targets_agent_status").on(table.agentId, table.status),
+}));
 
 export const activationDispatchStates = sqliteTable("activation_dispatch_states", {
   agentId: text("agent_id").notNull(),
@@ -78,7 +84,10 @@ export const activationDispatchStates = sqliteTable("activation_dispatch_states"
   pendingSubscriptionIdsJson: text("pending_subscription_ids_json").notNull(),
   pendingSourceIdsJson: text("pending_source_ids_json").notNull(),
   updatedAt: text("updated_at").notNull(),
-});
+}, (table) => ({
+  pk: primaryKey({ columns: [table.agentId, table.targetId] }),
+  targetLeaseIdx: index("idx_activation_dispatch_states_target").on(table.targetId, table.leaseExpiresAt),
+}));
 
 export const inboxItems = sqliteTable("inbox_items", {
   itemId: text("item_id").primaryKey(),
@@ -91,7 +100,13 @@ export const inboxItems = sqliteTable("inbox_items", {
   rawPayloadJson: text("raw_payload_json").notNull(),
   deliveryHandleJson: text("delivery_handle_json"),
   ackedAt: text("acked_at"),
-});
+}, (table) => ({
+  sourceNativeEventInboxUnique: uniqueIndex("idx_inbox_items_source_native_event_inbox")
+    .on(table.sourceId, table.sourceNativeId, table.eventVariant, table.inboxId),
+  ackedAtIdx: index("idx_inbox_items_acked_at").on(table.ackedAt),
+  inboxAckedAtIdx: index("idx_inbox_items_inbox_acked_at").on(table.inboxId, table.ackedAt),
+  sourceOccurredAtIdx: index("idx_inbox_items_source_occurred_at").on(table.sourceId, table.occurredAt),
+}));
 
 export const activations = sqliteTable("activations", {
   activationId: text("activation_id").primaryKey(),
@@ -128,7 +143,10 @@ export const streams = sqliteTable("streams", {
   streamKey: text("stream_key").notNull(),
   backend: text("backend").notNull(),
   createdAt: text("created_at").notNull(),
-});
+}, (table) => ({
+  sourceIdUnique: uniqueIndex("idx_streams_source_id").on(table.sourceId),
+  streamKeyUnique: uniqueIndex("idx_streams_stream_key").on(table.streamKey),
+}));
 
 export const streamEvents = sqliteTable("stream_events", {
   offset: integer("offset").primaryKey({ autoIncrement: true }),
@@ -142,7 +160,13 @@ export const streamEvents = sqliteTable("stream_events", {
   rawPayloadJson: text("raw_payload_json").notNull(),
   deliveryHandleJson: text("delivery_handle_json"),
   createdAt: text("created_at").notNull(),
-});
+}, (table) => ({
+  streamEventIdUnique: uniqueIndex("idx_stream_events_stream_event_id").on(table.streamEventId),
+  streamSourceNativeVariantUnique: uniqueIndex("idx_stream_events_stream_source_native_variant")
+    .on(table.streamId, table.sourceNativeId, table.eventVariant),
+  streamOffsetIdx: index("idx_stream_events_stream_offset").on(table.streamId, table.offset),
+  streamOccurredAtIdx: index("idx_stream_events_stream_occurred_at").on(table.streamId, table.occurredAt),
+}));
 
 export const consumers = sqliteTable("consumers", {
   consumerId: text("consumer_id").primaryKey(),
@@ -155,7 +179,11 @@ export const consumers = sqliteTable("consumers", {
   nextOffset: integer("next_offset").notNull(),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
-});
+}, (table) => ({
+  subscriptionIdUnique: uniqueIndex("idx_consumers_subscription_id").on(table.subscriptionId),
+  consumerKeyUnique: uniqueIndex("idx_consumers_consumer_key").on(table.consumerKey),
+  streamIdx: index("idx_consumers_stream").on(table.streamId),
+}));
 
 export const consumerCommits = sqliteTable("consumer_commits", {
   commitId: text("commit_id").primaryKey(),
@@ -163,5 +191,6 @@ export const consumerCommits = sqliteTable("consumer_commits", {
   streamId: text("stream_id").notNull(),
   committedOffset: integer("committed_offset").notNull(),
   committedAt: text("committed_at").notNull(),
-});
-
+}, (table) => ({
+  consumerCommittedOffsetIdx: index("idx_consumer_commits_consumer").on(table.consumerId, table.committedOffset),
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@holon-run/uxc-daemon-client": "^0.13.3",
-        "drizzle-orm": "^0.44.2",
         "jexl": "^2.3.0",
         "sql.js": "^1.13.0"
       },
@@ -21,6 +20,7 @@
         "@types/node": "^24.5.2",
         "@types/sql.js": "^1.4.9",
         "drizzle-kit": "^0.31.6",
+        "drizzle-orm": "^0.44.2",
         "mdorigin": "^0.5.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
@@ -1071,7 +1071,7 @@
       "version": "1.41.5",
       "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
       "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -1105,7 +1105,7 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1116,7 +1116,7 @@
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
       "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1831,6 +1831,7 @@
       "version": "0.44.7",
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
       "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
@@ -3540,7 +3541,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@holon-run/uxc-daemon-client": "^0.13.3",
+        "drizzle-orm": "^0.44.2",
         "jexl": "^2.3.0",
         "sql.js": "^1.13.0"
       },
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@types/node": "^24.5.2",
         "@types/sql.js": "^1.4.9",
+        "drizzle-kit": "^0.31.6",
         "mdorigin": "^0.5.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
@@ -47,6 +49,449 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -626,7 +1071,7 @@
       "version": "1.41.5",
       "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
       "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -660,8 +1105,9 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -670,8 +1116,9 @@
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
       "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/emscripten": "*",
         "@types/node": "*"
@@ -744,6 +1191,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -871,6 +1325,631 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/drizzle-kit": {
+      "version": "0.31.10",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
+      "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.25.4",
+        "tsx": "^4.21.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.44.7",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
+      "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
       }
     },
     "node_modules/entities": {
@@ -2285,6 +3364,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -2307,7 +3407,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
       "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -2426,6 +3527,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2438,7 +3540,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "files": [
     "dist/src/",
+    "drizzle/",
     "README.md",
     "LICENSE"
   ],
@@ -34,17 +35,20 @@
     "docs:build": "npm run docs:search && mdorigin build cloudflare --root docs/site --search dist/search",
     "docs:build:cloudflare": "npm run docs:build",
     "docs:deploy": "npm run docs:index && npm run docs:build && npx wrangler@4 deploy --config wrangler.jsonc",
+    "db:migrations:generate": "drizzle-kit generate --config drizzle.config.ts",
     "prepack": "npm run build",
     "test": "node --require ts-node/register --test test/*.test.ts"
   },
   "dependencies": {
     "@holon-run/uxc-daemon-client": "^0.13.3",
+    "drizzle-orm": "^0.44.2",
     "jexl": "^2.3.0",
     "sql.js": "^1.13.0"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",
     "@types/sql.js": "^1.4.9",
+    "drizzle-kit": "^0.31.6",
     "mdorigin": "^0.5.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@holon-run/uxc-daemon-client": "^0.13.3",
-    "drizzle-orm": "^0.44.2",
     "jexl": "^2.3.0",
     "sql.js": "^1.13.0"
   },
@@ -49,6 +48,7 @@
     "@types/node": "^24.5.2",
     "@types/sql.js": "^1.4.9",
     "drizzle-kit": "^0.31.6",
+    "drizzle-orm": "^0.44.2",
     "mdorigin": "^0.5.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,8 +29,14 @@ import {
 } from "./model";
 import { generateId, nowIso } from "./util";
 
-const SCHEMA_VERSION = 12;
+const LEGACY_SCHEMA_VERSION = 12;
+const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
 type SqlBindParams = unknown[];
+
+interface SqlMigration {
+  tag: string;
+  sql: string;
+}
 
 function parseJson<T>(value: string | null): T {
   if (!value) {
@@ -77,257 +83,104 @@ export class AgentInboxStore {
   }
 
   private migrate(): void {
+    const migrations = this.loadSqlMigrations();
+    const hasMigrationTable = this.tableExists(DRIZZLE_MIGRATIONS_TABLE);
+    this.ensureDrizzleMigrationsTable();
+    const applied = this.listAppliedMigrationTags();
     const userVersion = this.userVersion();
-    if (userVersion === 0) {
-      this.dropKnownTables();
-      this.createCurrentSchema();
-      this.setUserVersion(SCHEMA_VERSION);
-      return;
+
+    if (applied.size === 0 && !hasMigrationTable && this.tableExists("sources")) {
+      if (userVersion !== 0 && userVersion !== LEGACY_SCHEMA_VERSION) {
+        throw new Error(`unsupported legacy database schema version ${userVersion} at ${this.dbPath}`);
+      }
+      this.recordAppliedMigration(migrations[0]!.tag);
+      applied.add(migrations[0]!.tag);
     }
-    if (userVersion !== SCHEMA_VERSION) {
-      throw new Error(
-        `unsupported database schema version ${userVersion}; delete ${this.dbPath} to recreate`,
-      );
+
+    const pending = migrations.filter((migration) => !applied.has(migration.tag));
+    if (pending.length > 0) {
+      if (this.shouldBackupBeforeMigration()) {
+        this.backupDatabase();
+      }
+      for (const migration of pending) {
+        this.applyMigration(migration);
+      }
     }
-    this.createCurrentSchema();
+
+    this.setUserVersion(migrations.length);
   }
 
-  private dropKnownTables(): void {
-    const tables = [
-      "consumer_commits",
-      "consumers",
-      "stream_events",
-      "streams",
-      "deliveries",
-      "activations",
-      "inbox_items",
-      "activation_dispatch_states",
-      "activation_targets",
-      "subscriptions",
-      "inboxes",
-      "agents",
-      "sources",
-      "terminal_dispatch_states",
-      "terminal_targets",
-      "interests",
+  private loadSqlMigrations(): SqlMigration[] {
+    const migrationsDir = this.resolveMigrationsDir();
+    const files = fs
+      .readdirSync(migrationsDir)
+      .filter((name) => name.endsWith(".sql"))
+      .sort();
+    if (files.length === 0) {
+      throw new Error(`no SQL migrations found in ${migrationsDir}`);
+    }
+    return files.map((name) => ({
+      tag: name.replace(/\.sql$/, ""),
+      sql: fs.readFileSync(path.join(migrationsDir, name), "utf8"),
+    }));
+  }
+
+  private resolveMigrationsDir(): string {
+    const candidates = [
+      path.resolve(__dirname, "../drizzle/migrations"),
+      path.resolve(__dirname, "../../drizzle/migrations"),
+      path.resolve(process.cwd(), "drizzle/migrations"),
     ];
-    this.inTransaction(() => {
-      for (const table of tables) {
-        if (this.tableExists(table)) {
-          this.db.exec(`drop table ${table};`);
-        }
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) {
+        return candidate;
       }
+    }
+    throw new Error(`cannot locate drizzle migrations directory from ${__dirname}`);
+  }
+
+  private ensureDrizzleMigrationsTable(): void {
+    this.db.exec(`
+      create table if not exists ${DRIZZLE_MIGRATIONS_TABLE} (
+        id integer primary key autoincrement,
+        tag text not null unique,
+        applied_at text not null
+      );
+    `);
+  }
+
+  private listAppliedMigrationTags(): Set<string> {
+    const rows = this.getAll(
+      `select tag from ${DRIZZLE_MIGRATIONS_TABLE} order by id asc`,
+    );
+    return new Set(rows.map((row) => String(row.tag)));
+  }
+
+  private applyMigration(migration: SqlMigration): void {
+    this.inTransaction(() => {
+      this.db.exec(migration.sql);
+      this.recordAppliedMigration(migration.tag);
     });
   }
 
-  private createCurrentSchema(): void {
-    this.db.exec(`
-      create table if not exists sources (
-        source_id text primary key,
-        source_type text not null,
-        source_key text not null,
-        config_ref text,
-        config_json text not null,
-        status text not null,
-        checkpoint text,
-        created_at text not null,
-        updated_at text not null,
-        unique(source_type, source_key)
-      );
+  private recordAppliedMigration(tag: string): void {
+    this.db.run(
+      `insert or ignore into ${DRIZZLE_MIGRATIONS_TABLE} (tag, applied_at) values (?, ?)`,
+      [tag, nowIso()],
+    );
+  }
 
-      create table if not exists agents (
-        agent_id text primary key,
-        status text not null,
-        offline_since text,
-        runtime_kind text not null,
-        runtime_session_id text,
-        created_at text not null,
-        updated_at text not null,
-        last_seen_at text not null
-      );
+  private shouldBackupBeforeMigration(): boolean {
+    if (!fs.existsSync(this.dbPath)) {
+      return false;
+    }
+    return this.tableExists("sources");
+  }
 
-      create table if not exists inboxes (
-        inbox_id text primary key,
-        owner_agent_id text not null unique,
-        created_at text not null
-      );
-
-      create table if not exists subscriptions (
-        subscription_id text primary key,
-        agent_id text not null,
-        source_id text not null,
-        filter_json text not null,
-        lifecycle_mode text not null,
-        expires_at text,
-        start_policy text not null,
-        start_offset integer,
-        start_time text,
-        created_at text not null
-      );
-
-      create table if not exists activation_targets (
-        target_id text primary key,
-        agent_id text not null,
-        kind text not null,
-        status text not null,
-        offline_since text,
-        consecutive_failures integer not null,
-        last_delivered_at text,
-        last_error text,
-        mode text not null,
-        notify_lease_ms integer not null,
-        url text,
-        runtime_kind text,
-        runtime_session_id text,
-        backend text,
-        tmux_pane_id text,
-        tty text,
-        term_program text,
-        iterm_session_id text,
-        created_at text not null,
-        updated_at text not null,
-        last_seen_at text not null
-      );
-
-      create table if not exists activation_dispatch_states (
-        agent_id text not null,
-        target_id text not null,
-        status text not null,
-        lease_expires_at text,
-        pending_new_item_count integer not null,
-        pending_summary text,
-        pending_subscription_ids_json text not null,
-        pending_source_ids_json text not null,
-        updated_at text not null,
-        primary key (agent_id, target_id)
-      );
-
-      create table if not exists inbox_items (
-        item_id text primary key,
-        source_id text not null,
-        source_native_id text not null,
-        event_variant text not null,
-        inbox_id text not null,
-        occurred_at text not null,
-        metadata_json text not null,
-        raw_payload_json text not null,
-        delivery_handle_json text,
-        acked_at text,
-        unique(source_id, source_native_id, event_variant, inbox_id)
-      );
-
-      create table if not exists activations (
-        activation_id text primary key,
-        kind text not null,
-        agent_id text not null,
-        inbox_id text not null,
-        target_id text not null,
-        target_kind text not null,
-        subscription_ids_json text not null,
-        source_ids_json text not null,
-        new_item_count integer not null,
-        summary text not null,
-        items_json text,
-        created_at text not null,
-        delivered_at text
-      );
-
-      create table if not exists deliveries (
-        delivery_id text primary key,
-        provider text not null,
-        surface text not null,
-        target_ref text not null,
-        thread_ref text,
-        reply_mode text,
-        kind text not null,
-        payload_json text not null,
-        status text not null,
-        created_at text not null
-      );
-
-      create table if not exists streams (
-        stream_id text primary key,
-        source_id text not null unique,
-        stream_key text not null unique,
-        backend text not null,
-        created_at text not null
-      );
-
-      create table if not exists stream_events (
-        offset integer primary key autoincrement,
-        stream_event_id text not null unique,
-        stream_id text not null,
-        source_id text not null,
-        source_native_id text not null,
-        event_variant text not null,
-        occurred_at text not null,
-        metadata_json text not null,
-        raw_payload_json text not null,
-        delivery_handle_json text,
-        created_at text not null,
-        unique(stream_id, source_native_id, event_variant)
-      );
-
-      create table if not exists consumers (
-        consumer_id text primary key,
-        stream_id text not null,
-        subscription_id text not null unique,
-        consumer_key text not null unique,
-        start_policy text not null,
-        start_offset integer,
-        start_time text,
-        next_offset integer not null,
-        created_at text not null,
-        updated_at text not null
-      );
-
-      create table if not exists consumer_commits (
-        commit_id text primary key,
-        consumer_id text not null,
-        stream_id text not null,
-        committed_offset integer not null,
-        committed_at text not null
-      );
-
-      create unique index if not exists idx_activation_targets_terminal_tmux
-        on activation_targets(tmux_pane_id)
-        where kind = 'terminal' and tmux_pane_id is not null;
-
-      create unique index if not exists idx_activation_targets_terminal_iterm
-        on activation_targets(iterm_session_id)
-        where kind = 'terminal' and iterm_session_id is not null;
-
-      create unique index if not exists idx_activation_targets_runtime_session
-        on activation_targets(runtime_kind, runtime_session_id)
-        where kind = 'terminal' and runtime_session_id is not null;
-
-      create index if not exists idx_activation_dispatch_states_target
-        on activation_dispatch_states(target_id, lease_expires_at);
-
-      create index if not exists idx_inbox_items_acked_at
-        on inbox_items(acked_at);
-
-      create index if not exists idx_inbox_items_inbox_acked_at
-        on inbox_items(inbox_id, acked_at);
-
-      create index if not exists idx_agents_status_offline
-        on agents(status, offline_since);
-
-      create index if not exists idx_activation_targets_agent_status
-        on activation_targets(agent_id, status);
-
-      create index if not exists idx_stream_events_stream_offset
-        on stream_events(stream_id, offset);
-
-      create index if not exists idx_stream_events_stream_occurred_at
-        on stream_events(stream_id, occurred_at);
-
-      create index if not exists idx_consumers_stream
-        on consumers(stream_id);
-
-      create index if not exists idx_consumer_commits_consumer
-        on consumer_commits(consumer_id, committed_offset);
-    `);
+  private backupDatabase(): void {
+    const safeStamp = nowIso().replace(/[:.]/g, "-");
+    const backupPath = `${this.dbPath}.backup-${safeStamp}`;
+    fs.copyFileSync(this.dbPath, backupPath);
   }
 
   private persist(): void {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
+import initSqlJs from "sql.js";
 import { AdapterRegistry } from "../src/adapters";
 import { SqliteEventBusBackend } from "../src/backend";
 import { Activation, ActivationTarget, AppendSourceEventInput, Subscription, TerminalActivationTarget } from "../src/model";
@@ -78,6 +79,66 @@ async function registerTmuxAgent(service: AgentInboxService, suffix: string): Pr
     targetId: registered.terminalTarget.targetId,
   };
 }
+
+async function createLegacyDb(dbPath: string): Promise<void> {
+  const SQL = await initSqlJs({
+    locateFile: (file: string) => require.resolve(`sql.js/dist/${file}`),
+  });
+  const db = new SQL.Database();
+  const initialMigrationPath = path.join(__dirname, "..", "drizzle", "migrations", "0000_initial.sql");
+  db.exec(fs.readFileSync(initialMigrationPath, "utf8"));
+  db.exec("pragma user_version = 12;");
+  fs.writeFileSync(dbPath, Buffer.from(db.export()));
+  db.close();
+}
+
+async function readMigrationState(dbPath: string): Promise<{ appliedCount: number; hasNewIndex: boolean }> {
+  const SQL = await initSqlJs({
+    locateFile: (file: string) => require.resolve(`sql.js/dist/${file}`),
+  });
+  const db = new SQL.Database(fs.readFileSync(dbPath));
+  const migrationResult = db.exec("select count(*) as count from __drizzle_migrations;") as Array<{ values: unknown[][] }>;
+  const appliedCount = Number(migrationResult[0]?.values?.[0]?.[0] ?? 0);
+  const indexResult = db.exec("pragma index_list('inbox_items');") as Array<{ values: unknown[][] }>;
+  const hasNewIndex = indexResult.some((set) =>
+    set.values.some((row) => String(row[1]) === "idx_inbox_items_source_occurred_at"),
+  );
+  db.close();
+  return { appliedCount, hasNewIndex };
+}
+
+test("store migrates a new database using drizzle SQL migrations", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-migrate-new-"));
+  const dbPath = path.join(dir, "agentinbox.sqlite");
+  const store = await AgentInboxStore.open(dbPath);
+  try {
+    const state = await readMigrationState(dbPath);
+    assert.equal(state.appliedCount, 2);
+    assert.equal(state.hasNewIndex, true);
+    const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
+    assert.equal(backups.length, 0);
+  } finally {
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("store upgrades a legacy v12 database with backup and forward migration", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-migrate-legacy-"));
+  const dbPath = path.join(dir, "agentinbox.sqlite");
+  await createLegacyDb(dbPath);
+  const store = await AgentInboxStore.open(dbPath);
+  try {
+    const state = await readMigrationState(dbPath);
+    assert.equal(state.appliedCount, 2);
+    assert.equal(state.hasNewIndex, true);
+    const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
+    assert.equal(backups.length, 1);
+  } finally {
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("agent register creates a stable agent, inbox, and terminal activation target", async () => {
   const { store, service, dir } = await makeService();


### PR DESCRIPTION
Closes #38

## Summary
- introduce Drizzle schema/migration scaffolding (`drizzle.config.ts`, `drizzle/schema.ts`, SQL migrations)
- replace destructive schema bootstrap in `AgentInboxStore` with forward SQL migration application
- add legacy v12 bridge: existing databases are baselined and then migrated forward instead of forcing delete/recreate
- add pre-migration local backup (`agentinbox.sqlite.backup-<timestamp>`) before applying pending migrations on existing DBs
- add migration regression tests for both fresh DB bootstrap and legacy DB upgrade paths

## Validation
- `npm run build`
- `npm test`