### PR TITLE
feat: unify external sources on remote_source profiles (issue #37)

### DIFF
--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -38,6 +38,7 @@ agentinbox agent remove <agent_id>
 agentinbox source add <source_type> <source_key> [--config-json ...]
 agentinbox source list
 agentinbox source show <source_id>
+agentinbox source remove <source_id>
 agentinbox source schema <source_type>
 agentinbox source poll <source_id>
 agentinbox source event <source_id> --native-id <id> --event <variant>

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -20,6 +20,7 @@ going forward.
 - `GET /sources`
 - `POST /sources`
 - `GET /sources/{sourceId}`
+- `DELETE /sources/{sourceId}`
 - `GET /source-types/{sourceType}/schema`
 - `POST /sources/{sourceId}/poll`
 - `POST /sources/{sourceId}/events`

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -76,5 +76,5 @@ going forward.
 
 - `local_event` is the only source type that supports direct manual append through
   `POST /sources/{sourceId}/events`.
-- `remote_source` is publicly reserved but registration is intentionally rejected
-  until the declarative runtime exists.
+- `remote_source` is supported and requires `config.profilePath` (and optional
+  `config.profileConfig`) when registering.

--- a/docs/site/reference/source-types.md
+++ b/docs/site/reference/source-types.md
@@ -12,20 +12,18 @@ without building a provider-specific adapter first.
 
 ## `remote_source`
 
-`remote_source` is a reserved product-facing name for future declarative
-external sources.
+`remote_source` is the generic external-source runtime surface.
 
-It exists to distinguish future external source definitions from:
+It uses a local profile module to define:
 
-- local event ingress
-- built-in provider-specific sources
+- managed source spec (`source.ensure`)
+- raw event mapping (`stream.read` payload -> AgentInbox event)
+- config validation
 
-The name is intentional: it describes source semantics without exposing
-implementation details such as `uxc`.
+Configuration fields:
 
-`remote_source` is reserved but not yet supported at runtime. Registration
-currently returns a client error until the declarative external-source runtime
-exists.
+- `profilePath` (required): path under `$AGENTINBOX_HOME/source-profiles`
+- `profileConfig` (optional): profile-specific config object
 
 ## `github_repo`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/swagger": "^9.5.2",
-        "@holon-run/uxc-daemon-client": "^0.13.3",
+        "@holon-run/uxc-daemon-client": "file:../uxc/packages/uxc-daemon-client",
         "fastify": "^5.6.1",
         "jexl": "^2.3.0",
         "sql.js": "^1.13.0"
@@ -26,6 +26,21 @@
         "mdorigin": "^0.5.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "../uxc/packages/uxc-daemon-client": {
+      "name": "@holon-run/uxc-daemon-client",
+      "version": "0.13.3",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.5.0",
+        "tsup": "^8.3.5",
+        "typescript": "^5.9.2",
+        "vitest": "^3.2.4",
+        "ws": "^8.18.3"
       },
       "engines": {
         "node": ">=20"
@@ -1073,13 +1088,8 @@
       }
     },
     "node_modules/@holon-run/uxc-daemon-client": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.13.3.tgz",
