### PR TITLE
feat: migrate control plane HTTP to Fastify and generate OpenAPI

### DIFF
--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -12,6 +12,7 @@ going forward.
 
 - `GET /healthz`
 - `GET /status`
+- `GET /openapi.json`
 - `POST /gc`
 
 ## Sources
@@ -69,6 +70,9 @@ going forward.
 ```
 
 ## Notes
+
+- The OpenAPI contract is generated from the same Fastify route schemas used for
+  runtime validation and is served at `GET /openapi.json`.
 
 - `local_event` is the only source type that supports direct manual append through
   `POST /sources/{sourceId}/events`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@fastify/swagger": "^9.5.2",
         "@holon-run/uxc-daemon-client": "^0.13.3",
+        "fastify": "^5.6.1",
         "jexl": "^2.3.0",
         "sql.js": "^1.13.0"
       },
@@ -936,6 +938,140 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/swagger": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-9.7.0.tgz",
+      "integrity": "sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "json-schema-resolver": "^3.0.0",
+        "openapi-types": "^12.1.3",
+        "rfdc": "^1.3.1",
+        "yaml": "^2.4.2"
+      }
+    },
     "node_modules/@holon-run/uxc-daemon-client": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.13.3.tgz",
@@ -1028,6 +1164,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -1138,6 +1280,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1164,6 +1312,39 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1179,6 +1360,35 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
+      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
       }
     },
     "node_modules/bail": {
@@ -1254,6 +1464,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -1265,7 +1488,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1297,7 +1519,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2055,6 +2276,139 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.3.0.tgz",
+      "integrity": "sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
+      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
+      "integrity": "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2269,6 +2623,15 @@
         "@indexbind/native-linux-x64-gnu": "0.6.2"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -2315,6 +2678,48 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-resolver/-/json-schema-resolver-3.0.0.tgz",
+      "integrity": "sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fast-uri": "^3.0.5",
+        "rfdc": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/Eomm/json-schema-resolver?sponsor=1"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -2324,6 +2729,43 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -3195,7 +3637,21 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "license": "MIT"
     },
     "node_modules/parse5": {
@@ -3211,6 +3667,59 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -3220,6 +3729,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/rehype-raw": {
@@ -3341,6 +3865,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3349,6 +3882,62 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.0.tgz",
+      "integrity": "sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/section-matter": {
@@ -3363,6 +3952,49 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -3395,6 +4027,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -3434,6 +4075,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/trim-lines": {
@@ -3698,6 +4360,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
   },
   "dependencies": {
     "@holon-run/uxc-daemon-client": "^0.13.3",
+    "@fastify/swagger": "^9.5.2",
+    "fastify": "^5.6.1",
     "jexl": "^2.3.0",
     "sql.js": "^1.13.0"
   },

--- a/src/http.ts
+++ b/src/http.ts
@@ -213,7 +213,7 @@ function buildFastifyServer(service: AgentInboxService) {
         properties: {
           sourceNativeId: { type: "string", minLength: 1 },
           eventVariant: { type: "string", minLength: 1 },
-          occurredAt: { type: "string" },
+          occurredAt: { type: "string", minLength: 1 },
           metadata: jsonObjectSchema,
           rawPayload: jsonObjectSchema,
           deliveryHandle: deliveryHandleSchema,
@@ -237,7 +237,7 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.appendSourceEventByCaller(decodeURIComponent(params.sourceId), {
       sourceNativeId: body.sourceNativeId,
       eventVariant: body.eventVariant,
-      occurredAt: body.occurredAt,
+      occurredAt: optionalString(body.occurredAt),
       metadata: body.metadata ?? {},
       rawPayload: body.rawPayload ?? {},
       deliveryHandle: body.deliveryHandle ?? null,
@@ -823,9 +823,37 @@ function buildFastifyServer(service: AgentInboxService) {
   app.post("/deliveries/send", {
     schema: {
       tags: ["deliveries"],
-      body: jsonObjectSchema,
+      body: {
+        oneOf: [
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["kind", "payload", "deliveryHandle"],
+            properties: {
+              kind: { type: "string", minLength: 1 },
+              payload: jsonObjectSchema,
+              deliveryHandle: deliveryHandleSchema,
+            },
+          },
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["kind", "payload", "provider", "surface", "targetRef"],
+            properties: {
+              kind: { type: "string", minLength: 1 },
+              payload: jsonObjectSchema,
+              provider: { type: "string", minLength: 1 },
+              surface: { type: "string", minLength: 1 },
+              targetRef: { type: "string", minLength: 1 },
+              threadRef: { type: "string" },
+              replyMode: { type: "string" },
+            },
+          },
+        ],
+      },
       response: {
         200: jsonObjectSchema,
+        400: errorResponseSchema,
       },
     },
   }, async (request) => service.sendDelivery(request.body as never));

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,25 +1,9 @@
 import http from "node:http";
+import Fastify from "fastify";
+import swagger from "@fastify/swagger";
 import { AgentInboxService } from "./service";
 import { ActivationMode, DeliveryHandle, WatchInboxOptions } from "./model";
-import { asObject, jsonResponse } from "./util";
-
-async function readJson(req: http.IncomingMessage): Promise<Record<string, unknown>> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(Buffer.from(chunk));
-  }
-  const body = Buffer.concat(chunks).toString("utf8");
-  if (!body) {
-    return {};
-  }
-  return asObject(JSON.parse(body));
-}
-
-function send(res: http.ServerResponse, statusCode: number, data: unknown): void {
-  res.statusCode = statusCode;
-  res.setHeader("content-type", "application/json; charset=utf-8");
-  res.end(jsonResponse(data));
-}
+import { jsonResponse } from "./util";
 
 function sendSse(res: http.ServerResponse, event: string, data: unknown): void {
   res.write(`event: ${event}\n`);
@@ -30,328 +14,882 @@ function sendSse(res: http.ServerResponse, event: string, data: unknown): void {
   res.write(`${payload}\n\n`);
 }
 
-export function createServer(service: AgentInboxService): http.Server {
-  return http.createServer(async (req, res) => {
-    try {
-      if (!req.url || !req.method) {
-        send(res, 400, { error: "missing request metadata" });
-        return;
-      }
+const jsonObjectSchema = {
+  type: "object",
+  additionalProperties: true,
+} as const;
 
-      const url = new URL(req.url, "http://127.0.0.1");
+const errorResponseSchema = {
+  type: "object",
+  required: ["error"],
+  additionalProperties: false,
+  properties: {
+    error: { type: "string" },
+  },
+} as const;
 
-      if (req.method === "GET" && url.pathname === "/healthz") {
-        send(res, 200, { ok: true });
-        return;
-      }
+const deliveryHandleSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["provider", "surface", "targetRef"],
+  properties: {
+    provider: { type: "string", minLength: 1 },
+    surface: { type: "string", minLength: 1 },
+    targetRef: { type: "string", minLength: 1 },
+    threadRef: { type: "string" },
+    replyMode: { type: "string" },
+  },
+} as const;
 
-      if (req.method === "GET" && url.pathname === "/status") {
-        send(res, 200, service.status());
-        return;
-      }
-
-      if (req.method === "POST" && url.pathname === "/gc") {
-        send(res, 200, service.gc());
-        return;
-      }
-
-      if (req.method === "GET" && url.pathname === "/sources") {
-        send(res, 200, { sources: service.listSources() });
-        return;
-      }
-
-      if (req.method === "POST" && url.pathname === "/sources") {
-        send(res, 200, await service.registerSource(await readJson(req) as never));
-        return;
-      }
-
-      const sourceMatch = url.pathname.match(/^\/sources\/([^/]+)$/);
-      if (req.method === "GET" && sourceMatch) {
-        send(res, 200, service.getSourceDetails(decodeURIComponent(sourceMatch[1])));
-        return;
-      }
-
-      const sourceSchemaMatch = url.pathname.match(/^\/source-types\/([^/]+)\/schema$/);
-      if (req.method === "GET" && sourceSchemaMatch) {
-        send(res, 200, service.getSourceSchema(decodeURIComponent(sourceSchemaMatch[1]) as never));
-        return;
-      }
-
-      const sourcePollMatch = url.pathname.match(/^\/sources\/([^/]+)\/poll$/);
-      if (req.method === "POST" && sourcePollMatch) {
-        send(res, 200, await service.pollSource(decodeURIComponent(sourcePollMatch[1])));
-        return;
-      }
-
-      const sourceEventsMatch = url.pathname.match(/^\/sources\/([^/]+)\/events$/);
-      if (req.method === "POST" && sourceEventsMatch) {
-        const body = await readJson(req);
-        const sourceId = decodeURIComponent(sourceEventsMatch[1]);
-        const sourceNativeId = parseRequiredString(body.sourceNativeId, "sources/events requires sourceNativeId");
-        const eventVariant = parseRequiredString(body.eventVariant, "sources/events requires eventVariant");
-        send(res, 200, await service.appendSourceEventByCaller(sourceId, {
-          sourceNativeId,
-          eventVariant,
-          occurredAt: parseOptionalString(body.occurredAt),
-          metadata: asObject(body.metadata),
-          rawPayload: asObject(body.rawPayload),
-          deliveryHandle: parseOptionalDeliveryHandle(body.deliveryHandle),
-        }));
-        return;
-      }
-
-      if (req.method === "GET" && url.pathname === "/agents") {
-        send(res, 200, { agents: service.listAgents() });
-        return;
-      }
-
-      if (req.method === "POST" && url.pathname === "/agents") {
-        const body = await readJson(req);
-        const backend = parseRequiredString(body.backend, "agents requires backend");
-        send(res, 200, service.registerAgent({
-          agentId: parseOptionalString(body.agentId) ?? null,
-          forceRebind: parseOptionalBoolean(body.forceRebind) ?? false,
-          backend: backend as never,
-          runtimeKind: parseOptionalString(body.runtimeKind) as never,
-          runtimeSessionId: parseOptionalString(body.runtimeSessionId),
-          mode: "agent_prompt",
-          tmuxPaneId: parseOptionalString(body.tmuxPaneId),
-          tty: parseOptionalString(body.tty),
-          termProgram: parseOptionalString(body.termProgram),
-          itermSessionId: parseOptionalString(body.itermSessionId),
-          notifyLeaseMs: parseOptionalInteger(body.notifyLeaseMs) ?? null,
-        }));
-        return;
-      }
-
-      const agentMatch = url.pathname.match(/^\/agents\/([^/]+)$/);
-      if (req.method === "GET" && agentMatch) {
-        send(res, 200, service.getAgentDetails(decodeURIComponent(agentMatch[1])));
-        return;
-      }
-      if (req.method === "DELETE" && agentMatch) {
-        send(res, 200, service.removeAgent(decodeURIComponent(agentMatch[1])));
-        return;
-      }
-
-      const agentTargetsMatch = url.pathname.match(/^\/agents\/([^/]+)\/targets$/);
-      if (req.method === "GET" && agentTargetsMatch) {
-        send(res, 200, {
-          targets: service.listActivationTargets(decodeURIComponent(agentTargetsMatch[1])),
-        });
-        return;
-      }
-
-      if (req.method === "POST" && agentTargetsMatch) {
-        const body = await readJson(req);
-        const agentId = decodeURIComponent(agentTargetsMatch[1]);
-        const kind = parseRequiredString(body.kind, "agents/targets requires kind");
-        if (kind !== "webhook") {
-          send(res, 400, { error: `unsupported activation target kind: ${kind}` });
-          return;
-        }
-        const urlValue = parseRequiredString(body.url, "agents/targets requires url");
-        send(res, 200, service.addWebhookActivationTarget(agentId, {
-          url: urlValue,
-          activationMode: parseOptionalString(body.activationMode) as ActivationMode | undefined,
-          notifyLeaseMs: parseOptionalInteger(body.notifyLeaseMs) ?? null,
-        }));
-        return;
-      }
-
-      const agentTargetMatch = url.pathname.match(/^\/agents\/([^/]+)\/targets\/([^/]+)$/);
-      if (req.method === "DELETE" && agentTargetMatch) {
-        send(res, 200, service.removeActivationTarget(
-          decodeURIComponent(agentTargetMatch[1]),
-          decodeURIComponent(agentTargetMatch[2]),
-        ));
-        return;
-      }
-
-      if (req.method === "GET" && url.pathname === "/subscriptions") {
-        send(res, 200, {
-          subscriptions: service.listSubscriptions({
-            sourceId: url.searchParams.get("source_id") ?? undefined,
-            agentId: url.searchParams.get("agent_id") ?? undefined,
-          }),
-        });
-        return;
-      }
-
-      if (req.method === "POST" && url.pathname === "/subscriptions") {
-        const body = await readJson(req);
-        send(res, 200, await service.registerSubscription({
-          agentId: parseRequiredString(body.agentId, "subscriptions requires agentId"),
-          sourceId: parseRequiredString(body.sourceId, "subscriptions requires sourceId"),
-          filter: asObject(body.filter),
-          lifecycleMode: parseOptionalString(body.lifecycleMode) as never,
-          expiresAt: parseOptionalString(body.expiresAt) ?? null,
-          startPolicy: parseOptionalString(body.startPolicy) as never,
-          startOffset: parseOptionalInteger(body.startOffset),
-          startTime: parseOptionalString(body.startTime) ?? undefined,
-        }));
-        return;
-      }
-
-      const subscriptionMatch = url.pathname.match(/^\/subscriptions\/([^/]+)$/);
-      if (req.method === "GET" && subscriptionMatch) {
-        send(res, 200, await service.getSubscriptionDetails(decodeURIComponent(subscriptionMatch[1])));
-        return;
-      }
-      if (req.method === "DELETE" && subscriptionMatch) {
-        send(res, 200, await service.removeSubscription(decodeURIComponent(subscriptionMatch[1])));
-        return;
-      }
-
-      const subscriptionPollMatch = url.pathname.match(/^\/subscriptions\/([^/]+)\/poll$/);
-      if (req.method === "POST" && subscriptionPollMatch) {
-        send(res, 200, await service.pollSubscription(decodeURIComponent(subscriptionPollMatch[1])));
-        return;
-      }
-
-      const subscriptionLagMatch = url.pathname.match(/^\/subscriptions\/([^/]+)\/lag$/);
-      if (req.method === "GET" && subscriptionLagMatch) {
-        send(res, 200, await service.getSubscriptionLag(decodeURIComponent(subscriptionLagMatch[1])));
-        return;
-      }
-
-      const subscriptionResetMatch = url.pathname.match(/^\/subscriptions\/([^/]+)\/reset$/);
-      if (req.method === "POST" && subscriptionResetMatch) {
-        const body = await readJson(req);
-        const startPolicy = parseRequiredString(body.startPolicy, "subscriptions/reset requires startPolicy");
-        send(res, 200, await service.resetSubscription({
-          subscriptionId: decodeURIComponent(subscriptionResetMatch[1]),
-          startPolicy: startPolicy as never,
-          startOffset: parseOptionalInteger(body.startOffset),
-          startTime: parseOptionalString(body.startTime) ?? null,
-        }));
-        return;
-      }
-
-      const agentInboxMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox$/);
-      if (req.method === "GET" && agentInboxMatch) {
-        send(res, 200, service.getInboxDetailsByAgent(decodeURIComponent(agentInboxMatch[1])));
-        return;
-      }
-
-      const agentInboxItemsMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/items$/);
-      if (req.method === "GET" && agentInboxItemsMatch) {
-        send(res, 200, {
-          items: service.listInboxItems(decodeURIComponent(agentInboxItemsMatch[1]), {
-            afterItemId: url.searchParams.get("after_item_id") ?? undefined,
-            includeAcked: url.searchParams.has("include_acked")
-              ? url.searchParams.get("include_acked") === "true"
-              : undefined,
-          }),
-        });
-        return;
-      }
-
-      const agentInboxWatchMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/watch$/);
-      if (req.method === "GET" && agentInboxWatchMatch) {
-        const agentId = decodeURIComponent(agentInboxWatchMatch[1]);
-        const watchOptions: WatchInboxOptions = {
-          afterItemId: url.searchParams.get("after_item_id") ?? undefined,
-          includeAcked: url.searchParams.has("include_acked")
-            ? url.searchParams.get("include_acked") === "true"
-            : undefined,
-          heartbeatMs: url.searchParams.has("heartbeat_ms")
-            ? parsePositiveInteger(url.searchParams.get("heartbeat_ms"))
-            : undefined,
-        };
-
-        res.writeHead(200, {
-          "content-type": "text/event-stream; charset=utf-8",
-          "cache-control": "no-cache, no-transform",
-          connection: "keep-alive",
-        });
-
-        const session = service.watchInbox(agentId, watchOptions, (event) => {
-          sendSse(res, event.event, event);
-        });
-        sendSse(res, "items", {
-          event: "items",
-          agentId,
-          items: session.initialItems,
-        });
-        session.start();
-
-        const heartbeatMs = watchOptions.heartbeatMs ?? 15_000;
-        const heartbeat = setInterval(() => {
-          sendSse(res, "heartbeat", {
-            event: "heartbeat",
-            agentId,
-            timestamp: new Date().toISOString(),
-          });
-        }, heartbeatMs);
-
-        const cleanup = () => {
-          clearInterval(heartbeat);
-          session.close();
-        };
-        req.on("close", cleanup);
-        req.on("error", cleanup);
-        return;
-      }
-
-      const agentInboxCompactMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/compact$/);
-      if (req.method === "POST" && agentInboxCompactMatch) {
-        send(res, 200, service.compactInbox(decodeURIComponent(agentInboxCompactMatch[1])));
-        return;
-      }
-
-      const agentInboxAckMatch = url.pathname.match(/^\/agents\/([^/]+)\/inbox\/ack$/);
-      if (req.method === "POST" && agentInboxAckMatch) {
-        const body = await readJson(req);
-        const itemIds = Array.isArray(body.itemIds) ? body.itemIds.map((itemId) => String(itemId)) : [];
-        const throughItemId = parseOptionalString(body.throughItemId);
-        const ackAll = parseOptionalBoolean(body.all) ?? false;
-        const modeCount = Number(itemIds.length > 0) + Number(Boolean(throughItemId)) + Number(ackAll);
-        if (modeCount !== 1) {
-          send(res, 400, { error: "inbox/ack accepts exactly one of itemIds, throughItemId, or all" });
-          return;
-        }
-        send(res, 200, service.ackInbox(decodeURIComponent(agentInboxAckMatch[1]), {
-          itemIds,
-          throughItemId: throughItemId ?? null,
-          all: ackAll,
-        }));
-        return;
-      }
-
-      if (req.method === "POST" && url.pathname === "/deliveries/send") {
-        send(res, 200, await service.sendDelivery(await readJson(req) as never));
-        return;
-      }
-      send(res, 404, { error: "not found" });
-    } catch (error) {
-      if (error instanceof SyntaxError) {
-        send(res, 400, { error: error.message });
-        return;
-      }
-      const message = error instanceof Error ? error.message : String(error);
-      if (message.startsWith("unknown ")) {
-        send(res, 404, { error: message });
-        return;
-      }
-      if (isBadRequestError(message)) {
-        send(res, 400, { error: message });
-        return;
-      }
-      send(res, 500, { error: message });
-    }
+function buildFastifyServer(service: AgentInboxService) {
+  const app = Fastify({
+    logger: false,
+    ajv: {
+      customOptions: {
+        coerceTypes: false,
+      },
+    },
   });
+
+  void app.register(swagger, {
+    openapi: {
+      info: {
+        title: "AgentInbox Control Plane API",
+        version: "0.1.0",
+      },
+    },
+  });
+
+  app.get("/healthz", {
+    schema: {
+      tags: ["system"],
+      response: {
+        200: {
+          type: "object",
+          required: ["ok"],
+          properties: {
+            ok: { type: "boolean" },
+          },
+        },
+      },
+    },
+  }, async () => ({ ok: true }));
+
+  app.get("/status", {
+    schema: {
+      tags: ["system"],
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async () => service.status());
+
+  app.get("/openapi.json", {
+    schema: {
+      tags: ["system"],
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async () => app.swagger());
+
+  app.post("/gc", {
+    schema: {
+      tags: ["inbox"],
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async () => service.gc());
+
+  app.get("/sources", {
+    schema: {
+      tags: ["sources"],
+      response: {
+        200: {
+          type: "object",
+          required: ["sources"],
+          properties: {
+            sources: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async () => ({ sources: service.listSources() }));
+
+  app.post("/sources", {
+    schema: {
+      tags: ["sources"],
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["sourceType", "sourceKey"],
+        properties: {
+          sourceType: { type: "string", minLength: 1 },
+          sourceKey: { type: "string", minLength: 1 },
+          configRef: { type: "string" },
+          config: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => service.registerSource(request.body as never));
+
+  app.get("/sources/:sourceId", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    return service.getSourceDetails(decodeURIComponent(params.sourceId));
+  });
+
+  app.get("/source-types/:sourceType/schema", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceType"],
+        properties: {
+          sourceType: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceType: string };
+    return service.getSourceSchema(decodeURIComponent(params.sourceType) as never);
+  });
+
+  app.post("/sources/:sourceId/poll", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    return service.pollSource(decodeURIComponent(params.sourceId));
+  });
+
+  app.post("/sources/:sourceId/events", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["sourceNativeId", "eventVariant"],
+        properties: {
+          sourceNativeId: { type: "string", minLength: 1 },
+          eventVariant: { type: "string", minLength: 1 },
+          occurredAt: { type: "string" },
+          metadata: jsonObjectSchema,
+          rawPayload: jsonObjectSchema,
+          deliveryHandle: deliveryHandleSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    const body = request.body as {
+      sourceNativeId: string;
+      eventVariant: string;
+      occurredAt?: string;
+      metadata?: Record<string, unknown>;
+      rawPayload?: Record<string, unknown>;
+      deliveryHandle?: DeliveryHandle;
+    };
+    return service.appendSourceEventByCaller(decodeURIComponent(params.sourceId), {
+      sourceNativeId: body.sourceNativeId,
+      eventVariant: body.eventVariant,
+      occurredAt: body.occurredAt,
+      metadata: body.metadata ?? {},
+      rawPayload: body.rawPayload ?? {},
+      deliveryHandle: body.deliveryHandle ?? null,
+    });
+  });
+
+  app.get("/agents", {
+    schema: {
+      tags: ["agents"],
+      response: {
+        200: {
+          type: "object",
+          required: ["agents"],
+          properties: {
+            agents: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async () => ({ agents: service.listAgents() }));
+
+  app.post("/agents", {
+    schema: {
+      tags: ["agents"],
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["backend"],
+        properties: {
+          agentId: { type: "string" },
+          forceRebind: { type: "boolean" },
+          backend: { type: "string", minLength: 1 },
+          runtimeKind: { type: "string" },
+          runtimeSessionId: { type: "string" },
+          tmuxPaneId: { type: "string" },
+          tty: { type: "string" },
+          termProgram: { type: "string" },
+          itermSessionId: { type: "string" },
+          notifyLeaseMs: { type: "integer", minimum: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const body = request.body as Record<string, unknown>;
+    return service.registerAgent({
+      agentId: optionalString(body.agentId) ?? null,
+      forceRebind: body.forceRebind === true,
+      backend: String(body.backend) as never,
+      runtimeKind: optionalString(body.runtimeKind) as never,
+      runtimeSessionId: optionalString(body.runtimeSessionId),
+      mode: "agent_prompt",
+      tmuxPaneId: optionalString(body.tmuxPaneId),
+      tty: optionalString(body.tty),
+      termProgram: optionalString(body.termProgram),
+      itermSessionId: optionalString(body.itermSessionId),
+      notifyLeaseMs: typeof body.notifyLeaseMs === "number" ? body.notifyLeaseMs : null,
+    });
+  });
+
+  app.get("/agents/:agentId", {
+    schema: {
+      tags: ["agents"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    return service.getAgentDetails(decodeURIComponent(params.agentId));
+  });
+
+  app.delete("/agents/:agentId", {
+    schema: {
+      tags: ["agents"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    return service.removeAgent(decodeURIComponent(params.agentId));
+  });
+
+  app.get("/agents/:agentId/targets", {
+    schema: {
+      tags: ["agents"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: {
+          type: "object",
+          required: ["targets"],
+          properties: {
+            targets: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    return { targets: service.listActivationTargets(decodeURIComponent(params.agentId)) };
+  });
+
+  app.post("/agents/:agentId/targets", {
+    schema: {
+      tags: ["agents"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["kind", "url"],
+        properties: {
+          kind: { type: "string", enum: ["webhook"] },
+          url: { type: "string", minLength: 1 },
+          activationMode: { type: "string" },
+          notifyLeaseMs: { type: "integer", minimum: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    const body = request.body as {
+      url: string;
+      activationMode?: ActivationMode;
+      notifyLeaseMs?: number;
+    };
+    return service.addWebhookActivationTarget(decodeURIComponent(params.agentId), {
+      url: body.url,
+      activationMode: body.activationMode,
+      notifyLeaseMs: body.notifyLeaseMs ?? null,
+    });
+  });
+
+  app.delete("/agents/:agentId/targets/:targetId", {
+    schema: {
+      tags: ["agents"],
+      params: {
+        type: "object",
+        required: ["agentId", "targetId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+          targetId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string; targetId: string };
+    return service.removeActivationTarget(decodeURIComponent(params.agentId), decodeURIComponent(params.targetId));
+  });
+
+  app.get("/subscriptions", {
+    schema: {
+      tags: ["subscriptions"],
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          source_id: { type: "string" },
+          agent_id: { type: "string" },
+        },
+      },
+      response: {
+        200: {
+          type: "object",
+          required: ["subscriptions"],
+          properties: {
+            subscriptions: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async (request) => {
+    const query = request.query as { source_id?: string; agent_id?: string };
+    return {
+      subscriptions: service.listSubscriptions({
+        sourceId: query.source_id,
+        agentId: query.agent_id,
+      }),
+    };
+  });
+
+  app.post("/subscriptions", {
+    schema: {
+      tags: ["subscriptions"],
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["agentId", "sourceId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+          sourceId: { type: "string", minLength: 1 },
+          filter: jsonObjectSchema,
+          lifecycleMode: { type: "string" },
+          expiresAt: { type: "string" },
+          startPolicy: { type: "string" },
+          startOffset: { type: "integer" },
+          startTime: { type: "string" },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const body = request.body as Record<string, unknown>;
+    return service.registerSubscription({
+      agentId: String(body.agentId),
+      sourceId: String(body.sourceId),
+      filter: (body.filter as Record<string, unknown> | undefined) ?? {},
+      lifecycleMode: optionalString(body.lifecycleMode) as never,
+      expiresAt: optionalString(body.expiresAt) ?? null,
+      startPolicy: optionalString(body.startPolicy) as never,
+      startOffset: typeof body.startOffset === "number" ? body.startOffset : undefined,
+      startTime: optionalString(body.startTime) ?? undefined,
+    });
+  });
+
+  app.get("/subscriptions/:subscriptionId", {
+    schema: {
+      tags: ["subscriptions"],
+      params: {
+        type: "object",
+        required: ["subscriptionId"],
+        properties: {
+          subscriptionId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { subscriptionId: string };
+    return service.getSubscriptionDetails(decodeURIComponent(params.subscriptionId));
+  });
+
+  app.delete("/subscriptions/:subscriptionId", {
+    schema: {
+      tags: ["subscriptions"],
+      params: {
+        type: "object",
+        required: ["subscriptionId"],
+        properties: {
+          subscriptionId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { subscriptionId: string };
+    return service.removeSubscription(decodeURIComponent(params.subscriptionId));
+  });
+
+  app.post("/subscriptions/:subscriptionId/poll", {
+    schema: {
+      tags: ["subscriptions"],
+      params: {
+        type: "object",
+        required: ["subscriptionId"],
+        properties: {
+          subscriptionId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { subscriptionId: string };
+    return service.pollSubscription(decodeURIComponent(params.subscriptionId));
+  });
+
+  app.get("/subscriptions/:subscriptionId/lag", {
+    schema: {
+      tags: ["subscriptions"],
+      params: {
+        type: "object",
+        required: ["subscriptionId"],
+        properties: {
+          subscriptionId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { subscriptionId: string };
+    return service.getSubscriptionLag(decodeURIComponent(params.subscriptionId));
+  });
+
+  app.post("/subscriptions/:subscriptionId/reset", {
+    schema: {
+      tags: ["subscriptions"],
+      params: {
+        type: "object",
+        required: ["subscriptionId"],
+        properties: {
+          subscriptionId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["startPolicy"],
+        properties: {
+          startPolicy: { type: "string", minLength: 1 },
+          startOffset: { type: "integer" },
+          startTime: { type: "string" },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { subscriptionId: string };
+    const body = request.body as { startPolicy: string; startOffset?: number; startTime?: string };
+    return service.resetSubscription({
+      subscriptionId: decodeURIComponent(params.subscriptionId),
+      startPolicy: body.startPolicy as never,
+      startOffset: body.startOffset,
+      startTime: body.startTime ?? null,
+    });
+  });
+
+  app.get("/agents/:agentId/inbox", {
+    schema: {
+      tags: ["inbox"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    return service.getInboxDetailsByAgent(decodeURIComponent(params.agentId));
+  });
+
+  app.get("/agents/:agentId/inbox/items", {
+    schema: {
+      tags: ["inbox"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          after_item_id: { type: "string" },
+          include_acked: { type: "string", enum: ["true", "false"] },
+        },
+      },
+      response: {
+        200: {
+          type: "object",
+          required: ["items"],
+          properties: {
+            items: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    const query = request.query as { after_item_id?: string; include_acked?: "true" | "false" };
+    return {
+      items: service.listInboxItems(decodeURIComponent(params.agentId), {
+        afterItemId: query.after_item_id,
+        includeAcked: query.include_acked ? query.include_acked === "true" : undefined,
+      }),
+    };
+  });
+
+  app.get("/agents/:agentId/inbox/watch", {
+    schema: {
+      tags: ["inbox"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          after_item_id: { type: "string" },
+          include_acked: { type: "string", enum: ["true", "false"] },
+          heartbeat_ms: { type: "string", pattern: "^[1-9][0-9]*$" },
+        },
+      },
+      response: {
+        200: { type: "string" },
+      },
+    },
+  }, async (request, reply) => {
+    const params = request.params as { agentId: string };
+    const query = request.query as {
+      after_item_id?: string;
+      include_acked?: "true" | "false";
+      heartbeat_ms?: string;
+    };
+    const agentId = decodeURIComponent(params.agentId);
+    const watchOptions: WatchInboxOptions = {
+      afterItemId: query.after_item_id,
+      includeAcked: query.include_acked ? query.include_acked === "true" : undefined,
+      heartbeatMs: query.heartbeat_ms ? Number(query.heartbeat_ms) : undefined,
+    };
+
+    reply.hijack();
+    const raw = reply.raw;
+    raw.writeHead(200, {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+    });
+
+    const session = service.watchInbox(agentId, watchOptions, (event) => {
+      sendSse(raw, event.event, event);
+    });
+    sendSse(raw, "items", {
+      event: "items",
+      agentId,
+      items: session.initialItems,
+    });
+    session.start();
+
+    const heartbeatMs = watchOptions.heartbeatMs ?? 15_000;
+    const heartbeat = setInterval(() => {
+      sendSse(raw, "heartbeat", {
+        event: "heartbeat",
+        agentId,
+        timestamp: new Date().toISOString(),
+      });
+    }, heartbeatMs);
+
+    const cleanup = () => {
+      clearInterval(heartbeat);
+      session.close();
+      raw.end();
+    };
+    request.raw.on("close", cleanup);
+    request.raw.on("error", cleanup);
+  });
+
+  app.post("/agents/:agentId/inbox/compact", {
+    schema: {
+      tags: ["inbox"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    return service.compactInbox(decodeURIComponent(params.agentId));
+  });
+
+  app.post("/agents/:agentId/inbox/ack", {
+    schema: {
+      tags: ["inbox"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        oneOf: [
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["itemIds"],
+            properties: {
+              itemIds: {
+                type: "array",
+                minItems: 1,
+                items: { type: "string", minLength: 1 },
+              },
+            },
+          },
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["throughItemId"],
+            properties: {
+              throughItemId: { type: "string", minLength: 1 },
+            },
+          },
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["all"],
+            properties: {
+              all: { type: "boolean", const: true },
+            },
+          },
+        ],
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    const body = request.body as {
+      itemIds?: string[];
+      throughItemId?: string;
+      all?: boolean;
+    };
+    return service.ackInbox(decodeURIComponent(params.agentId), {
+      itemIds: body.itemIds ?? [],
+      throughItemId: body.throughItemId ?? null,
+      all: body.all ?? false,
+    });
+  });
+
+  app.post("/deliveries/send", {
+    schema: {
+      tags: ["deliveries"],
+      body: jsonObjectSchema,
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => service.sendDelivery(request.body as never));
+
+  app.setNotFoundHandler((_request, reply) => {
+    void reply.code(404).send({ error: "not found" });
+  });
+
+  app.setErrorHandler((error, _request, reply) => {
+    const message = error instanceof Error ? error.message : String(error);
+    if ((error as { validation?: unknown }).validation) {
+      void reply.code(400).send({ error: normalizeValidationMessage(message) });
+      return;
+    }
+    if (message.startsWith("unknown ")) {
+      void reply.code(404).send({ error: message });
+      return;
+    }
+    if (isBadRequestError(message)) {
+      void reply.code(400).send({ error: message });
+      return;
+    }
+    void reply.code(500).send({ error: message });
+  });
+
+  return app;
 }
 
-function parseRequiredString(value: unknown, message: string): string {
-  const parsed = parseOptionalString(value);
-  if (!parsed) {
-    throw new Error(message);
-  }
-  return parsed;
+export function createServer(service: AgentInboxService): http.Server {
+  const app = buildFastifyServer(service);
+  const ready = app.ready();
+  const server = http.createServer((req, res) => {
+    void Promise.resolve(ready)
+      .then(() => {
+        app.routing(req, res);
+      })
+      .catch((error: unknown) => {
+        res.statusCode = 500;
+        res.setHeader("content-type", "application/json; charset=utf-8");
+        const message = error instanceof Error ? error.message : String(error);
+        res.end(jsonResponse({ error: message }));
+      });
+  });
+
+  const originalClose = server.close.bind(server);
+  const wrappedClose: typeof server.close = ((callback?: (err?: Error) => void) => {
+    return originalClose((closeError?: Error) => {
+      void app
+        .close()
+        .then(() => callback?.(closeError))
+        .catch((appCloseError) => {
+          const normalized = appCloseError instanceof Error
+            ? appCloseError
+            : new Error(String(appCloseError));
+          callback?.(closeError ?? normalized);
+        });
+    });
+  }) as typeof server.close;
+  server.close = wrappedClose;
+
+  return server;
 }
 
-function parseOptionalString(value: unknown): string | undefined {
+function optionalString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
@@ -359,33 +897,17 @@ function parseOptionalString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function parseOptionalInteger(value: unknown): number | undefined {
-  if (value == null) {
-    return undefined;
+function normalizeValidationMessage(message: string): string {
+  if (message.includes("must be boolean")) {
+    return "expected boolean";
   }
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed)) {
-    throw new Error(`expected integer, received ${String(value)}`);
+  if (message.includes("must be integer")) {
+    return "expected integer";
   }
-  return parsed;
-}
-
-function parseOptionalBoolean(value: unknown): boolean | undefined {
-  if (value == null) {
-    return undefined;
+  if (message.includes("must be object")) {
+    return "expected object";
   }
-  if (typeof value !== "boolean") {
-    throw new Error(`expected boolean, received ${String(value)}`);
-  }
-  return value;
-}
-
-function parsePositiveInteger(value: unknown): number {
-  const parsed = parseOptionalInteger(value);
-  if (parsed == null || parsed <= 0) {
-    throw new Error(`expected positive integer, received ${String(value)}`);
-  }
-  return parsed;
+  return message;
 }
 
 function isBadRequestError(message: string): boolean {
@@ -413,21 +935,4 @@ function isBadRequestError(message: string): boolean {
     message.includes("requires a supported terminal context") ||
     message.includes("belongs to agent")
   );
-}
-
-function parseOptionalDeliveryHandle(value: unknown): DeliveryHandle | null {
-  if (!value) {
-    return null;
-  }
-  const object = asObject(value);
-  const provider = parseRequiredString(object.provider, "deliveryHandle.provider is required");
-  const surface = parseRequiredString(object.surface, "deliveryHandle.surface is required");
-  const targetRef = parseRequiredString(object.targetRef, "deliveryHandle.targetRef is required");
-  return {
-    provider,
-    surface,
-    targetRef,
-    threadRef: parseOptionalString(object.threadRef) ?? null,
-    replyMode: parseOptionalString(object.replyMode) ?? null,
-  };
 }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -208,6 +208,70 @@ test("unix socket control plane replaces stale socket files and serves requests"
   }
 });
 
+test("control plane validates sources/events occurredAt and deliveries/send request shape", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-schema-home-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    await adapters.start();
+    await service.start();
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const sourceResponse = await client.request<{ sourceId: string }>("/sources", {
+        sourceType: "local_event",
+        sourceKey: "schema-validate-demo",
+        config: {},
+      } satisfies RegisterSourceInput);
+      assert.equal(sourceResponse.statusCode, 200);
+
+      const invalidOccurredAt = await client.request<{ error: string }>(
+        `/sources/${encodeURIComponent(sourceResponse.data.sourceId)}/events`,
+        {
+          sourceNativeId: "evt-schema-1",
+          eventVariant: "message.created",
+          occurredAt: "",
+          metadata: {},
+          rawPayload: {},
+        },
+      );
+      assert.equal(invalidOccurredAt.statusCode, 400);
+      assert.equal(typeof invalidOccurredAt.data.error, "string");
+
+      const invalidDelivery = await client.request<{ error: string }>("/deliveries/send", {
+        kind: "comment",
+        payload: { body: "hello" },
+      });
+      assert.equal(invalidDelivery.statusCode, 400);
+      assert.equal(typeof invalidDelivery.data.error, "string");
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("e2e control plane can register an agent, route events, watch inbox, and send aggregated activation webhook", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-e2e-home-"));
   const socketPath = path.join(homeDir, "agentinbox.sock");

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -192,6 +192,11 @@ test("unix socket control plane replaces stale socket files and serves requests"
       const health = await client.request<{ ok: boolean }>("/healthz", undefined, "GET");
       assert.equal(health.statusCode, 200);
       assert.deepEqual(health.data, { ok: true });
+
+      const openapi = await client.request<Record<string, unknown>>("/openapi.json", undefined, "GET");
+      assert.equal(openapi.statusCode, 200);
+      assert.equal(typeof openapi.data.openapi, "string");
+      assert.ok(typeof openapi.data.paths === "object");
     } finally {
       await started.close();
     }


### PR DESCRIPTION
Closes #34

## Summary
- migrate control-plane HTTP server from handwritten `node:http` routing to Fastify routes
- add explicit request/response JSON schemas on routes and use them for runtime validation
- add generated OpenAPI endpoint at `GET /openapi.json` via `@fastify/swagger`
- keep existing endpoint paths and service behavior compatible
- add control-plane coverage for `/openapi.json` and update HTTP API docs reference

## Validation
- `npm run build`
- `npm test`