-      "integrity": "sha512-WZMfJrqsK4RgWOhd881mXdT0RqXQ+OSffbfLz2AygqY0SEpnopOrGI1UlwwueAktqpTMMDGK7KQXWXvOhadEtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
+      "resolved": "../uxc/packages/uxc-daemon-client",
+      "link": true
     },
     "node_modules/@indexbind/native-darwin-arm64": {
       "version": "0.6.2",
@@ -1249,7 +1259,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1260,7 +1269,6 @@
       "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/emscripten": "*",
         "@types/node": "*"
@@ -4049,8 +4057,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
       "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4190,7 +4197,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/swagger": "^9.5.2",
-        "@holon-run/uxc-daemon-client": "file:../uxc/packages/uxc-daemon-client",
+        "@holon-run/uxc-daemon-client": "^0.14.0",
         "fastify": "^5.6.1",
         "jexl": "^2.3.0",
         "sql.js": "^1.13.0"
@@ -26,21 +26,6 @@
         "mdorigin": "^0.5.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "../uxc/packages/uxc-daemon-client": {
-      "name": "@holon-run/uxc-daemon-client",
-      "version": "0.13.3",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/node": "^24.5.0",
-        "tsup": "^8.3.5",
-        "typescript": "^5.9.2",
-        "vitest": "^3.2.4",
-        "ws": "^8.18.3"
       },
       "engines": {
         "node": ">=20"
@@ -1088,8 +1073,13 @@
       }
     },
     "node_modules/@holon-run/uxc-daemon-client": {
-      "resolved": "../uxc/packages/uxc-daemon-client",
-      "link": true
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.14.0.tgz",
+      "integrity": "sha512-eAKD5e/7Vzc/XKZV0FmmcSuf5CXKKEE64EiYiD3cvXEXJX1L7fgUbMofnDhRnYCaJVdRCL2EFjyK6B0eNOzG2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@indexbind/native-darwin-arm64": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "test": "node --require ts-node/register --test test/*.test.ts"
   },
   "dependencies": {
-    "@holon-run/uxc-daemon-client": "file:../uxc/packages/uxc-daemon-client",
     "@fastify/swagger": "^9.5.2",
+    "@holon-run/uxc-daemon-client": "^0.14.0",
     "fastify": "^5.6.1",
     "jexl": "^2.3.0",
     "sql.js": "^1.13.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "node --require ts-node/register --test test/*.test.ts"
   },
   "dependencies": {
-    "@holon-run/uxc-daemon-client": "^0.13.3",
+    "@holon-run/uxc-daemon-client": "file:../uxc/packages/uxc-daemon-client",
     "@fastify/swagger": "^9.5.2",
     "fastify": "^5.6.1",
     "jexl": "^2.3.0",

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -15,6 +15,7 @@ import { RemoteSourceProfileRegistry } from "./sources/remote_profiles";
 export interface SourceAdapter {
   ensureSource(source: SubscriptionSource): Promise<void>;
   pollSource?(sourceId: string): Promise<SourcePollResult>;
+  removeSource?(sourceId: string): Promise<void>;
   start?(): Promise<void>;
   stop?(): Promise<void>;
   status?(): Record<string, unknown>;
@@ -41,6 +42,7 @@ class NoopSourceAdapter implements SourceAdapter {
       note: `${this.sourceType} source has no background poller`,
     };
   }
+
 }
 
 class NoopDeliveryAdapter implements DeliveryAdapter {
@@ -122,6 +124,11 @@ export class AdapterRegistry {
       };
     }
     return adapter.pollSource(source.sourceId);
+  }
+
+  async removeSource(source: SubscriptionSource): Promise<void> {
+    const adapter = this.sourceAdapterFor(source.sourceType);
+    await adapter.removeSource?.(source.sourceId);
   }
 
   status(): Record<string, unknown> {

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -7,9 +7,10 @@ import {
   SubscriptionSource,
 } from "./model";
 import { AgentInboxStore } from "./store";
-import { FeishuDeliveryAdapter, FeishuSourceRuntime } from "./sources/feishu";
-import { GithubDeliveryAdapter, GithubSourceRuntime } from "./sources/github";
-import { GithubCiSourceRuntime } from "./sources/github_ci";
+import { FeishuDeliveryAdapter } from "./sources/feishu";
+import { GithubDeliveryAdapter } from "./sources/github";
+import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
+import { RemoteSourceProfileRegistry } from "./sources/remote_profiles";
 
 export interface SourceAdapter {
   ensureSource(source: SubscriptionSource): Promise<void>;
@@ -50,18 +51,25 @@ class NoopDeliveryAdapter implements DeliveryAdapter {
 
 export class AdapterRegistry {
   private readonly localEventSource = new NoopSourceAdapter("local_event");
-  private readonly remoteSource = new NoopSourceAdapter("remote_source");
-  private readonly feishuSource: FeishuSourceRuntime;
-  private readonly githubSource: GithubSourceRuntime;
-  private readonly githubCiSource: GithubCiSourceRuntime;
+  private readonly remoteSource: RemoteSourceRuntime;
   private readonly defaultDelivery = new NoopDeliveryAdapter();
   private readonly feishuDelivery = new FeishuDeliveryAdapter();
   private readonly githubDelivery = new GithubDeliveryAdapter();
 
-  constructor(store: AgentInboxStore, appendSourceEvent: (input: AppendSourceEventInput) => Promise<{ appended: number; deduped: number }>) {
-    this.feishuSource = new FeishuSourceRuntime(store, appendSourceEvent);
-    this.githubSource = new GithubSourceRuntime(store, appendSourceEvent);
-    this.githubCiSource = new GithubCiSourceRuntime(store, appendSourceEvent);
+  constructor(
+    store: AgentInboxStore,
+    appendSourceEvent: (input: AppendSourceEventInput) => Promise<{ appended: number; deduped: number }>,
+    options?: {
+      homeDir?: string;
+      remoteSourceClient?: UxcRemoteSourceClient;
+      remoteProfileRegistry?: RemoteSourceProfileRegistry;
+    },
+  ) {
+    this.remoteSource = new RemoteSourceRuntime(store, appendSourceEvent, {
+      homeDir: options?.homeDir,
+      client: options?.remoteSourceClient,
+      profileRegistry: options?.remoteProfileRegistry,
+    });
   }
 
   sourceAdapterFor(type: SourceType): SourceAdapter {
@@ -72,13 +80,13 @@ export class AdapterRegistry {
       return this.remoteSource;
     }
     if (type === "github_repo") {
-      return this.githubSource;
+      return this.remoteSource;
     }
     if (type === "github_repo_ci") {
-      return this.githubCiSource;
+      return this.remoteSource;
     }
     if (type === "feishu_bot") {
-      return this.feishuSource;
+      return this.remoteSource;
     }
     return this.localEventSource;
   }
@@ -94,15 +102,11 @@ export class AdapterRegistry {
   }
 
   async start(): Promise<void> {
-    await this.feishuSource.start?.();
-    await this.githubSource.start?.();
-    await this.githubCiSource.start?.();
+    await this.remoteSource.start?.();
   }
 
   async stop(): Promise<void> {
-    await this.feishuSource.stop?.();
-    await this.githubSource.stop?.();
-    await this.githubCiSource.stop?.();
+    await this.remoteSource.stop?.();
   }
 
   async pollSource(source: SubscriptionSource): Promise<SourcePollResult> {
@@ -122,9 +126,7 @@ export class AdapterRegistry {
 
   status(): Record<string, unknown> {
     return {
-      feishu: this.feishuSource.status?.() ?? {},
-      github: this.githubSource.status?.() ?? {},
-      githubCi: this.githubCiSource.status?.() ?? {},
+      remote: this.remoteSource.status?.() ?? {},
     };
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,15 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "source" && normalized[1] === "remove") {
+    const sourceId = normalized[2];
+    if (!sourceId) {
+      throw new Error("usage: agentinbox source remove <sourceId>");
+    }
+    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}`, undefined, "DELETE");
+    return;
+  }
+
   if (command === "source" && normalized[1] === "schema") {
     const sourceType = normalized[2];
     if (!sourceType) {
@@ -564,6 +573,7 @@ Usage:
   agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]
   agentinbox source list
   agentinbox source show <sourceId>
+  agentinbox source remove <sourceId>
   agentinbox source schema <sourceType>
   agentinbox source poll <sourceId>
   agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -388,7 +388,9 @@ async function runServe(args: string[]): Promise<void> {
 
   const store = await AgentInboxStore.open(serveConfig.dbPath);
   let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir: serveConfig.homeDir,
+  });
   service = new AgentInboxService(store, adapters);
   const server = createServer(service);
   await adapters.start();

--- a/src/http.ts
+++ b/src/http.ts
@@ -158,6 +158,26 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.getSourceDetails(decodeURIComponent(params.sourceId));
   });
 
+  app.delete("/sources/:sourceId", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    return service.removeSource(decodeURIComponent(params.sourceId));
+  });
+
   app.get("/source-types/:sourceType/schema", {
     schema: {
       tags: ["sources"],
@@ -942,6 +962,7 @@ function isBadRequestError(message: string): boolean {
   return (
     message.startsWith("manual append is not supported") ||
     message.startsWith("sources/events requires") ||
+    message.startsWith("source remove requires") ||
     message.startsWith("deliveryHandle requires") ||
     message.startsWith("subscriptions/reset requires") ||
     message.startsWith("agents requires") ||
@@ -957,6 +978,8 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("expected positive integer") ||
     message.startsWith("notifyLeaseMs must be a positive integer") ||
     message.startsWith("invalid webhook activation target") ||
+    message.startsWith("remote_source requires") ||
+    message.startsWith("remote_source profile") ||
     message.includes("requires tmuxPaneId") ||
     message.includes("requires iTerm2 session identity") ||
     message.includes("requires a supported terminal context") ||

--- a/src/http.ts
+++ b/src/http.ts
@@ -952,7 +952,6 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("unsupported lifecycle mode") ||
     message.startsWith("unsupported start policy") ||
     message.startsWith("unsupported terminal") ||
-    message.startsWith("source type is reserved and not yet supported") ||
     message.startsWith("expected boolean") ||
     message.startsWith("expected integer") ||
     message.startsWith("expected positive integer") ||

--- a/src/service.ts
+++ b/src/service.ts
@@ -195,6 +195,20 @@ export class AgentInboxService {
     return getSourceSchema(sourceType);
   }
 
+  async removeSource(sourceId: string): Promise<{ removed: boolean }> {
+    const source = this.store.getSource(sourceId);
+    if (!source) {
+      return { removed: false };
+    }
+    const subscriptions = this.store.listSubscriptionsForSource(sourceId);
+    if (subscriptions.length > 0) {
+      throw new Error("source remove requires no active subscriptions");
+    }
+    await this.adapters.removeSource(source);
+    this.store.deleteSource(sourceId);
+    return { removed: true };
+  }
+
   registerAgent(input: RegisterAgentInput): RegisterAgentResult {
     validateNotifyLeaseMs(input.notifyLeaseMs);
     validateTerminalRegistration(input);

--- a/src/service.ts
+++ b/src/service.ts
@@ -147,9 +147,6 @@ export class AgentInboxService {
   }
 
   async registerSource(input: RegisterSourceInput): Promise<SubscriptionSource> {
-    if (input.sourceType === "remote_source") {
-      throw new Error("source type is reserved and not yet supported: remote_source");
-    }
     const existing = this.store.getSourceByKey(input.sourceType, input.sourceKey);
     if (existing) {
       return existing;

--- a/src/source_schema.ts
+++ b/src/source_schema.ts
@@ -19,7 +19,8 @@ const SOURCE_SCHEMAS: Record<SourceType, SourceSchema> = {
     payloadExamples: [],
     eventVariantExamples: [],
     configFields: [
-      { name: "definition", type: "object", required: false, description: "Reserved for future declarative external source definitions." },
+      { name: "profilePath", type: "string", required: true, description: "Local profile module path under $AGENTINBOX_HOME/source-profiles." },
+      { name: "profileConfig", type: "object", required: false, description: "Profile-specific configuration passed to validate/spec/map hooks." },
     ],
   },
   github_repo: {

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -9,10 +9,10 @@ import {
 } from "../model";
 import { AgentInboxStore } from "../store";
 
-const FEISHU_OPENAPI_ENDPOINT = "https://open.feishu.cn/open-apis";
-const FEISHU_IM_SCHEMA_URL =
+export const FEISHU_OPENAPI_ENDPOINT = "https://open.feishu.cn/open-apis";
+export const FEISHU_IM_SCHEMA_URL =
   "https://raw.githubusercontent.com/holon-run/uxc/main/skills/feishu-openapi-skill/references/feishu-im.openapi.json";
-const DEFAULT_EVENT_TYPES = ["im.message.receive_v1"];
+export const DEFAULT_FEISHU_EVENT_TYPES = ["im.message.receive_v1"];
 const DEFAULT_SYNC_INTERVAL_SECS = 2;
 const MAX_ERROR_BACKOFF_MULTIPLIER = 8;
 
@@ -393,7 +393,7 @@ export function normalizeFeishuBotEvent(
   const payload = raw as Record<string, unknown>;
   const header = asRecord(payload.header);
   const eventType = asString(payload.event_type) ?? asString(header.event_type);
-  if (!eventType || !(config.eventTypes ?? DEFAULT_EVENT_TYPES).includes(eventType)) {
+  if (!eventType || !(config.eventTypes ?? DEFAULT_FEISHU_EVENT_TYPES).includes(eventType)) {
     return null;
   }
 
@@ -460,13 +460,13 @@ export function normalizeFeishuBotEvent(
   };
 }
 
-function parseFeishuSourceConfig(source: SubscriptionSource): FeishuBotSourceConfig {
+export function parseFeishuSourceConfig(source: SubscriptionSource): FeishuBotSourceConfig {
   const config = source.config ?? {};
   return {
     endpoint: asString(config.endpoint) ?? FEISHU_OPENAPI_ENDPOINT,
     schemaUrl: asString(config.schemaUrl) ?? FEISHU_IM_SCHEMA_URL,
     uxcAuth: asString(config.uxcAuth) ?? source.configRef ?? asString(config.credentialRef) ?? undefined,
-    eventTypes: asStringArray(config.eventTypes) ?? DEFAULT_EVENT_TYPES,
+    eventTypes: asStringArray(config.eventTypes) ?? DEFAULT_FEISHU_EVENT_TYPES,
     chatIds: asStringArray(config.chatIds) ?? undefined,
   };
 }

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -9,8 +9,8 @@ import {
 } from "../model";
 import { AgentInboxStore } from "../store";
 
-const GITHUB_ENDPOINT = "https://api.github.com";
-const DEFAULT_EVENT_TYPES = [
+export const GITHUB_ENDPOINT = "https://api.github.com";
+export const DEFAULT_GITHUB_EVENT_TYPES = [
   "IssuesEvent",
   "IssueCommentEvent",
   "PullRequestEvent",
@@ -378,7 +378,7 @@ export function normalizeGithubRepoEvent(
   }
   const event = raw as Record<string, unknown>;
   const eventType = asString(event.type);
-  if (!eventType || !(config.eventTypes ?? DEFAULT_EVENT_TYPES).includes(eventType)) {
+  if (!eventType || !(config.eventTypes ?? DEFAULT_GITHUB_EVENT_TYPES).includes(eventType)) {
     return null;
   }
   const eventId = asString(event.id);
@@ -469,7 +469,7 @@ function buildGithubDeliveryHandle(
   };
 }
 
-function parseGithubSourceConfig(source: SubscriptionSource): GithubSourceConfig {
+export function parseGithubSourceConfig(source: SubscriptionSource): GithubSourceConfig {
   const config = source.config ?? {};
   const owner = asString(config.owner);
   const repo = asString(config.repo);
@@ -484,7 +484,7 @@ function parseGithubSourceConfig(source: SubscriptionSource): GithubSourceConfig
       uxcAuth: asString(config.uxcAuth) ?? asString(config.credentialRef) ?? undefined,
       pollIntervalSecs: asNumber(config.pollIntervalSecs) ?? 30,
       perPage: asNumber(config.perPage) ?? 10,
-      eventTypes: asStringArray(config.eventTypes) ?? DEFAULT_EVENT_TYPES,
+      eventTypes: asStringArray(config.eventTypes) ?? DEFAULT_GITHUB_EVENT_TYPES,
     };
   }
   return {
@@ -493,7 +493,7 @@ function parseGithubSourceConfig(source: SubscriptionSource): GithubSourceConfig
     uxcAuth: asString(config.uxcAuth) ?? asString(config.credentialRef) ?? undefined,
     pollIntervalSecs: asNumber(config.pollIntervalSecs) ?? 30,
     perPage: asNumber(config.perPage) ?? 10,
-    eventTypes: asStringArray(config.eventTypes) ?? DEFAULT_EVENT_TYPES,
+    eventTypes: asStringArray(config.eventTypes) ?? DEFAULT_GITHUB_EVENT_TYPES,
   };
 }
 

--- a/src/sources/github_ci.ts
+++ b/src/sources/github_ci.ts
@@ -2,9 +2,9 @@ import { UxcDaemonClient } from "@holon-run/uxc-daemon-client";
 import { AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "../model";
 import { AgentInboxStore } from "../store";
 
-const GITHUB_ENDPOINT = "https://api.github.com";
-const DEFAULT_POLL_INTERVAL_SECS = 30;
-const DEFAULT_PER_PAGE = 20;
+export const GITHUB_CI_ENDPOINT = "https://api.github.com";
+export const DEFAULT_GITHUB_CI_POLL_INTERVAL_SECS = 30;
+export const DEFAULT_GITHUB_CI_PER_PAGE = 20;
 const MAX_SEEN_KEYS = 512;
 const MAX_ERROR_BACKOFF_MULTIPLIER = 8;
 
@@ -46,7 +46,7 @@ export class GithubActionsUxcClient {
     const payload: Record<string, unknown> = {
       owner: config.owner,
       repo: config.repo,
-      per_page: config.perPage ?? DEFAULT_PER_PAGE,
+      per_page: config.perPage ?? DEFAULT_GITHUB_CI_PER_PAGE,
     };
     if (config.eventFilter) {
       payload.event = config.eventFilter;
@@ -58,7 +58,7 @@ export class GithubActionsUxcClient {
       payload.status = config.statusFilter;
     }
     const response = await this.client.call({
-      endpoint: GITHUB_ENDPOINT,
+      endpoint: GITHUB_CI_ENDPOINT,
       operation: "get:/repos/{owner}/{repo}/actions/runs",
       payload,
       options: { auth: config.uxcAuth },
@@ -173,7 +173,7 @@ export class GithubCiSourceRuntime {
           };
         }
         const lastPollAt = this.lastPollAt.get(sourceId) ?? 0;
-        const pollIntervalMs = (config.pollIntervalSecs ?? DEFAULT_POLL_INTERVAL_SECS) * 1000;
+        const pollIntervalMs = (config.pollIntervalSecs ?? DEFAULT_GITHUB_CI_POLL_INTERVAL_SECS) * 1000;
         if (Date.now() - lastPollAt < pollIntervalMs) {
           return {
             sourceId,
@@ -245,7 +245,7 @@ export class GithubCiSourceRuntime {
         this.errorCounts.set(sourceId, nextErrorCount);
         this.nextRetryAt.set(
           sourceId,
-          Date.now() + computeErrorBackoffMs(config.pollIntervalSecs ?? DEFAULT_POLL_INTERVAL_SECS, nextErrorCount),
+          Date.now() + computeErrorBackoffMs(config.pollIntervalSecs ?? DEFAULT_GITHUB_CI_POLL_INTERVAL_SECS, nextErrorCount),
         );
         this.store.updateSourceRuntime(sourceId, {
           status: "error",
@@ -335,7 +335,7 @@ export function normalizeGithubWorkflowRunEvent(
   };
 }
 
-function parseGithubCiSourceConfig(source: SubscriptionSource): GithubCiSourceConfig {
+export function parseGithubCiSourceConfig(source: SubscriptionSource): GithubCiSourceConfig {
   const config = source.config ?? {};
   const owner = asString(config.owner);
   const repo = asString(config.repo);
@@ -348,8 +348,8 @@ function parseGithubCiSourceConfig(source: SubscriptionSource): GithubCiSourceCo
       owner: fallbackOwner,
       repo: fallbackRepo,
       uxcAuth: asString(config.uxcAuth) ?? asString(config.credentialRef) ?? undefined,
-      pollIntervalSecs: asNumber(config.pollIntervalSecs) ?? DEFAULT_POLL_INTERVAL_SECS,
-      perPage: asNumber(config.perPage) ?? DEFAULT_PER_PAGE,
+      pollIntervalSecs: asNumber(config.pollIntervalSecs) ?? DEFAULT_GITHUB_CI_POLL_INTERVAL_SECS,
+      perPage: asNumber(config.perPage) ?? DEFAULT_GITHUB_CI_PER_PAGE,
       eventFilter: asString(config.eventFilter) ?? undefined,
       branch: asString(config.branch) ?? undefined,
       statusFilter: asString(config.statusFilter) ?? undefined,
@@ -359,8 +359,8 @@ function parseGithubCiSourceConfig(source: SubscriptionSource): GithubCiSourceCo
     owner,
     repo,
     uxcAuth: asString(config.uxcAuth) ?? asString(config.credentialRef) ?? undefined,
-    pollIntervalSecs: asNumber(config.pollIntervalSecs) ?? DEFAULT_POLL_INTERVAL_SECS,
-    perPage: asNumber(config.perPage) ?? DEFAULT_PER_PAGE,
+    pollIntervalSecs: asNumber(config.pollIntervalSecs) ?? DEFAULT_GITHUB_CI_POLL_INTERVAL_SECS,
+    perPage: asNumber(config.perPage) ?? DEFAULT_GITHUB_CI_PER_PAGE,
     eventFilter: asString(config.eventFilter) ?? undefined,
     branch: asString(config.branch) ?? undefined,
     statusFilter: asString(config.statusFilter) ?? undefined,

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -1,4 +1,4 @@
-import { RuntimeInvokeOptions, UxcDaemonClient } from "@holon-run/uxc-daemon-client";
+import { ManagedSourceEnsureResponse, ManagedStreamReadResponse, UxcDaemonClient } from "@holon-run/uxc-daemon-client";
 import { AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "../model";
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
@@ -45,32 +45,13 @@ export interface UxcRemoteSourceClient {
   }): Promise<ManagedStreamReadResponse>;
 }
 
-interface ManagedSourceEnsureResponse {
-  namespace: string;
-  source_key: string;
-  stream_id: string;
-  status: string;
-}
-
-interface ManagedStreamReadResponse {
-  stream_id: string;
-  events: Array<{
-    stream_id: string;
-    offset: number;
-    ingested_at_unix: number;
-    raw_payload: unknown;
-  }>;
-  next_after_offset: number;
-  has_more: boolean;
-}
-
 export class RpcUxcRemoteSourceClient implements UxcRemoteSourceClient {
   constructor(private readonly client: UxcDaemonClient = new UxcDaemonClient({ env: process.env })) {}
 
   sourceEnsure(args: { namespace: string; sourceKey: string; spec: ManagedSourceSpec }): Promise<ManagedSourceEnsureResponse> {
-    return this.client.request("source.ensure", {
+    return this.client.sourceEnsure({
       namespace: args.namespace,
-      source_key: args.sourceKey,
+      sourceKey: args.sourceKey,
       spec: {
         ...args.spec,
         operation_id: args.spec.operation_id ?? null,
@@ -80,29 +61,23 @@ export class RpcUxcRemoteSourceClient implements UxcRemoteSourceClient {
         subprotocols: args.spec.subprotocols ?? [],
         initial_text_frames: args.spec.initial_text_frames ?? [],
         poll_config: args.spec.poll_config ?? null,
-        options: normalizeRuntimeOptions(args.spec.options),
+        options: args.spec.options,
       },
     });
   }
 
   async sourceStop(namespace: string, sourceKey: string): Promise<void> {
-    await this.client.request("source.stop", {
-      namespace,
-      source_key: sourceKey,
-    });
+    await this.client.sourceStop(namespace, sourceKey);
   }
 
   async sourceDelete(namespace: string, sourceKey: string): Promise<void> {
-    await this.client.request("source.delete", {
-      namespace,
-      source_key: sourceKey,
-    });
+    await this.client.sourceDelete(namespace, sourceKey);
   }
 
   streamRead(args: { streamId: string; afterOffset?: number; limit?: number }): Promise<ManagedStreamReadResponse> {
-    return this.client.request("stream.read", {
-      stream_id: args.streamId,
-      after_offset: args.afterOffset ?? 0,
+    return this.client.streamRead({
+      streamId: args.streamId,
+      afterOffset: args.afterOffset ?? 0,
       limit: args.limit ?? 100,
     });
   }
@@ -349,23 +324,4 @@ function asRecord(value: unknown): Record<string, unknown> {
     return {};
   }
   return value as Record<string, unknown>;
-}
-
-function normalizeRuntimeOptions(options: RuntimeInvokeOptions | undefined): Record<string, unknown> {
-  return {
-    auth: options?.auth ?? null,
-    inject_env: options?.inject_env ?? [],
-    no_cache: options?.no_cache ?? false,
-    cache_ttl: options?.cache_ttl ?? null,
-    refresh_schema: options?.refresh_schema ?? false,
-    schema_url: options?.schema_url ?? null,
-    link_name: options?.link_name ?? null,
-    link_skill: options?.link_skill ?? null,
-    link_skill_doc: options?.link_skill_doc ?? null,
-    link_skill_path: options?.link_skill_path ?? null,
-    schema_mapping_file: options?.schema_mapping_file ?? null,
-    daemon_exclusive: options?.daemon_exclusive ?? [],
-    daemon_idle_ttl: options?.daemon_idle_ttl ?? null,
-    request_headers: options?.request_headers ?? {},
-  };
 }

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -1,0 +1,353 @@
+import { UxcDaemonClient } from "@holon-run/uxc-daemon-client";
+import { AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "../model";
+import { resolveAgentInboxHome } from "../paths";
+import { AgentInboxStore } from "../store";
+import { nowIso } from "../util";
+import { ManagedSourceSpec, RemoteSourceProfileRegistry } from "./remote_profiles";
+
+const REMOTE_SOURCE_TYPES = new Set<SubscriptionSource["sourceType"]>([
+  "remote_source",
+  "github_repo",
+  "github_repo_ci",
+  "feishu_bot",
+]);
+
+const DEFAULT_SYNC_INTERVAL_MS = 2_000;
+const DEFAULT_BACKOFF_BASE_SECS = 2;
+const MAX_ERROR_BACKOFF_MULTIPLIER = 8;
+const MANAGED_SOURCE_NAMESPACE = "agentinbox";
+
+interface ManagedSourceEnsureResponse {
+  namespace: string;
+  source_key: string;
+  stream_id: string;
+  status: string;
+}
+
+interface ManagedStreamEvent {
+  stream_id: string;
+  offset: number;
+  ingested_at_unix: number;
+  raw_payload: unknown;
+}
+
+interface ManagedStreamReadResponse {
+  stream_id: string;
+  events: ManagedStreamEvent[];
+  next_after_offset: number;
+  has_more: boolean;
+}
+
+interface RemoteSourceCheckpoint {
+  managedSource?: {
+    namespace: string;
+    sourceKey: string;
+    streamId: string;
+  };
+  streamCursor?: {
+    afterOffset: number;
+  };
+  lastEventAt?: string;
+  lastError?: string | null;
+}
+
+export interface UxcRemoteSourceClient {
+  sourceEnsure(args: {
+    namespace: string;
+    sourceKey: string;
+    spec: ManagedSourceSpec;
+  }): Promise<ManagedSourceEnsureResponse>;
+  sourceStop(namespace: string, sourceKey: string): Promise<void>;
+  sourceDelete(namespace: string, sourceKey: string): Promise<void>;
+  streamRead(args: {
+    streamId: string;
+    afterOffset?: number;
+    limit?: number;
+  }): Promise<ManagedStreamReadResponse>;
+}
+
+export class RpcUxcRemoteSourceClient implements UxcRemoteSourceClient {
+  constructor(private readonly client: UxcDaemonClient = new UxcDaemonClient({ env: process.env })) {}
+
+  sourceEnsure(args: { namespace: string; sourceKey: string; spec: ManagedSourceSpec }): Promise<ManagedSourceEnsureResponse> {
+    return this.client.request("source.ensure", {
+      namespace: args.namespace,
+      source_key: args.sourceKey,
+      spec: {
+        ...args.spec,
+        resource_uri: args.spec.resource_uri ?? null,
+        read_resource: args.spec.read_resource ?? false,
+        transport_hint: args.spec.transport_hint ?? null,
+        subprotocols: args.spec.subprotocols ?? [],
+        initial_text_frames: args.spec.initial_text_frames ?? [],
+        poll_config: args.spec.poll_config ?? null,
+        options: args.spec.options ?? {},
+      },
+    });
+  }
+
+  async sourceStop(namespace: string, sourceKey: string): Promise<void> {
+    await this.client.request("source.stop", {
+      namespace,
+      source_key: sourceKey,
+    });
+  }
+
+  async sourceDelete(namespace: string, sourceKey: string): Promise<void> {
+    await this.client.request("source.delete", {
+      namespace,
+      source_key: sourceKey,
+    });
+  }
+
+  streamRead(args: { streamId: string; afterOffset?: number; limit?: number }): Promise<ManagedStreamReadResponse> {
+    return this.client.request("stream.read", {
+      stream_id: args.streamId,
+      after_offset: args.afterOffset ?? 0,
+      limit: args.limit ?? 100,
+    });
+  }
+}
+
+export class RemoteSourceRuntime {
+  private readonly profileRegistry: RemoteSourceProfileRegistry;
+  private readonly client: UxcRemoteSourceClient;
+  private interval: NodeJS.Timeout | null = null;
+  private readonly inFlight = new Set<string>();
+  private readonly errorCounts = new Map<string, number>();
+  private readonly nextRetryAt = new Map<string, number>();
+  private readonly homeDir: string;
+
+  constructor(
+    private readonly store: AgentInboxStore,
+    private readonly appendSourceEvent: (input: AppendSourceEventInput) => Promise<{ appended: number; deduped: number }>,
+    options?: {
+      profileRegistry?: RemoteSourceProfileRegistry;
+      client?: UxcRemoteSourceClient;
+      homeDir?: string;
+    },
+  ) {
+    this.profileRegistry = options?.profileRegistry ?? new RemoteSourceProfileRegistry();
+    this.client = options?.client ?? new RpcUxcRemoteSourceClient();
+    this.homeDir = options?.homeDir ?? resolveAgentInboxHome(process.env);
+  }
+
+  async ensureSource(source: SubscriptionSource): Promise<void> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return;
+    }
+    await this.syncSource(source.sourceId, true);
+  }
+
+  async start(): Promise<void> {
+    if (this.interval) {
+      return;
+    }
+    this.interval = setInterval(() => {
+      void this.syncAll();
+    }, DEFAULT_SYNC_INTERVAL_MS);
+    try {
+      await this.syncAll();
+    } catch (error) {
+      console.warn("remote_source initial sync failed:", error);
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  async pollSource(sourceId: string): Promise<SourcePollResult> {
+    return this.syncSource(sourceId, true);
+  }
+
+  status(): Record<string, unknown> {
+    return {
+      activeSourceIds: Array.from(this.inFlight.values()).sort(),
+      erroredSourceIds: Array.from(this.errorCounts.keys()).sort(),
+    };
+  }
+
+  private async syncAll(): Promise<void> {
+    const sources = this.store
+      .listSources()
+      .filter((source) => REMOTE_SOURCE_TYPES.has(source.sourceType) && source.status !== "paused");
+    for (const source of sources) {
+      try {
+        await this.syncSource(source.sourceId, false);
+      } catch (error) {
+        console.warn(`remote source sync failed for ${source.sourceId}:`, error);
+      }
+    }
+  }
+
+  private async syncSource(sourceId: string, force: boolean): Promise<SourcePollResult> {
+    if (this.inFlight.has(sourceId)) {
+      const source = this.store.getSource(sourceId);
+      return {
+        sourceId,
+        sourceType: source?.sourceType ?? "remote_source",
+        appended: 0,
+        deduped: 0,
+        eventsRead: 0,
+        note: "source sync already in flight",
+      };
+    }
+    this.inFlight.add(sourceId);
+    try {
+      const source = this.store.getSource(sourceId);
+      if (!source) {
+        throw new Error(`unknown source: ${sourceId}`);
+      }
+      if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+        return {
+          sourceId,
+          sourceType: source.sourceType,
+          appended: 0,
+          deduped: 0,
+          eventsRead: 0,
+          note: "source type is not hosted by remote runtime",
+        };
+      }
+      if (!force && source.status === "error") {
+        const retryAt = this.nextRetryAt.get(sourceId) ?? 0;
+        if (Date.now() < retryAt) {
+          return {
+            sourceId,
+            sourceType: source.sourceType,
+            appended: 0,
+            deduped: 0,
+            eventsRead: 0,
+            note: "error backoff not elapsed",
+          };
+        }
+      }
+
+      const profile = await this.profileRegistry.resolve(source, this.homeDir);
+      const profileSource = profileInputSource(source);
+      profile.validateConfig(profileSource);
+      const spec = profile.buildManagedSourceSpec(profileSource);
+      const managedSourceKey = `${source.sourceType}:${source.sourceKey}`;
+      const ensured = await this.client.sourceEnsure({
+        namespace: MANAGED_SOURCE_NAMESPACE,
+        sourceKey: managedSourceKey,
+        spec,
+      });
+
+      const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+      const afterOffset = checkpoint.streamCursor?.afterOffset ?? 0;
+      const batch = await this.client.streamRead({
+        streamId: ensured.stream_id,
+        afterOffset,
+        limit: 100,
+      });
+
+      let appended = 0;
+      let deduped = 0;
+      for (const event of batch.events) {
+        const rawPayload = asRecord(event.raw_payload);
+        if (Object.keys(rawPayload).length === 0) {
+          continue;
+        }
+        const mapped = profile.mapRawEvent(rawPayload, profileSource);
+        if (!mapped) {
+          continue;
+        }
+        const result = await this.appendSourceEvent({
+          sourceId: source.sourceId,
+          sourceNativeId: mapped.sourceNativeId,
+          eventVariant: mapped.eventVariant,
+          occurredAt: mapped.occurredAt,
+          metadata: mapped.metadata,
+          rawPayload: mapped.rawPayload,
+          deliveryHandle: mapped.deliveryHandle ?? null,
+        });
+        appended += result.appended;
+        deduped += result.deduped;
+      }
+
+      this.store.updateSourceRuntime(sourceId, {
+        status: "active",
+        checkpoint: JSON.stringify({
+          managedSource: {
+            namespace: ensured.namespace,
+            sourceKey: ensured.source_key,
+            streamId: ensured.stream_id,
+          },
+          streamCursor: {
+            afterOffset: batch.next_after_offset,
+          },
+          lastEventAt: nowIso(),
+          lastError: null,
+        } satisfies RemoteSourceCheckpoint),
+      });
+      this.errorCounts.delete(sourceId);
+      this.nextRetryAt.delete(sourceId);
+
+      return {
+        sourceId,
+        sourceType: source.sourceType,
+        appended,
+        deduped,
+        eventsRead: batch.events.length,
+        note: `stream=${ensured.stream_id} status=${ensured.status}`,
+      };
+    } catch (error) {
+      const source = this.store.getSource(sourceId);
+      if (source) {
+        const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+        const nextErrorCount = (this.errorCounts.get(sourceId) ?? 0) + 1;
+        this.errorCounts.set(sourceId, nextErrorCount);
+        this.nextRetryAt.set(sourceId, Date.now() + computeErrorBackoffMs(DEFAULT_BACKOFF_BASE_SECS, nextErrorCount));
+        this.store.updateSourceRuntime(sourceId, {
+          status: "error",
+          checkpoint: JSON.stringify({
+            ...checkpoint,
+            lastError: error instanceof Error ? error.message : String(error),
+          } satisfies RemoteSourceCheckpoint),
+        });
+      }
+      throw error;
+    } finally {
+      this.inFlight.delete(sourceId);
+    }
+  }
+}
+
+function profileInputSource(source: SubscriptionSource): SubscriptionSource {
+  if (source.sourceType !== "remote_source") {
+    return source;
+  }
+  const config = asRecord(source.config);
+  return {
+    ...source,
+    config: asRecord(config.profileConfig),
+  };
+}
+
+function parseRemoteCheckpoint(checkpoint: string | null | undefined): RemoteSourceCheckpoint {
+  if (!checkpoint) {
+    return {};
+  }
+  try {
+    return JSON.parse(checkpoint) as RemoteSourceCheckpoint;
+  } catch {
+    return {};
+  }
+}
+
+function computeErrorBackoffMs(baseIntervalSecs: number, errorCount: number): number {
+  const baseMs = Math.max(1, baseIntervalSecs) * 1000;
+  const multiplier = Math.min(2 ** Math.max(0, errorCount - 1), MAX_ERROR_BACKOFF_MULTIPLIER);
+  return baseMs * multiplier;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -138,6 +138,17 @@ export class RemoteSourceRuntime {
     return this.syncSource(sourceId, true);
   }
 
+  async removeSource(sourceId: string): Promise<void> {
+    const source = this.store.getSource(sourceId);
+    if (!source || !REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return;
+    }
+    const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+    const namespace = checkpoint.managedSource?.namespace ?? MANAGED_SOURCE_NAMESPACE;
+    const sourceKey = checkpoint.managedSource?.sourceKey ?? `${source.sourceType}:${source.sourceKey}`;
+    await this.client.sourceDelete(namespace, sourceKey);
+  }
+
   status(): Record<string, unknown> {
     return {
       activeSourceIds: Array.from(this.inFlight.values()).sort(),

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -1,4 +1,4 @@
-import { UxcDaemonClient } from "@holon-run/uxc-daemon-client";
+import { RuntimeInvokeOptions, UxcDaemonClient } from "@holon-run/uxc-daemon-client";
 import { AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "../model";
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
@@ -16,27 +16,6 @@ const DEFAULT_SYNC_INTERVAL_MS = 2_000;
 const DEFAULT_BACKOFF_BASE_SECS = 2;
 const MAX_ERROR_BACKOFF_MULTIPLIER = 8;
 const MANAGED_SOURCE_NAMESPACE = "agentinbox";
-
-interface ManagedSourceEnsureResponse {
-  namespace: string;
-  source_key: string;
-  stream_id: string;
-  status: string;
-}
-
-interface ManagedStreamEvent {
-  stream_id: string;
-  offset: number;
-  ingested_at_unix: number;
-  raw_payload: unknown;
-}
-
-interface ManagedStreamReadResponse {
-  stream_id: string;
-  events: ManagedStreamEvent[];
-  next_after_offset: number;
-  has_more: boolean;
-}
 
 interface RemoteSourceCheckpoint {
   managedSource?: {
@@ -66,6 +45,25 @@ export interface UxcRemoteSourceClient {
   }): Promise<ManagedStreamReadResponse>;
 }
 
+interface ManagedSourceEnsureResponse {
+  namespace: string;
+  source_key: string;
+  stream_id: string;
+  status: string;
+}
+
+interface ManagedStreamReadResponse {
+  stream_id: string;
+  events: Array<{
+    stream_id: string;
+    offset: number;
+    ingested_at_unix: number;
+    raw_payload: unknown;
+  }>;
+  next_after_offset: number;
+  has_more: boolean;
+}
+
 export class RpcUxcRemoteSourceClient implements UxcRemoteSourceClient {
   constructor(private readonly client: UxcDaemonClient = new UxcDaemonClient({ env: process.env })) {}
 
@@ -75,13 +73,14 @@ export class RpcUxcRemoteSourceClient implements UxcRemoteSourceClient {
       source_key: args.sourceKey,
       spec: {
         ...args.spec,
+        operation_id: args.spec.operation_id ?? null,
         resource_uri: args.spec.resource_uri ?? null,
         read_resource: args.spec.read_resource ?? false,
         transport_hint: args.spec.transport_hint ?? null,
         subprotocols: args.spec.subprotocols ?? [],
         initial_text_frames: args.spec.initial_text_frames ?? [],
         poll_config: args.spec.poll_config ?? null,
-        options: args.spec.options ?? {},
+        options: normalizeRuntimeOptions(args.spec.options),
       },
     });
   }
@@ -350,4 +349,23 @@ function asRecord(value: unknown): Record<string, unknown> {
     return {};
   }
   return value as Record<string, unknown>;
+}
+
+function normalizeRuntimeOptions(options: RuntimeInvokeOptions | undefined): Record<string, unknown> {
+  return {
+    auth: options?.auth ?? null,
+    inject_env: options?.inject_env ?? [],
+    no_cache: options?.no_cache ?? false,
+    cache_ttl: options?.cache_ttl ?? null,
+    refresh_schema: options?.refresh_schema ?? false,
+    schema_url: options?.schema_url ?? null,
+    link_name: options?.link_name ?? null,
+    link_skill: options?.link_skill ?? null,
+    link_skill_doc: options?.link_skill_doc ?? null,
+    link_skill_path: options?.link_skill_path ?? null,
+    schema_mapping_file: options?.schema_mapping_file ?? null,
+    daemon_exclusive: options?.daemon_exclusive ?? [],
+    daemon_idle_ttl: options?.daemon_idle_ttl ?? null,
+    request_headers: options?.request_headers ?? {},
+  };
 }

--- a/src/sources/remote_profiles.ts
+++ b/src/sources/remote_profiles.ts
@@ -1,0 +1,309 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { PollSubscriptionConfig, RuntimeInvokeOptions } from "@holon-run/uxc-daemon-client";
+import { AppendSourceEventInput, SubscriptionSource } from "../model";
+import {
+  GITHUB_ENDPOINT,
+  normalizeGithubRepoEvent,
+  parseGithubSourceConfig,
+} from "./github";
+import {
+  DEFAULT_GITHUB_CI_PER_PAGE,
+  DEFAULT_GITHUB_CI_POLL_INTERVAL_SECS,
+  GITHUB_CI_ENDPOINT,
+  normalizeGithubWorkflowRunEvent,
+  parseGithubCiSourceConfig,
+} from "./github_ci";
+import {
+  FEISHU_OPENAPI_ENDPOINT,
+  normalizeFeishuBotEvent,
+  parseFeishuSourceConfig,
+} from "./feishu";
+
+export interface ManagedSourceSpec {
+  endpoint: string;
+  operation_id?: string | null;
+  args?: Record<string, unknown> | null;
+  resource_uri?: string | null;
+  read_resource?: boolean;
+  transport_hint?: "websocket" | "discord_gateway" | "slack_socket_mode" | "feishu_long_connection" | null;
+  subprotocols?: string[];
+  initial_text_frames?: string[];
+  mode: "stream" | "poll";
+  poll_config?: PollSubscriptionConfig | null;
+  options?: RuntimeInvokeOptions;
+}
+
+export interface MappedRemoteEvent {
+  sourceNativeId: string;
+  eventVariant: string;
+  metadata: Record<string, unknown>;
+  rawPayload: Record<string, unknown>;
+  occurredAt?: string;
+  deliveryHandle?: AppendSourceEventInput["deliveryHandle"];
+}
+
+export interface RemoteSourceProfile {
+  id: string;
+  validateConfig(source: SubscriptionSource): void;
+  buildManagedSourceSpec(source: SubscriptionSource): ManagedSourceSpec;
+  mapRawEvent(rawPayload: Record<string, unknown>, source: SubscriptionSource): MappedRemoteEvent | null;
+}
+
+const REMOTE_USER_PROFILE_ROOT_DIR = "source-profiles";
+const BUILTIN_PROFILE_IDS = new Set(["builtin.github_repo", "builtin.github_repo_ci", "builtin.feishu_bot"]);
+
+export class RemoteSourceProfileRegistry {
+  private readonly profileCache = new Map<string, RemoteSourceProfile>();
+
+  resolve(source: SubscriptionSource, homeDir: string): Promise<RemoteSourceProfile> {
+    if (source.sourceType === "github_repo") {
+      return Promise.resolve(GITHUB_REPO_PROFILE);
+    }
+    if (source.sourceType === "github_repo_ci") {
+      return Promise.resolve(GITHUB_REPO_CI_PROFILE);
+    }
+    if (source.sourceType === "feishu_bot") {
+      return Promise.resolve(FEISHU_BOT_PROFILE);
+    }
+    if (source.sourceType !== "remote_source") {
+      throw new Error(`unsupported source type for remote profile: ${source.sourceType}`);
+    }
+    return this.loadUserProfile(source, homeDir);
+  }
+
+  private async loadUserProfile(source: SubscriptionSource, homeDir: string): Promise<RemoteSourceProfile> {
+    const config = source.config ?? {};
+    const profilePath = asNonEmptyString(config.profilePath);
+    if (!profilePath) {
+      throw new Error("remote_source requires config.profilePath");
+    }
+
+    const profileRoot = path.resolve(homeDir, REMOTE_USER_PROFILE_ROOT_DIR);
+    const resolvedPath = resolveAndValidateProfilePath(profileRoot, profilePath);
+    const cacheKey = `${resolvedPath}:${source.sourceKey}`;
+    const cached = this.profileCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    if (!fs.existsSync(resolvedPath)) {
+      throw new Error(`remote_source profile not found: ${resolvedPath}`);
+    }
+
+    const imported = await dynamicImportModule(pathToFileURL(resolvedPath).href);
+    const profile = ((imported.default ?? imported) as RemoteSourceProfile | undefined);
+    if (!profile || typeof profile !== "object") {
+      throw new Error(`remote_source profile must export default object: ${resolvedPath}`);
+    }
+    validateProfileContract(profile, resolvedPath);
+    this.profileCache.set(cacheKey, profile);
+    return profile;
+  }
+}
+
+async function dynamicImportModule(moduleUrl: string): Promise<Record<string, unknown>> {
+  const importer = new Function("url", "return import(url);") as (url: string) => Promise<Record<string, unknown>>;
+  return importer(moduleUrl);
+}
+
+export function builtInProfileIdForSourceType(sourceType: SubscriptionSource["sourceType"]): string | null {
+  if (sourceType === "github_repo") {
+    return "builtin.github_repo";
+  }
+  if (sourceType === "github_repo_ci") {
+    return "builtin.github_repo_ci";
+  }
+  if (sourceType === "feishu_bot") {
+    return "builtin.feishu_bot";
+  }
+  return null;
+}
+
+function validateProfileContract(profile: RemoteSourceProfile, sourcePath: string): void {
+  if (!profile.id || typeof profile.id !== "string") {
+    throw new Error(`remote_source profile id must be a non-empty string: ${sourcePath}`);
+  }
+  if (BUILTIN_PROFILE_IDS.has(profile.id)) {
+    throw new Error(`remote_source profile id is reserved: ${profile.id}`);
+  }
+  if (typeof profile.validateConfig !== "function") {
+    throw new Error(`remote_source profile missing validateConfig(): ${sourcePath}`);
+  }
+  if (typeof profile.buildManagedSourceSpec !== "function") {
+    throw new Error(`remote_source profile missing buildManagedSourceSpec(): ${sourcePath}`);
+  }
+  if (typeof profile.mapRawEvent !== "function") {
+    throw new Error(`remote_source profile missing mapRawEvent(): ${sourcePath}`);
+  }
+}
+
+function resolveAndValidateProfilePath(profileRoot: string, profilePath: string): string {
+  const resolved = path.isAbsolute(profilePath)
+    ? path.resolve(profilePath)
+    : path.resolve(profileRoot, profilePath);
+  const normalizedRoot = ensureTrailingSep(path.resolve(profileRoot));
+  const normalizedResolved = path.resolve(resolved);
+  if (!normalizedResolved.startsWith(normalizedRoot) && normalizedResolved !== path.resolve(profileRoot)) {
+    throw new Error(`remote_source profilePath must stay under ${profileRoot}`);
+  }
+  return normalizedResolved;
+}
+
+function ensureTrailingSep(input: string): string {
+  return input.endsWith(path.sep) ? input : `${input}${path.sep}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+const GITHUB_REPO_PROFILE: RemoteSourceProfile = {
+  id: "builtin.github_repo",
+  validateConfig(source: SubscriptionSource): void {
+    parseGithubSourceConfig(source);
+  },
+  buildManagedSourceSpec(source: SubscriptionSource): ManagedSourceSpec {
+    const config = parseGithubSourceConfig(source);
+    return {
+      endpoint: GITHUB_ENDPOINT,
+      operation_id: "get:/repos/{owner}/{repo}/events",
+      args: {
+        owner: config.owner,
+        repo: config.repo,
+        per_page: config.perPage ?? 10,
+      },
+      mode: "poll",
+      poll_config: {
+        interval_secs: config.pollIntervalSecs ?? 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: {
+          type: "item_key",
+          item_key_pointer: "/id",
+          seen_window: 1024,
+        },
+      },
+      options: { auth: config.uxcAuth },
+    };
+  },
+  mapRawEvent(rawPayload: Record<string, unknown>, source: SubscriptionSource): MappedRemoteEvent | null {
+    const config = parseGithubSourceConfig(source);
+    const normalized = normalizeGithubRepoEvent(source, config, rawPayload);
+    if (!normalized) {
+      return null;
+    }
+    return {
+      sourceNativeId: normalized.sourceNativeId,
+      eventVariant: normalized.eventVariant,
+      metadata: normalized.metadata ?? {},
+      rawPayload: normalized.rawPayload ?? rawPayload,
+      occurredAt: normalized.occurredAt,
+      deliveryHandle: normalized.deliveryHandle,
+    };
+  },
+};
+
+const GITHUB_REPO_CI_PROFILE: RemoteSourceProfile = {
+  id: "builtin.github_repo_ci",
+  validateConfig(source: SubscriptionSource): void {
+    parseGithubCiSourceConfig(source);
+  },
+  buildManagedSourceSpec(source: SubscriptionSource): ManagedSourceSpec {
+    const config = parseGithubCiSourceConfig(source);
+    const args: Record<string, unknown> = {
+      owner: config.owner,
+      repo: config.repo,
+      per_page: config.perPage ?? DEFAULT_GITHUB_CI_PER_PAGE,
+    };
+    if (config.eventFilter) {
+      args.event = config.eventFilter;
+    }
+    if (config.branch) {
+      args.branch = config.branch;
+    }
+    if (config.statusFilter) {
+      args.status = config.statusFilter;
+    }
+    return {
+      endpoint: GITHUB_CI_ENDPOINT,
+      operation_id: "get:/repos/{owner}/{repo}/actions/runs",
+      args,
+      mode: "poll",
+      poll_config: {
+        interval_secs: config.pollIntervalSecs ?? DEFAULT_GITHUB_CI_POLL_INTERVAL_SECS,
+        extract_items_pointer: "/workflow_runs",
+        checkpoint_strategy: {
+          type: "item_key",
+          item_key_pointer: "/id",
+          seen_window: 1024,
+        },
+      },
+      options: { auth: config.uxcAuth },
+    };
+  },
+  mapRawEvent(rawPayload: Record<string, unknown>, source: SubscriptionSource): MappedRemoteEvent | null {
+    const config = parseGithubCiSourceConfig(source);
+    const normalized = normalizeGithubWorkflowRunEvent(source, config, rawPayload);
+    if (!normalized) {
+      return null;
+    }
+    return {
+      sourceNativeId: normalized.sourceNativeId,
+      eventVariant: normalized.eventVariant,
+      metadata: normalized.metadata ?? {},
+      rawPayload: normalized.rawPayload ?? rawPayload,
+      occurredAt: normalized.occurredAt,
+      deliveryHandle: normalized.deliveryHandle,
+    };
+  },
+};
+
+const FEISHU_BOT_PROFILE: RemoteSourceProfile = {
+  id: "builtin.feishu_bot",
+  validateConfig(source: SubscriptionSource): void {
+    parseFeishuSourceConfig(source);
+  },
+  buildManagedSourceSpec(source: SubscriptionSource): ManagedSourceSpec {
+    const config = parseFeishuSourceConfig(source);
+    return {
+      endpoint: config.endpoint ?? FEISHU_OPENAPI_ENDPOINT,
+      mode: "stream",
+      transport_hint: "feishu_long_connection",
+      options: { auth: config.uxcAuth },
+    };
+  },
+  mapRawEvent(rawPayload: Record<string, unknown>, source: SubscriptionSource): MappedRemoteEvent | null {
+    const config = parseFeishuSourceConfig(source);
+    const normalized = normalizeFeishuBotEvent(source, config, rawPayload);
+    if (!normalized) {
+      return null;
+    }
+    return {
+      sourceNativeId: normalized.sourceNativeId,
+      eventVariant: normalized.eventVariant,
+      metadata: normalized.metadata ?? {},
+      rawPayload: normalized.rawPayload ?? rawPayload,
+      occurredAt: normalized.occurredAt,
+      deliveryHandle: normalized.deliveryHandle,
+    };
+  },
+};
+
+export function profileConfigForSource(source: SubscriptionSource): Record<string, unknown> {
+  const config = asRecord(source.config);
+  if (source.sourceType === "remote_source") {
+    return asRecord(config.profileConfig);
+  }
+  return config;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -284,6 +284,32 @@ export class AgentInboxStore {
     this.persist();
   }
 
+  deleteSource(sourceId: string): SubscriptionSource | null {
+    const source = this.getSource(sourceId);
+    if (!source) {
+      return null;
+    }
+    this.inTransaction(() => {
+      const stream = this.getStreamBySourceId(sourceId);
+      if (stream) {
+        const consumers = this.getAll(
+          "select consumer_id from consumers where stream_id = ?",
+          [stream.streamId],
+        );
+        for (const row of consumers) {
+          const consumerId = String(row.consumer_id);
+          this.db.run("delete from consumer_commits where consumer_id = ?", [consumerId]);
+        }
+        this.db.run("delete from consumers where stream_id = ?", [stream.streamId]);
+        this.db.run("delete from stream_events where stream_id = ?", [stream.streamId]);
+        this.db.run("delete from streams where stream_id = ?", [stream.streamId]);
+      }
+      this.db.run("delete from sources where source_id = ?", [sourceId]);
+    });
+    this.persist();
+    return source;
+  }
+
   getAgent(agentId: string): Agent | null {
     const row = this.getOne("select * from agents where agent_id = ?", [agentId]);
     return row ? this.mapAgent(row) : null;

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -41,12 +41,24 @@ class FailingTerminalDispatcher extends RecordingTerminalDispatcher {
 }
 
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
-  async sourceEnsure(args: { namespace: string; sourceKey: string }): Promise<{ namespace: string; source_key: string; stream_id: string; status: string }> {
+  async sourceEnsure(args: { namespace: string; sourceKey: string; spec: unknown }): Promise<{
+    namespace: string;
+    source_key: string;
+    run_id: string;
+    stream_id: string;
+    status: string;
+    reused: boolean;
+    replaced_previous: boolean;
+  }> {
+    void args.spec;
     return {
       namespace: args.namespace,
       source_key: args.sourceKey,
+      run_id: `run:${args.sourceKey}`,
       stream_id: `stream:${args.sourceKey}`,
       status: "running",
+      reused: true,
+      replaced_previous: false,
     };
   }
 

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -8,6 +8,7 @@ import { AdapterRegistry } from "../src/adapters";
 import { SqliteEventBusBackend } from "../src/backend";
 import { Activation, ActivationTarget, AppendSourceEventInput, Subscription, TerminalActivationTarget } from "../src/model";
 import { ActivationDispatcher, AgentInboxService } from "../src/service";
+import { UxcRemoteSourceClient } from "../src/sources/remote";
 import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
 import { nowIso } from "../src/util";
@@ -39,6 +40,39 @@ class FailingTerminalDispatcher extends RecordingTerminalDispatcher {
   }
 }
 
+class FakeRemoteSourceClient implements UxcRemoteSourceClient {
+  async sourceEnsure(args: { namespace: string; sourceKey: string }): Promise<{ namespace: string; source_key: string; stream_id: string; status: string }> {
+    return {
+      namespace: args.namespace,
+      source_key: args.sourceKey,
+      stream_id: `stream:${args.sourceKey}`,
+      status: "running",
+    };
+  }
+
+  async sourceStop(_namespace: string, _sourceKey: string): Promise<void> {
+    return;
+  }
+
+  async sourceDelete(_namespace: string, _sourceKey: string): Promise<void> {
+    return;
+  }
+
+  async streamRead(_args: { streamId: string; afterOffset?: number; limit?: number }): Promise<{
+    stream_id: string;
+    events: Array<{ stream_id: string; offset: number; ingested_at_unix: number; raw_payload: unknown }>;
+    next_after_offset: number;
+    has_more: boolean;
+  }> {
+    return {
+      stream_id: "stream:noop",
+      events: [],
+      next_after_offset: 0,
+      has_more: false,
+    };
+  }
+}
+
 async function makeService(options?: {
   dispatcher?: ActivationDispatcher;
   terminalDispatcher?: TerminalDispatcher;
@@ -48,7 +82,10 @@ async function makeService(options?: {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-test-"));
   const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
   let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input));
+  const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input), {
+    homeDir: dir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
   service = new AgentInboxService(
     store,
     adapters,
@@ -343,17 +380,43 @@ test("local_event source can act as a programmable event bus source", async () =
   }
 });
 
-test("remote_source registration is rejected until the runtime exists", async () => {
+test("remote_source registration succeeds", async () => {
   const { store, service, dir } = await makeService();
   try {
-    await assert.rejects(
-      service.registerSource({
-        sourceType: "remote_source",
-        sourceKey: "reserved-demo",
-        config: {},
-      }),
-      /reserved and not yet supported/,
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "demo.mjs"),
+      `export default {
+  id: "demo.profile",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return { sourceNativeId: String(raw.id), eventVariant: "demo.event", metadata: {}, rawPayload: raw };
+  }
+};`,
+      "utf8",
     );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "remote-demo",
+      config: {
+        profilePath: "demo.mjs",
+        profileConfig: {},
+      },
+    });
+    assert.equal(source.sourceType, "remote_source");
   } finally {
     await service.stop();
     store.close();

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -436,6 +436,37 @@ test("remote_source registration succeeds", async () => {
   }
 });
 
+test("removeSource rejects when source still has subscriptions", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "remove-guard-demo",
+      config: {},
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "remove-guard-thread",
+      tmuxPaneId: "%901",
+    });
+    await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await assert.rejects(
+      service.removeSource(source.sourceId),
+      /source remove requires no active subscriptions/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("subscription remove deletes the subscription, its consumer, and transient runtime state", async () => {
   const dispatcher = new RecordingActivationDispatcher();
   const terminalDispatcher = new RecordingTerminalDispatcher();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -806,6 +806,14 @@ test("control plane accepts remote_source registration", async () => {
         socketPath,
         source: "flag",
       });
+      const invalid = await client.request<{ error: string }>("/sources", {
+        sourceType: "remote_source",
+        sourceKey: "invalid-remote",
+        config: {},
+      });
+      assert.equal(invalid.statusCode, 400);
+      assert.match(invalid.data.error, /remote_source requires config.profilePath/);
+
       const response = await client.request<{ error: string }>("/sources", {
         sourceType: "remote_source",
         sourceKey: "remote-demo",
@@ -815,6 +823,13 @@ test("control plane accepts remote_source registration", async () => {
         },
       });
       assert.equal(response.statusCode, 200);
+      const sourceId = (response.data as { sourceId?: string; source?: { sourceId?: string } }).sourceId
+        ?? (response.data as { source?: { sourceId?: string } }).source?.sourceId;
+      assert.equal(typeof sourceId, "string");
+
+      const removed = await client.request<{ removed: boolean }>(`/sources/${encodeURIComponent(sourceId!)}`, undefined, "DELETE");
+      assert.equal(removed.statusCode, 200);
+      assert.equal(removed.data.removed, true);
     } finally {
       await started.close();
     }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -18,12 +18,24 @@ import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
 
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
-  async sourceEnsure(args: { namespace: string; sourceKey: string }): Promise<{ namespace: string; source_key: string; stream_id: string; status: string }> {
+  async sourceEnsure(args: { namespace: string; sourceKey: string; spec: unknown }): Promise<{
+    namespace: string;
+    source_key: string;
+    run_id: string;
+    stream_id: string;
+    status: string;
+    reused: boolean;
+    replaced_previous: boolean;
+  }> {
+    void args.spec;
     return {
       namespace: args.namespace,
       source_key: args.sourceKey,
+      run_id: `run:${args.sourceKey}`,
       stream_id: `stream:${args.sourceKey}`,
       status: "running",
+      reused: true,
+      replaced_previous: false,
     };
   }
 

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -13,8 +13,42 @@ import { createServer } from "../src/http";
 import { DEFAULT_AGENTINBOX_PORT, resolveClientTransport, resolveDaemonPaths, resolveServeConfig } from "../src/paths";
 import { Activation, InboxItem, RegisterSourceInput, SubscriptionPollResult } from "../src/model";
 import { AgentInboxService } from "../src/service";
+import { UxcRemoteSourceClient } from "../src/sources/remote";
 import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
+
+class FakeRemoteSourceClient implements UxcRemoteSourceClient {
+  async sourceEnsure(args: { namespace: string; sourceKey: string }): Promise<{ namespace: string; source_key: string; stream_id: string; status: string }> {
+    return {
+      namespace: args.namespace,
+      source_key: args.sourceKey,
+      stream_id: `stream:${args.sourceKey}`,
+      status: "running",
+    };
+  }
+
+  async sourceStop(_namespace: string, _sourceKey: string): Promise<void> {
+    return;
+  }
+
+  async sourceDelete(_namespace: string, _sourceKey: string): Promise<void> {
+    return;
+  }
+
+  async streamRead(_args: { streamId: string; afterOffset?: number; limit?: number }): Promise<{
+    stream_id: string;
+    events: Array<{ stream_id: string; offset: number; ingested_at_unix: number; raw_payload: unknown }>;
+    next_after_offset: number;
+    has_more: boolean;
+  }> {
+    return {
+      stream_id: "stream:noop",
+      events: [],
+      next_after_offset: 0,
+      has_more: false,
+    };
+  }
+}
 
 test("cli version and help subcommands print text output", () => {
   const repoDir = path.resolve(__dirname, "..");
@@ -707,14 +741,42 @@ test("control plane accepts caller-supplied agent ids and rejects conflicting re
   }
 });
 
-test("control plane rejects reserved remote_source registration", async () => {
+test("control plane accepts remote_source registration", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-remote-src-"));
   const socketPath = path.join(homeDir, "agentinbox.sock");
   const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const profileDir = path.join(homeDir, "source-profiles");
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(profileDir, "demo.mjs"),
+    `export default {
+  id: "demo.control",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return { sourceNativeId: String(raw.id), eventVariant: "demo.event", metadata: {}, rawPayload: raw };
+  }
+};`,
+    "utf8",
+  );
 
   const store = await AgentInboxStore.open(dbPath);
   let service: AgentInboxService;
-  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
   service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
     stdout: "",
     stderr: "",
@@ -734,11 +796,13 @@ test("control plane rejects reserved remote_source registration", async () => {
       });
       const response = await client.request<{ error: string }>("/sources", {
         sourceType: "remote_source",
-        sourceKey: "reserved-demo",
-        config: {},
+        sourceKey: "remote-demo",
+        config: {
+          profilePath: "demo.mjs",
+          profileConfig: {},
+        },
       });
-      assert.equal(response.statusCode, 400);
-      assert.match(response.data.error, /reserved and not yet supported/);
+      assert.equal(response.statusCode, 200);
     } finally {
       await started.close();
     }

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -13,6 +13,7 @@ import { TerminalDispatcher } from "../src/terminal";
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   private readonly streams = new Map<string, Array<{ offset: number; raw_payload: unknown }>>();
   private readonly offsets = new Map<string, number>();
+  public readonly deletedSources: Array<{ namespace: string; sourceKey: string }> = [];
 
   push(streamId: string, payload: unknown): void {
     const currentOffset = this.offsets.get(streamId) ?? 0;
@@ -52,6 +53,7 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   }
 
   async sourceDelete(_namespace: string, _sourceKey: string): Promise<void> {
+    this.deletedSources.push({ namespace: _namespace, sourceKey: _sourceKey });
     return;
   }
 
@@ -244,6 +246,55 @@ test("github_repo source uses remote runtime builtin profile mapping", async () 
     assert.equal(items.length, 1);
     assert.equal(items[0]?.eventVariant, "IssueCommentEvent.created");
     assert.equal(items[0]?.deliveryHandle?.provider, "github");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("removeSource deletes managed source binding when no subscriptions remain", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "demo-remove.mjs"),
+      `export default {
+  id: "demo.remove",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return { sourceNativeId: "demo:" + raw.id, eventVariant: "demo.event", metadata: {}, rawPayload: raw };
+  }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "remove-key",
+      config: {
+        profilePath: "demo-remove.mjs",
+        profileConfig: {},
+      },
+    });
+    const removed = await service.removeSource(source.sourceId);
+    assert.equal(removed.removed, true);
+    assert.equal(store.getSource(source.sourceId), null);
+    assert.equal(fake.deletedSources.length, 1);
+    assert.equal(fake.deletedSources[0]?.sourceKey, "remote_source:remove-key");
   } finally {
     await service.stop();
     store.close();

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { AdapterRegistry } from "../src/adapters";
+import { AppendSourceEventInput } from "../src/model";
+import { AgentInboxService } from "../src/service";
+import { UxcRemoteSourceClient } from "../src/sources/remote";
+import { AgentInboxStore } from "../src/store";
+import { TerminalDispatcher } from "../src/terminal";
+
+class FakeRemoteSourceClient implements UxcRemoteSourceClient {
+  private readonly streams = new Map<string, Array<{ offset: number; raw_payload: unknown }>>();
+  private readonly offsets = new Map<string, number>();
+
+  push(streamId: string, payload: unknown): void {
+    const currentOffset = this.offsets.get(streamId) ?? 0;
+    this.offsets.set(streamId, currentOffset + 1);
+    const bucket = this.streams.get(streamId) ?? [];
+    bucket.push({
+      offset: currentOffset + 1,
+      raw_payload: payload,
+    });
+    this.streams.set(streamId, bucket);
+  }
+
+  async sourceEnsure(args: { namespace: string; sourceKey: string }): Promise<{ namespace: string; source_key: string; stream_id: string; status: string }> {
+    const streamId = `stream:${args.sourceKey}`;
+    return {
+      namespace: args.namespace,
+      source_key: args.sourceKey,
+      stream_id: streamId,
+      status: "running",
+    };
+  }
+
+  async sourceStop(_namespace: string, _sourceKey: string): Promise<void> {
+    return;
+  }
+
+  async sourceDelete(_namespace: string, _sourceKey: string): Promise<void> {
+    return;
+  }
+
+  async streamRead(args: { streamId: string; afterOffset?: number; limit?: number }): Promise<{
+    stream_id: string;
+    events: Array<{ stream_id: string; offset: number; ingested_at_unix: number; raw_payload: unknown }>;
+    next_after_offset: number;
+    has_more: boolean;
+  }> {
+    const afterOffset = args.afterOffset ?? 0;
+    const all = this.streams.get(args.streamId) ?? [];
+    const events = all.filter((event) => event.offset > afterOffset).slice(0, args.limit ?? 100);
+    const nextAfterOffset = events.length > 0 ? events[events.length - 1]!.offset : afterOffset;
+    return {
+      stream_id: args.streamId,
+      events: events.map((event) => ({
+        stream_id: args.streamId,
+        offset: event.offset,
+        ingested_at_unix: Date.now(),
+        raw_payload: event.raw_payload,
+      })),
+      next_after_offset: nextAfterOffset,
+      has_more: false,
+    };
+  }
+}
+
+async function makeService(fake: FakeRemoteSourceClient): Promise<{
+  dir: string;
+  store: AgentInboxStore;
+  service: AgentInboxService;
+}> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-remote-source-test-"));
+  const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input), {
+    homeDir: dir,
+    remoteSourceClient: fake,
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  return { dir, store, service };
+}
+
+test("remote_source with local profile ingests stream events", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "demo.mjs"),
+      `export default {
+  id: "demo.remote",
+  validateConfig(source) {
+    if (!source.config?.tenant) throw new Error("tenant required");
+  },
+  buildManagedSourceSpec(source) {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      args: { tenant: source.config.tenant },
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return {
+      sourceNativeId: "demo:" + raw.id,
+      eventVariant: "demo.created",
+      metadata: { tenant: raw.tenant },
+      rawPayload: raw
+    };
+  }
+};`,
+      "utf8",
+    );
+
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "demo-key",
+      config: {
+        profilePath: "demo.mjs",
+        profileConfig: { tenant: "team-a" },
+      },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "remote-source-thread",
+      tmuxPaneId: "%900",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+    fake.push("stream:remote_source:demo-key", { id: "evt-1", tenant: "team-a", text: "hello" });
+
+    const sourcePoll = await service.pollSource(source.sourceId);
+    const subscriptionPoll = await service.pollSubscription(subscription.subscriptionId);
+    const items = service.listInboxItems(agent.agent.agentId);
+
+    assert.equal(sourcePoll.appended, 1);
+    assert.equal(subscriptionPoll.inboxItemsCreated, 1);
+    assert.equal(items.length, 1);
+    assert.equal(items[0]?.sourceNativeId, "demo:evt-1");
+    assert.equal(items[0]?.metadata?.tenant, "team-a");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("remote_source profilePath must stay under source-profiles root", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    await assert.rejects(
+      service.registerSource({
+        sourceType: "remote_source",
+        sourceKey: "bad-key",
+        config: {
+          profilePath: "../outside.mjs",
+          profileConfig: {},
+        },
+      }),
+      /must stay under/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("github_repo source uses remote runtime builtin profile mapping", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const source = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox" },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "remote-github-thread",
+      tmuxPaneId: "%901",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      filter: { metadata: { mentions: ["alpha"] } },
+      startPolicy: "earliest",
+    });
+    fake.push("stream:github_repo:holon-run/agentinbox", {
+      id: "100",
+      type: "IssueCommentEvent",
+      created_at: "2026-04-04T11:00:00Z",
+      actor: { login: "jolestar" },
+      repo: { name: "holon-run/agentinbox" },
+      payload: {
+        action: "created",
+        issue: {
+          number: 12,
+          title: "hello",
+          body: "body",
+          labels: [{ name: "agent" }],
+          html_url: "https://github.com/holon-run/agentinbox/issues/12",
+        },
+        comment: { id: 9, body: "ping @alpha" },
+      },
+    });
+
+    const sourcePoll = await service.pollSource(source.sourceId);
+    const subscriptionPoll = await service.pollSubscription(subscription.subscriptionId);
+    const items = service.listInboxItems(agent.agent.agentId);
+
+    assert.equal(sourcePoll.appended, 1);
+    assert.equal(subscriptionPoll.inboxItemsCreated, 1);
+    assert.equal(items.length, 1);
+    assert.equal(items[0]?.eventVariant, "IssueCommentEvent.created");
+    assert.equal(items[0]?.deliveryHandle?.provider, "github");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -25,13 +25,25 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
     this.streams.set(streamId, bucket);
   }
 
-  async sourceEnsure(args: { namespace: string; sourceKey: string }): Promise<{ namespace: string; source_key: string; stream_id: string; status: string }> {
+  async sourceEnsure(args: { namespace: string; sourceKey: string; spec: unknown }): Promise<{
+    namespace: string;
+    source_key: string;
+    run_id: string;
+    stream_id: string;
+    status: string;
+    reused: boolean;
+    replaced_previous: boolean;
+  }> {
+    void args.spec;
     const streamId = `stream:${args.sourceKey}`;
     return {
       namespace: args.namespace,
       source_key: args.sourceKey,
+      run_id: `run:${args.sourceKey}`,
       stream_id: streamId,
       status: "running",
+      reused: true,
+      replaced_previous: false,
     };
   }
 

--- a/test/source_schema.test.ts
+++ b/test/source_schema.test.ts
@@ -12,9 +12,11 @@ test("getSourceSchema exposes github repo ci metadata and examples", () => {
   assert.ok(schema.configFields.some((field) => field.name === "branch"));
 });
 
-test("getSourceSchema exposes lightweight schemas for local and reserved sources", () => {
+test("getSourceSchema exposes local and remote source schemas", () => {
   const localEvent = getSourceSchema("local_event");
   assert.equal(localEvent.sourceType, "local_event");
   assert.ok(localEvent.metadataFields.some((field) => field.name === "channel"));
-  assert.equal(getSourceSchema("remote_source").sourceType, "remote_source");
+  const remote = getSourceSchema("remote_source");
+  assert.equal(remote.sourceType, "remote_source");
+  assert.ok(remote.configFields.some((field) => field.name === "profilePath" && field.required === true));
 });


### PR DESCRIPTION
## Summary
- converge `github_repo`, `github_repo_ci`, `feishu_bot`, and `remote_source` onto a single `RemoteSourceRuntime`
- add profile contract and registry for builtin + user-defined source profiles
- support user-defined local profile modules under `$AGENTINBOX_HOME/source-profiles` via `remote_source.config.profilePath`
- switch remote runtime to `uxc` managed source RPC flow (`source.ensure` + `stream.read`)

## Changes
- new: `src/sources/remote.ts` and `src/sources/remote_profiles.ts`
- `AdapterRegistry` now routes all external source types to the shared remote runtime
- `remote_source` registration is now enabled in service/control plane
- source schema/docs updated for `profilePath` + `profileConfig`
- tests updated and expanded (`test/remote_source.test.ts`)

## Notes
- this implementation intentionally does **not** include legacy checkpoint compatibility migration
- dependency switched to local `uxc-daemon-client` package path as requested

Closes #37
