### PR TITLE
feat(cli): default to current agent for session workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,18 @@ Register the current terminal session:
 ```bash
 agentinbox agent register
 agentinbox agent register --agent-id agent-alpha
+agentinbox agent current
 ```
 
 Create a local source and publish an event:
 
 ```bash
 agentinbox source add local_event local-demo
-agentinbox subscription add <agent_id> <source_id>
+agentinbox subscription add <source_id>
+agentinbox subscription add <source_id> --agent-id <agent_id>
 agentinbox source event <source_id> --native-id demo-1 --event local.demo
-agentinbox inbox read <agent_id>
+agentinbox inbox read
+agentinbox inbox read --agent-id <agent_id>
 ```
 
 Remove a task-specific subscription without deleting the whole agent:

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -56,6 +56,7 @@ Register the current terminal session as an agent:
 ```bash
 agentinbox agent register
 agentinbox agent register --agent-id agent-alpha
+agentinbox agent current
 ```
 
 This detects the current runtime and terminal context, assigns or restores an
@@ -74,13 +75,15 @@ The shortest end-to-end flow is a local source:
 
 ```bash
 agentinbox source add local_event local-demo
-agentinbox subscription add <agent_id> <source_id>
+agentinbox subscription add <source_id>
+agentinbox subscription add <source_id> --agent-id <agent_id>
 agentinbox source event <source_id> \
   --native-id demo-1 \
   --event local.demo \
   --metadata-json '{"channel":"engineering"}' \
   --payload-json '{"text":"hello from a local producer"}'
-agentinbox inbox read <agent_id>
+agentinbox inbox read
+agentinbox inbox read --agent-id <agent_id>
 ```
 
 ## GitHub Repo CI Example
@@ -88,7 +91,7 @@ agentinbox inbox read <agent_id>
 ```bash
 agentinbox source add github_repo_ci holon-run/agentinbox \
   --config-json '{"owner":"holon-run","repo":"agentinbox","uxcAuth":"github-default","pollIntervalSecs":30}'
-agentinbox subscription add <agent_id> <source_id> \
+agentinbox subscription add <source_id> --agent-id <agent_id> \
   --filter-json '{"metadata":{"status":"completed","conclusion":"failure","headBranch":"main"}}'
 agentinbox source poll <source_id>
 ```

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -49,7 +49,7 @@ agentinbox source event <source_id> --native-id <id> --event <variant>
 
 ```bash
 agentinbox subscription add <source_id> [--agent-id <agent_id>] [--filter-json ...]
-agentinbox subscription list [--agent-id <agent_id>]
+agentinbox subscription list [--agent-id <agent_id>] [--source-id <source_id>]
 agentinbox subscription show <subscription_id>
 agentinbox subscription remove <subscription_id>
 agentinbox subscription lag <subscription_id>

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -28,6 +28,7 @@ agentinbox daemon status
 ```bash
 agentinbox agent register [--agent-id ID] [--force-rebind]
 agentinbox agent list
+agentinbox agent current
 agentinbox agent show <agent_id>
 agentinbox agent remove <agent_id>
 ```
@@ -47,8 +48,8 @@ agentinbox source event <source_id> --native-id <id> --event <variant>
 ## Subscriptions
 
 ```bash
-agentinbox subscription add <agent_id> <source_id> [--filter-json ...]
-agentinbox subscription list
+agentinbox subscription add <source_id> [--agent-id <agent_id>] [--filter-json ...]
+agentinbox subscription list [--agent-id <agent_id>]
 agentinbox subscription show <subscription_id>
 agentinbox subscription remove <subscription_id>
 agentinbox subscription lag <subscription_id>
@@ -61,11 +62,11 @@ Inbox commands use `agentId`, not `inboxId`.
 
 ```bash
 agentinbox inbox show <agent_id>
-agentinbox inbox read <agent_id>
-agentinbox inbox watch <agent_id>
-agentinbox inbox ack <agent_id> --through <item_id>
-agentinbox inbox ack <agent_id> --item <item_id>
-agentinbox inbox ack <agent_id> --all
+agentinbox inbox read [--agent-id <agent_id>]
+agentinbox inbox watch [--agent-id <agent_id>]
+agentinbox inbox ack [--agent-id <agent_id>] --through <item_id>
+agentinbox inbox ack [--agent-id <agent_id>] --item <item_id>
+agentinbox inbox ack [--agent-id <agent_id>] --all
 agentinbox inbox compact <agent_id>
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -708,7 +708,9 @@ function tryDetectTerminalContext() {
 }
 
 function bindingKindForRecord(record: AgentWithTargets): BindingKind {
-  return record.activationTargets.some((target) => target.kind === "terminal") ? "session_bound" : "detached";
+  return record.agent.status === "active" && record.activationTargets.some((target) => target.kind === "terminal" && target.status === "active")
+    ? "session_bound"
+    : "detached";
 }
 
 function positionalArgs(args: string[], flagsWithValues: string[]): string[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { AdapterRegistry } from "./adapters";
 import { AgentInboxClient } from "./client";
 import { startControlServer } from "./control_server";
+import { AgentWithTargets, annotateAgents, BindingKind, resolveCurrentAgent } from "./current_agent";
 import { daemonStatus, ensureDaemonForClient, removePidFile, startDaemon, stopDaemon, writePidFile } from "./daemon";
 import { createServer } from "./http";
 import { resolveDaemonPaths, resolveServeConfig } from "./paths";
@@ -11,6 +12,19 @@ import { AgentInboxService } from "./service";
 import { AgentInboxStore } from "./store";
 import { detectTerminalContext } from "./terminal";
 import { jsonResponse, parseJsonArg } from "./util";
+
+interface CommandWarning {
+  code: "cross_session_agent";
+  message: string;
+  currentAgentId: string;
+  requestedAgentId: string;
+}
+
+interface AgentSelection {
+  agentId: string;
+  autoRegistered: boolean;
+  warnings: CommandWarning[];
+}
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -59,7 +73,7 @@ async function main(): Promise<void> {
     await printRemote(client, "/sources", {
       sourceType: type,
       sourceKey,
-      configRef: takeFlagValue(normalized, "--config-ref") ?? null,
+      configRef: takeFlagValue(normalized, "--config-ref") ?? undefined,
       config: parseJsonArg(takeFlagValue(normalized, "--config-json")),
     });
     return;
@@ -126,22 +140,27 @@ async function main(): Promise<void> {
   if (command === "agent" && normalized[1] === "register") {
     const detected = detectTerminalContext(process.env);
     await printRemote(client, "/agents", {
-      agentId: takeFlagValue(normalized, "--agent-id") ?? null,
+      agentId: takeFlagValue(normalized, "--agent-id") ?? undefined,
       forceRebind: normalized.includes("--force-rebind"),
       backend: detected.backend,
       runtimeKind: detected.runtimeKind,
-      runtimeSessionId: detected.runtimeSessionId ?? null,
-      tmuxPaneId: detected.tmuxPaneId ?? null,
-      tty: detected.tty ?? null,
-      termProgram: detected.termProgram ?? null,
-      itermSessionId: detected.itermSessionId ?? null,
-      notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? null,
+      runtimeSessionId: detected.runtimeSessionId ?? undefined,
+      tmuxPaneId: detected.tmuxPaneId ?? undefined,
+      tty: detected.tty ?? undefined,
+      termProgram: detected.termProgram ?? undefined,
+      itermSessionId: detected.itermSessionId ?? undefined,
+      notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? undefined,
     });
     return;
   }
 
   if (command === "agent" && normalized[1] === "list") {
-    await printRemote(client, "/agents", undefined, "GET");
+    await printAgentList(client);
+    return;
+  }
+
+  if (command === "agent" && normalized[1] === "current") {
+    await printCurrentAgent(client);
     return;
   }
 
@@ -173,7 +192,7 @@ async function main(): Promise<void> {
       kind: "webhook",
       url,
       activationMode: takeFlagValue(normalized, "--activation-mode") ?? undefined,
-      notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? null,
+      notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? undefined,
     });
     return;
   }
@@ -197,18 +216,25 @@ async function main(): Promise<void> {
   }
 
   if (command === "subscription" && normalized[1] === "add") {
-    const [agentId, sourceId] = normalized.slice(2, 4);
-    if (!agentId || !sourceId) {
-      throw new Error("usage: agentinbox subscription add <agentId> <sourceId> [--filter-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
+    const args = normalized.slice(2);
+    const positionals = positionalArgs(args, ["--agent-id", "--filter-json", "--start-policy", "--start-offset", "--start-time"]);
+    const sourceId = positionals[0];
+    if (!sourceId || positionals[1]) {
+      throw new Error("usage: agentinbox subscription add <sourceId> [--agent-id ID] [--filter-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
     }
-    await printRemote(client, "/subscriptions", {
-      agentId,
+    const selection = await selectAgentForCommand(client, {
+      explicitAgentId: takeFlagValue(normalized, "--agent-id"),
+      autoRegister: true,
+    });
+    const response = await requestRemote<Record<string, unknown>>(client, "/subscriptions", {
+      agentId: selection.agentId,
       sourceId,
       filter: parseJsonArg(takeFlagValue(normalized, "--filter-json")),
       startPolicy: takeFlagValue(normalized, "--start-policy") ?? undefined,
       startOffset: parseOptionalNumber(takeFlagValue(normalized, "--start-offset")),
       startTime: takeFlagValue(normalized, "--start-time") ?? undefined,
     });
+    console.log(jsonResponse(withCommandMetadata(response.data, selection)));
     return;
   }
 
@@ -286,24 +312,39 @@ async function main(): Promise<void> {
   }
 
   if (command === "inbox" && normalized[1] === "read") {
-    const agentId = normalized[2];
-    if (!agentId) {
-      throw new Error("usage: agentinbox inbox read <agentId>");
+    const args = normalized.slice(2);
+    if (positionalArgs(args, ["--agent-id", "--after-item"]).length > 0) {
+      throw new Error("usage: agentinbox inbox read [--agent-id ID] [--after-item ID] [--include-acked]");
     }
+    const selection = await selectAgentForCommand(client, {
+      explicitAgentId: takeFlagValue(normalized, "--agent-id"),
+      autoRegister: true,
+    });
     const query = buildQuery({
       after_item_id: takeFlagValue(normalized, "--after-item"),
       include_acked: hasFlag(normalized, "--include-acked") ? "true" : undefined,
     });
-    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox/items${query}`, undefined, "GET");
+    const response = await requestRemote<Record<string, unknown>>(client, `/agents/${encodeURIComponent(selection.agentId)}/inbox/items${query}`, undefined, "GET");
+    console.log(jsonResponse(withCommandMetadata(response.data, selection)));
     return;
   }
 
   if (command === "inbox" && normalized[1] === "watch") {
-    const agentId = normalized[2];
-    if (!agentId) {
-      throw new Error("usage: agentinbox inbox watch <agentId> [--after-item ID] [--include-acked] [--heartbeat-ms N]");
+    const args = normalized.slice(2);
+    if (positionalArgs(args, ["--agent-id", "--after-item", "--heartbeat-ms"]).length > 0) {
+      throw new Error("usage: agentinbox inbox watch [--agent-id ID] [--after-item ID] [--include-acked] [--heartbeat-ms N]");
     }
-    for await (const event of client.watchInbox(agentId, {
+    const selection = await selectAgentForCommand(client, {
+      explicitAgentId: takeFlagValue(normalized, "--agent-id"),
+      autoRegister: true,
+    });
+    const metadata = withCommandMetadata({
+      event: "watch_notice",
+    }, selection);
+    if (selection.autoRegistered || selection.warnings.length > 0) {
+      console.log(jsonResponse(metadata));
+    }
+    for await (const event of client.watchInbox(selection.agentId, {
       afterItemId: takeFlagValue(normalized, "--after-item"),
       includeAcked: hasFlag(normalized, "--include-acked"),
       heartbeatMs: parseOptionalNumber(takeFlagValue(normalized, "--heartbeat-ms")),
@@ -317,19 +358,24 @@ async function main(): Promise<void> {
   }
 
   if (command === "inbox" && normalized[1] === "ack") {
-    const agentId = normalized[2];
+    const args = normalized.slice(2);
     const itemId = takeFlagValue(normalized, "--item");
     const throughItemId = takeFlagValue(normalized, "--through");
     const ackAll = hasFlag(normalized, "--all");
     const modeCount = Number(Boolean(itemId)) + Number(Boolean(throughItemId)) + Number(ackAll);
-    if (!agentId || modeCount !== 1) {
-      throw new Error("usage: agentinbox inbox ack <agentId> (--through <itemId> | --item <itemId> | --all)");
+    if (positionalArgs(args, ["--agent-id", "--item", "--through"]).length > 0 || modeCount !== 1) {
+      throw new Error("usage: agentinbox inbox ack [--agent-id ID] (--through <itemId> | --item <itemId> | --all)");
     }
-    await printRemote(
+    const selection = await selectAgentForCommand(client, {
+      explicitAgentId: takeFlagValue(normalized, "--agent-id"),
+      autoRegister: true,
+    });
+    const response = await requestRemote<Record<string, unknown>>(
       client,
-      `/agents/${encodeURIComponent(agentId)}/inbox/ack`,
+      `/agents/${encodeURIComponent(selection.agentId)}/inbox/ack`,
       ackAll ? { all: true } : (throughItemId ? { throughItemId } : { itemIds: [itemId] }),
     );
+    console.log(jsonResponse(withCommandMetadata(response.data, selection)));
     return;
   }
 
@@ -359,8 +405,8 @@ async function main(): Promise<void> {
       provider,
       surface,
       targetRef,
-      threadRef: takeFlagValue(normalized, "--thread") ?? null,
-      replyMode: takeFlagValue(normalized, "--reply-mode") ?? null,
+      threadRef: takeFlagValue(normalized, "--thread") ?? undefined,
+      replyMode: takeFlagValue(normalized, "--reply-mode") ?? undefined,
       kind,
       payload: parseJsonArg(takeFlagValue(normalized, "--payload-json")),
     });
@@ -470,17 +516,113 @@ async function createClient(args: string[]): Promise<AgentInboxClient> {
   return new AgentInboxClient(transport);
 }
 
+async function printAgentList(client: AgentInboxClient): Promise<void> {
+  const records = await listAgentsWithTargets(client);
+  console.log(jsonResponse(annotateAgents(records, tryDetectTerminalContext())));
+}
+
+async function printCurrentAgent(client: AgentInboxClient): Promise<void> {
+  const context = getRequiredTerminalContext();
+  const records = await listAgentsWithTargets(client);
+  const current = resolveCurrentAgent(records, context);
+  if (!current) {
+    throw new Error("no current agent is registered for this terminal/runtime context; run `agentinbox agent register`");
+  }
+  console.log(jsonResponse(current));
+}
+
+async function selectAgentForCommand(
+  client: AgentInboxClient,
+  options: {
+    explicitAgentId?: string;
+    autoRegister: boolean;
+  },
+): Promise<AgentSelection> {
+  const records = await listAgentsWithTargets(client);
+  const context = tryDetectTerminalContext();
+
+  if (options.explicitAgentId) {
+    const current = context ? resolveCurrentAgent(records, context) : null;
+    const requested = records.find((entry) => entry.agent.agentId === options.explicitAgentId);
+    const warnings: CommandWarning[] = [];
+    if (current && requested && current.agentId !== requested.agent.agentId && current.bindingKind === "session_bound"
+      && bindingKindForRecord(requested) === "session_bound") {
+      warnings.push({
+        code: "cross_session_agent",
+        message: "Requested agent does not match the current terminal session.",
+        currentAgentId: current.agentId,
+        requestedAgentId: requested.agent.agentId,
+      });
+    }
+    return {
+      agentId: options.explicitAgentId,
+      autoRegistered: false,
+      warnings,
+    };
+  }
+
+  const contextForCurrent = getRequiredTerminalContext();
+  const current = resolveCurrentAgent(records, contextForCurrent);
+  if (current) {
+    return {
+      agentId: current.agentId,
+      autoRegistered: false,
+      warnings: [],
+    };
+  }
+
+  if (!options.autoRegister) {
+    throw new Error("no current agent is registered for this terminal/runtime context; run `agentinbox agent register`");
+  }
+
+  await requestRemote(client, "/agents", {
+    backend: contextForCurrent.backend,
+    runtimeKind: contextForCurrent.runtimeKind,
+    runtimeSessionId: contextForCurrent.runtimeSessionId ?? undefined,
+    tmuxPaneId: contextForCurrent.tmuxPaneId ?? undefined,
+    tty: contextForCurrent.tty ?? undefined,
+    termProgram: contextForCurrent.termProgram ?? undefined,
+    itermSessionId: contextForCurrent.itermSessionId ?? undefined,
+    notifyLeaseMs: undefined,
+  });
+  const refreshed = await listAgentsWithTargets(client);
+  const registered = resolveCurrentAgent(refreshed, contextForCurrent);
+  if (!registered) {
+    throw new Error("failed to resolve current agent after auto-register");
+  }
+  return {
+    agentId: registered.agentId,
+    autoRegistered: true,
+    warnings: [],
+  };
+}
+
+async function listAgentsWithTargets(client: AgentInboxClient): Promise<AgentWithTargets[]> {
+  const response = await requestRemote<{ agents: AgentWithTargets[] }>(client, "/agents?include_targets=true", undefined, "GET");
+  return response.data.agents;
+}
+
 async function printRemote(
   client: AgentInboxClient,
   endpoint: string,
   body?: unknown,
   method: "GET" | "POST" | "DELETE" = "POST",
 ): Promise<void> {
-  const response = await client.request(endpoint, body, method);
+  const response = await requestRemote(client, endpoint, body, method);
+  console.log(jsonResponse(response.data));
+}
+
+async function requestRemote<T = unknown>(
+  client: AgentInboxClient,
+  endpoint: string,
+  body?: unknown,
+  method: "GET" | "POST" | "DELETE" = "POST",
+): Promise<{ data: T }> {
+  const response = await client.request<T>(endpoint, body, method);
   if (response.statusCode < 200 || response.statusCode >= 300) {
     throw new Error(jsonResponse(response.data));
   }
-  console.log(jsonResponse(response.data));
+  return { data: response.data };
 }
 
 function takeFlagValue(args: string[], flag: string): string | undefined {
@@ -488,7 +630,11 @@ function takeFlagValue(args: string[], flag: string): string | undefined {
   if (index === -1) {
     return undefined;
   }
-  return args[index + 1];
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`flag ${flag} requires a value`);
+  }
+  return value;
 }
 
 function hasFlag(args: string[], flag: string): boolean {
@@ -529,6 +675,57 @@ function buildQuery(params: Record<string, string | undefined>): string {
   }
   const query = search.toString();
   return query ? `?${query}` : "";
+}
+
+function withCommandMetadata<T extends Record<string, unknown>>(data: T, selection: AgentSelection): T & {
+  agentId: string;
+  autoRegistered?: true;
+  warnings?: CommandWarning[];
+} {
+  return {
+    ...data,
+    agentId: selection.agentId,
+    ...(selection.autoRegistered ? { autoRegistered: true as const } : {}),
+    ...(selection.warnings.length > 0 ? { warnings: selection.warnings } : {}),
+  };
+}
+
+function getRequiredTerminalContext() {
+  try {
+    return detectTerminalContext(process.env);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`unable to resolve current agent: ${message}`);
+  }
+}
+
+function tryDetectTerminalContext() {
+  try {
+    return detectTerminalContext(process.env);
+  } catch {
+    return null;
+  }
+}
+
+function bindingKindForRecord(record: AgentWithTargets): BindingKind {
+  return record.activationTargets.some((target) => target.kind === "terminal") ? "session_bound" : "detached";
+}
+
+function positionalArgs(args: string[], flagsWithValues: string[]): string[] {
+  const flags = new Set(flagsWithValues);
+  const positionals: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (flags.has(token)) {
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("--")) {
+      continue;
+    }
+    positionals.push(token);
+  }
+  return positionals;
 }
 
 function printHelp(path: string[] = []): void {
@@ -583,6 +780,7 @@ Usage:
 Usage:
   agentinbox agent register [--agent-id ID] [--force-rebind] [--notify-lease-ms N]
   agentinbox agent list
+  agentinbox agent current
   agentinbox agent show <agentId>
   agentinbox agent remove <agentId>
   agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N]
@@ -592,7 +790,7 @@ Usage:
     subscription: `agentinbox subscription
 
 Usage:
-  agentinbox subscription add <agentId> <sourceId> [--filter-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
+  agentinbox subscription add <sourceId> [--agent-id ID] [--filter-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
   agentinbox subscription list [--source-id ID] [--agent-id ID]
   agentinbox subscription show <subscriptionId>
   agentinbox subscription remove <subscriptionId>
@@ -605,9 +803,9 @@ Usage:
 Usage:
   agentinbox inbox list
   agentinbox inbox show <agentId>
-  agentinbox inbox read <agentId> [--after-item ID] [--include-acked]
-  agentinbox inbox watch <agentId> [--after-item ID] [--include-acked] [--heartbeat-ms N]
-  agentinbox inbox ack <agentId> (--through <itemId> | --item <itemId> | --all)
+  agentinbox inbox read [--agent-id ID] [--after-item ID] [--include-acked]
+  agentinbox inbox watch [--agent-id ID] [--after-item ID] [--include-acked] [--heartbeat-ms N]
+  agentinbox inbox ack [--agent-id ID] (--through <itemId> | --item <itemId> | --all)
   agentinbox inbox compact <agentId>
 `,
     deliver: `agentinbox deliver

--- a/src/current_agent.ts
+++ b/src/current_agent.ts
@@ -6,6 +6,7 @@ export type BindingKind = "session_bound" | "detached";
 export interface TerminalTargetSummary {
   targetId: string;
   kind: "terminal";
+  status: "active" | "offline";
   backend: TerminalBackend;
   tmuxPaneId?: string | null;
   tty?: string | null;
@@ -18,6 +19,7 @@ export interface TerminalTargetSummary {
 export interface WebhookTargetSummary {
   targetId: string;
   kind: "webhook";
+  status: "active" | "offline";
 }
 
 export type ActivationTargetSummary = TerminalTargetSummary | WebhookTargetSummary;
@@ -48,6 +50,7 @@ export function summarizeActivationTarget(target: ActivationTarget): ActivationT
     return {
       targetId: target.targetId,
       kind: "terminal",
+      status: target.status,
       backend: target.backend,
       tmuxPaneId: target.tmuxPaneId ?? null,
       tty: target.tty ?? null,
@@ -60,6 +63,7 @@ export function summarizeActivationTarget(target: ActivationTarget): ActivationT
   return {
     targetId: target.targetId,
     kind: "webhook",
+    status: target.status,
   };
 }
 
@@ -109,7 +113,7 @@ function resolveAgentRecord(
 ): AgentWithTargets | null {
   if (context.tmuxPaneId) {
     const match = agents.find((agent) =>
-      terminalTargets(agent).some((target) => target.backend === "tmux" && target.tmuxPaneId === context.tmuxPaneId),
+      activeTerminalTargets(agent).some((target) => target.backend === "tmux" && target.tmuxPaneId === context.tmuxPaneId),
     );
     if (match) {
       return match;
@@ -118,7 +122,7 @@ function resolveAgentRecord(
 
   if (context.itermSessionId) {
     const match = agents.find((agent) =>
-      terminalTargets(agent).some((target) => target.backend === "iterm2" && target.itermSessionId === context.itermSessionId),
+      activeTerminalTargets(agent).some((target) => target.backend === "iterm2" && target.itermSessionId === context.itermSessionId),
     );
     if (match) {
       return match;
@@ -127,7 +131,7 @@ function resolveAgentRecord(
 
   if (context.tty) {
     const match = agents.find((agent) =>
-      terminalTargets(agent).some((target) => target.tty === context.tty),
+      activeTerminalTargets(agent).some((target) => target.tty === context.tty),
     );
     if (match) {
       return match;
@@ -145,15 +149,22 @@ function resolveAgentRecord(
 }
 
 function bindingKindForAgent(agent: AgentWithTargets): BindingKind {
-  return terminalTargets(agent).length > 0 ? "session_bound" : "detached";
+  return activeTerminalTargets(agent).length > 0 ? "session_bound" : "detached";
 }
 
 function terminalTargets(agent: AgentWithTargets): TerminalTargetSummary[] {
   return agent.activationTargets.filter((target): target is TerminalTargetSummary => target.kind === "terminal");
 }
 
+function activeTerminalTargets(agent: AgentWithTargets): TerminalTargetSummary[] {
+  if (agent.agent.status !== "active") {
+    return [];
+  }
+  return terminalTargets(agent).filter((target) => target.status === "active");
+}
+
 function terminalIdentityForAgent(agent: AgentWithTargets): string | null {
-  const target = terminalTargets(agent)[0];
+  const target = activeTerminalTargets(agent)[0];
   if (!target) {
     return null;
   }
@@ -170,7 +181,7 @@ function terminalIdentityForAgent(agent: AgentWithTargets): string | null {
 }
 
 function matchesCurrentTerminal(agent: AgentWithTargets, context: DetectedTerminalContext): boolean {
-  return terminalTargets(agent).some((target) =>
+  return activeTerminalTargets(agent).some((target) =>
     (context.tmuxPaneId != null && target.tmuxPaneId === context.tmuxPaneId)
     || (context.itermSessionId != null && target.itermSessionId === context.itermSessionId)
     || (context.tty != null && target.tty === context.tty),
@@ -178,10 +189,13 @@ function matchesCurrentTerminal(agent: AgentWithTargets, context: DetectedTermin
 }
 
 function matchesCurrentRuntime(agent: AgentWithTargets, context: DetectedTerminalContext): boolean {
+  if (agent.agent.status !== "active") {
+    return false;
+  }
   if (!context.runtimeSessionId) {
     return false;
   }
-  return terminalTargets(agent).some((target) =>
+  return activeTerminalTargets(agent).some((target) =>
     target.runtimeKind === context.runtimeKind && target.runtimeSessionId === context.runtimeSessionId,
   ) || (
     agent.agent.runtimeKind === context.runtimeKind

--- a/src/current_agent.ts
+++ b/src/current_agent.ts
@@ -15,17 +15,12 @@ export interface TerminalTargetSummary {
   runtimeSessionId?: string | null;
 }
 
-export interface ActivationTargetSummary {
+export interface WebhookTargetSummary {
   targetId: string;
-  kind: ActivationTarget["kind"];
-  backend?: TerminalBackend | null;
-  tmuxPaneId?: string | null;
-  tty?: string | null;
-  termProgram?: string | null;
-  itermSessionId?: string | null;
-  runtimeKind?: RuntimeKind | null;
-  runtimeSessionId?: string | null;
+  kind: "webhook";
 }
+
+export type ActivationTargetSummary = TerminalTargetSummary | WebhookTargetSummary;
 
 export interface AgentWithTargets {
   agent: Agent;

--- a/src/current_agent.ts
+++ b/src/current_agent.ts
@@ -1,0 +1,195 @@
+import { ActivationTarget, Agent, RuntimeKind, TerminalBackend } from "./model";
+import { DetectedTerminalContext } from "./terminal";
+
+export type BindingKind = "session_bound" | "detached";
+
+export interface TerminalTargetSummary {
+  targetId: string;
+  kind: "terminal";
+  backend: TerminalBackend;
+  tmuxPaneId?: string | null;
+  tty?: string | null;
+  termProgram?: string | null;
+  itermSessionId?: string | null;
+  runtimeKind?: RuntimeKind | null;
+  runtimeSessionId?: string | null;
+}
+
+export interface ActivationTargetSummary {
+  targetId: string;
+  kind: ActivationTarget["kind"];
+  backend?: TerminalBackend | null;
+  tmuxPaneId?: string | null;
+  tty?: string | null;
+  termProgram?: string | null;
+  itermSessionId?: string | null;
+  runtimeKind?: RuntimeKind | null;
+  runtimeSessionId?: string | null;
+}
+
+export interface AgentWithTargets {
+  agent: Agent;
+  activationTargets: ActivationTargetSummary[];
+}
+
+export interface CurrentAgentMatch {
+  agentId: string;
+  bindingKind: BindingKind;
+  matchesCurrentTerminal: boolean;
+  matchesCurrentRuntime: boolean;
+  terminalIdentity: string | null;
+}
+
+export interface AnnotatedAgent extends Agent {
+  bindingKind: BindingKind;
+  matchesCurrentTerminal: boolean;
+  matchesCurrentRuntime: boolean;
+  terminalIdentity: string | null;
+  isCurrent: boolean;
+}
+
+export function summarizeActivationTarget(target: ActivationTarget): ActivationTargetSummary {
+  if (target.kind === "terminal") {
+    return {
+      targetId: target.targetId,
+      kind: "terminal",
+      backend: target.backend,
+      tmuxPaneId: target.tmuxPaneId ?? null,
+      tty: target.tty ?? null,
+      termProgram: target.termProgram ?? null,
+      itermSessionId: target.itermSessionId ?? null,
+      runtimeKind: target.runtimeKind ?? null,
+      runtimeSessionId: target.runtimeSessionId ?? null,
+    };
+  }
+  return {
+    targetId: target.targetId,
+    kind: "webhook",
+  };
+}
+
+export function resolveCurrentAgent(
+  agents: AgentWithTargets[],
+  context: DetectedTerminalContext | null,
+): CurrentAgentMatch | null {
+  if (!context) {
+    return null;
+  }
+
+  const agent = resolveAgentRecord(agents, context);
+  if (!agent) {
+    return null;
+  }
+
+  return {
+    agentId: agent.agent.agentId,
+    bindingKind: bindingKindForAgent(agent),
+    matchesCurrentTerminal: matchesCurrentTerminal(agent, context),
+    matchesCurrentRuntime: matchesCurrentRuntime(agent, context),
+    terminalIdentity: terminalIdentityForAgent(agent),
+  };
+}
+
+export function annotateAgents(
+  agents: AgentWithTargets[],
+  context: DetectedTerminalContext | null,
+): { currentAgentId: string | null; agents: AnnotatedAgent[] } {
+  const current = resolveCurrentAgent(agents, context);
+  return {
+    currentAgentId: current?.agentId ?? null,
+    agents: agents.map((entry) => ({
+      ...entry.agent,
+      bindingKind: bindingKindForAgent(entry),
+      matchesCurrentTerminal: context ? matchesCurrentTerminal(entry, context) : false,
+      matchesCurrentRuntime: context ? matchesCurrentRuntime(entry, context) : false,
+      terminalIdentity: terminalIdentityForAgent(entry),
+      isCurrent: current?.agentId === entry.agent.agentId,
+    })),
+  };
+}
+
+function resolveAgentRecord(
+  agents: AgentWithTargets[],
+  context: DetectedTerminalContext,
+): AgentWithTargets | null {
+  if (context.tmuxPaneId) {
+    const match = agents.find((agent) =>
+      terminalTargets(agent).some((target) => target.backend === "tmux" && target.tmuxPaneId === context.tmuxPaneId),
+    );
+    if (match) {
+      return match;
+    }
+  }
+
+  if (context.itermSessionId) {
+    const match = agents.find((agent) =>
+      terminalTargets(agent).some((target) => target.backend === "iterm2" && target.itermSessionId === context.itermSessionId),
+    );
+    if (match) {
+      return match;
+    }
+  }
+
+  if (context.tty) {
+    const match = agents.find((agent) =>
+      terminalTargets(agent).some((target) => target.tty === context.tty),
+    );
+    if (match) {
+      return match;
+    }
+  }
+
+  if (context.runtimeSessionId) {
+    const match = agents.find((agent) => matchesCurrentRuntime(agent, context));
+    if (match) {
+      return match;
+    }
+  }
+
+  return null;
+}
+
+function bindingKindForAgent(agent: AgentWithTargets): BindingKind {
+  return terminalTargets(agent).length > 0 ? "session_bound" : "detached";
+}
+
+function terminalTargets(agent: AgentWithTargets): TerminalTargetSummary[] {
+  return agent.activationTargets.filter((target): target is TerminalTargetSummary => target.kind === "terminal");
+}
+
+function terminalIdentityForAgent(agent: AgentWithTargets): string | null {
+  const target = terminalTargets(agent)[0];
+  if (!target) {
+    return null;
+  }
+  if (target.tmuxPaneId) {
+    return `tmux:${target.tmuxPaneId}`;
+  }
+  if (target.itermSessionId) {
+    return `iterm2:${target.itermSessionId}`;
+  }
+  if (target.tty) {
+    return `tty:${target.tty}`;
+  }
+  return null;
+}
+
+function matchesCurrentTerminal(agent: AgentWithTargets, context: DetectedTerminalContext): boolean {
+  return terminalTargets(agent).some((target) =>
+    (context.tmuxPaneId != null && target.tmuxPaneId === context.tmuxPaneId)
+    || (context.itermSessionId != null && target.itermSessionId === context.itermSessionId)
+    || (context.tty != null && target.tty === context.tty),
+  );
+}
+
+function matchesCurrentRuntime(agent: AgentWithTargets, context: DetectedTerminalContext): boolean {
+  if (!context.runtimeSessionId) {
+    return false;
+  }
+  return terminalTargets(agent).some((target) =>
+    target.runtimeKind === context.runtimeKind && target.runtimeSessionId === context.runtimeSessionId,
+  ) || (
+    agent.agent.runtimeKind === context.runtimeKind
+    && agent.agent.runtimeSessionId === context.runtimeSessionId
+  );
+}

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 import Fastify from "fastify";
 import swagger from "@fastify/swagger";
+import { summarizeActivationTarget } from "./current_agent";
 import { AgentInboxService } from "./service";
 import { ActivationMode, DeliveryHandle, WatchInboxOptions } from "./model";
 import { jsonResponse } from "./util";
@@ -267,6 +268,13 @@ function buildFastifyServer(service: AgentInboxService) {
   app.get("/agents", {
     schema: {
       tags: ["agents"],
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          include_targets: { type: "string", enum: ["true", "false"] },
+        },
+      },
       response: {
         200: {
           type: "object",
@@ -277,7 +285,18 @@ function buildFastifyServer(service: AgentInboxService) {
         },
       },
     },
-  }, async () => ({ agents: service.listAgents() }));
+  }, async (request) => {
+    const query = request.query as { include_targets?: "true" | "false" };
+    if (query.include_targets === "true") {
+      return {
+        agents: service.listAgents().map((agent) => ({
+          agent,
+          activationTargets: service.listActivationTargets(agent.agentId).map(summarizeActivationTarget),
+        })),
+      };
+    }
+    return { agents: service.listAgents() };
+  });
 
   app.post("/agents", {
     schema: {

--- a/src/http.ts
+++ b/src/http.ts
@@ -287,15 +287,26 @@ function buildFastifyServer(service: AgentInboxService) {
     },
   }, async (request) => {
     const query = request.query as { include_targets?: "true" | "false" };
+    const agents = service.listAgents();
     if (query.include_targets === "true") {
+      const activationTargetsByAgentId = service.listActivationTargets().reduce((grouped, target) => {
+        const targets = grouped.get(target.agentId);
+        const summarized = summarizeActivationTarget(target);
+        if (targets) {
+          targets.push(summarized);
+        } else {
+          grouped.set(target.agentId, [summarized]);
+        }
+        return grouped;
+      }, new Map<string, ReturnType<typeof summarizeActivationTarget>[]>());
       return {
-        agents: service.listAgents().map((agent) => ({
+        agents: agents.map((agent) => ({
           agent,
-          activationTargets: service.listActivationTargets(agent.agentId).map(summarizeActivationTarget),
+          activationTargets: activationTargetsByAgentId.get(agent.agentId) ?? [],
         })),
       };
     }
-    return { agents: service.listAgents() };
+    return { agents };
   });
 
   app.post("/agents", {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -62,6 +62,16 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   }
 }
 
+function runCli(args: string[], env: NodeJS.ProcessEnv, timeout = 25_000) {
+  const repoDir = path.resolve(__dirname, "..");
+  return spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", ...args], {
+    cwd: repoDir,
+    env,
+    encoding: "utf8",
+    timeout,
+  });
+}
+
 test("cli version and help subcommands print text output", () => {
   const repoDir = path.resolve(__dirname, "..");
   const version = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "--version"], {
@@ -314,6 +324,142 @@ test("control plane validates sources/events occurredAt and deliveries/send requ
     await adapters.stop();
     await service.stop();
     store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane GET /agents can include activation target summaries", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-agents-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    await adapters.start();
+    await service.start();
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const agentResponse = await client.request<{
+        agent: { agentId: string };
+      }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-list",
+        tmuxPaneId: "%777",
+      });
+      assert.equal(agentResponse.statusCode, 200);
+      const agentId = agentResponse.data.agent.agentId;
+
+      const targetResponse = await client.request<{ targetId: string }>(`/agents/${encodeURIComponent(agentId)}/targets`, {
+        kind: "webhook",
+        url: "http://127.0.0.1:9999/webhook",
+      });
+      assert.equal(targetResponse.statusCode, 200);
+
+      const agentsResponse = await client.request<{
+        agents: Array<{
+          agent: { agentId: string };
+          activationTargets: Array<Record<string, unknown>>;
+        }>;
+      }>("/agents?include_targets=true", undefined, "GET");
+      assert.equal(agentsResponse.statusCode, 200);
+      const listed = agentsResponse.data.agents[0];
+      assert.ok(listed);
+      assert.equal(listed.agent.agentId, agentId);
+      assert.equal(Array.isArray(listed.activationTargets), true);
+      assert.deepEqual(listed.activationTargets[0], {
+        targetId: listed.activationTargets[0]?.targetId,
+        kind: "terminal",
+        backend: "tmux",
+        tmuxPaneId: "%777",
+        tty: null,
+        termProgram: null,
+        itermSessionId: null,
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-list",
+      });
+      assert.equal(listed.activationTargets[1]?.kind, "webhook");
+      assert.equal("url" in (listed.activationTargets[1] ?? {}), false);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli resolves current agent, auto-registers session workflows, and warns on cross-session targets", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-current-"));
+  const envBase = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+  };
+  const envCurrent = {
+    ...envBase,
+    TMUX_PANE: "%901",
+    CODEX_THREAD_ID: "thread-current",
+  };
+  const envOther = {
+    ...envBase,
+    TMUX_PANE: "%902",
+    CODEX_THREAD_ID: "thread-other",
+  };
+
+  try {
+    const sourceAdd = runCli(["source", "add", "local_event", "cli-current-demo"], envBase);
+    assert.equal(sourceAdd.status, 0, sourceAdd.stderr);
+    const source = JSON.parse(sourceAdd.stdout) as { sourceId: string };
+
+    const subscribeCurrent = runCli(["subscription", "add", source.sourceId], envCurrent);
+    assert.equal(subscribeCurrent.status, 0, subscribeCurrent.stderr);
+    const subscribed = JSON.parse(subscribeCurrent.stdout) as {
+      agentId: string;
+      autoRegistered?: boolean;
+    };
+    assert.equal(subscribed.autoRegistered, true);
+
+    const current = runCli(["agent", "current"], envCurrent);
+    assert.equal(current.status, 0, current.stderr);
+    const currentAgent = JSON.parse(current.stdout) as { agentId: string };
+    assert.equal(currentAgent.agentId, subscribed.agentId);
+
+    const otherRegister = runCli(["agent", "register", "--agent-id", "agent-other"], envOther);
+    assert.equal(otherRegister.status, 0, otherRegister.stderr);
+
+    const crossSessionRead = runCli(["inbox", "read", "--agent-id", "agent-other"], envCurrent);
+    assert.equal(crossSessionRead.status, 0, crossSessionRead.stderr);
+    const readResult = JSON.parse(crossSessionRead.stdout) as {
+      agentId: string;
+      warnings?: Array<{ code: string; currentAgentId: string; requestedAgentId: string }>;
+    };
+    assert.equal(readResult.agentId, "agent-other");
+    assert.deepEqual(readResult.warnings, [{
+      code: "cross_session_agent",
+      message: "Requested agent does not match the current terminal session.",
+      currentAgentId: subscribed.agentId,
+      requestedAgentId: "agent-other",
+    }]);
+
+    const oldSyntax = runCli(["subscription", "add", "agent-other", source.sourceId], envCurrent);
+    assert.notEqual(oldSyntax.status, 0);
+    assert.match(oldSyntax.stderr, /usage: agentinbox subscription add <sourceId> \[--agent-id ID]/);
+  } finally {
+    void runCli(["daemon", "stop"], envBase);
     fs.rmSync(homeDir, { recursive: true, force: true });
   }
 });

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -379,6 +379,7 @@ test("control plane GET /agents can include activation target summaries", async 
       assert.deepEqual(listed.activationTargets[0], {
         targetId: listed.activationTargets[0]?.targetId,
         kind: "terminal",
+        status: "active",
         backend: "tmux",
         tmuxPaneId: "%777",
         tty: null,
@@ -388,6 +389,7 @@ test("control plane GET /agents can include activation target summaries", async 
         runtimeSessionId: "thread-http-list",
       });
       assert.equal(listed.activationTargets[1]?.kind, "webhook");
+      assert.equal(listed.activationTargets[1]?.status, "active");
       assert.equal("url" in (listed.activationTargets[1] ?? {}), false);
     } finally {
       await started.close();

--- a/test/current_agent.test.ts
+++ b/test/current_agent.test.ts
@@ -4,6 +4,7 @@ import { annotateAgents, AgentWithTargets, resolveCurrentAgent } from "../src/cu
 
 function makeAgentRecord(input: {
   agentId: string;
+  status?: "active" | "offline";
   runtimeKind?: "codex" | "claude_code" | "unknown";
   runtimeSessionId?: string | null;
   activationTargets?: AgentWithTargets["activationTargets"];
@@ -11,7 +12,7 @@ function makeAgentRecord(input: {
   return {
     agent: {
       agentId: input.agentId,
-      status: "active",
+      status: input.status ?? "active",
       offlineSince: null,
       runtimeKind: input.runtimeKind ?? "codex",
       runtimeSessionId: input.runtimeSessionId ?? null,
@@ -31,6 +32,7 @@ test("resolveCurrentAgent prefers terminal identity over runtime identity", () =
       activationTargets: [{
         targetId: "tgt-runtime",
         kind: "terminal",
+        status: "active",
         backend: "tmux",
         tmuxPaneId: "%101",
         runtimeKind: "codex",
@@ -43,6 +45,7 @@ test("resolveCurrentAgent prefers terminal identity over runtime identity", () =
       activationTargets: [{
         targetId: "tgt-terminal",
         kind: "terminal",
+        status: "active",
         backend: "tmux",
         tmuxPaneId: "%202",
         runtimeKind: "codex",
@@ -78,6 +81,7 @@ test("annotateAgents marks current and detached agents correctly", () => {
       activationTargets: [{
         targetId: "tgt-current",
         kind: "terminal",
+        status: "active",
         backend: "iterm2",
         itermSessionId: "SESSION-1",
         tty: "/dev/ttys009",
@@ -107,4 +111,46 @@ test("annotateAgents marks current and detached agents correctly", () => {
   assert.equal(annotated.agents[1]?.isCurrent, false);
   assert.equal(annotated.agents[1]?.bindingKind, "detached");
   assert.equal(annotated.agents[1]?.terminalIdentity, null);
+});
+
+test("resolveCurrentAgent ignores offline agents and offline terminal targets", () => {
+  const agents: AgentWithTargets[] = [
+    makeAgentRecord({
+      agentId: "agent-offline-target",
+      activationTargets: [{
+        targetId: "tgt-offline",
+        kind: "terminal",
+        status: "offline",
+        backend: "tmux",
+        tmuxPaneId: "%501",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-offline-target",
+      }],
+    }),
+    makeAgentRecord({
+      agentId: "agent-offline-agent",
+      status: "offline",
+      activationTargets: [{
+        targetId: "tgt-active",
+        kind: "terminal",
+        status: "active",
+        backend: "tmux",
+        tmuxPaneId: "%501",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-offline-agent",
+      }],
+    }),
+  ];
+
+  const current = resolveCurrentAgent(agents, {
+    backend: "tmux",
+    tmuxPaneId: "%501",
+    tty: "/dev/ttys501",
+    termProgram: "tmux",
+    itermSessionId: null,
+    runtimeKind: "codex",
+    runtimeSessionId: "thread-offline-target",
+  });
+
+  assert.equal(current, null);
 });

--- a/test/current_agent.test.ts
+++ b/test/current_agent.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { annotateAgents, AgentWithTargets, resolveCurrentAgent } from "../src/current_agent";
+
+function makeAgentRecord(input: {
+  agentId: string;
+  runtimeKind?: "codex" | "claude_code" | "unknown";
+  runtimeSessionId?: string | null;
+  activationTargets?: AgentWithTargets["activationTargets"];
+}): AgentWithTargets {
+  return {
+    agent: {
+      agentId: input.agentId,
+      status: "active",
+      offlineSince: null,
+      runtimeKind: input.runtimeKind ?? "codex",
+      runtimeSessionId: input.runtimeSessionId ?? null,
+      createdAt: "2026-04-10T00:00:00Z",
+      updatedAt: "2026-04-10T00:00:00Z",
+      lastSeenAt: "2026-04-10T00:00:00Z",
+    },
+    activationTargets: input.activationTargets ?? [],
+  };
+}
+
+test("resolveCurrentAgent prefers terminal identity over runtime identity", () => {
+  const agents: AgentWithTargets[] = [
+    makeAgentRecord({
+      agentId: "agent-runtime",
+      runtimeSessionId: "thread-1",
+      activationTargets: [{
+        targetId: "tgt-runtime",
+        kind: "terminal",
+        backend: "tmux",
+        tmuxPaneId: "%101",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-1",
+      }],
+    }),
+    makeAgentRecord({
+      agentId: "agent-terminal",
+      runtimeSessionId: "thread-2",
+      activationTargets: [{
+        targetId: "tgt-terminal",
+        kind: "terminal",
+        backend: "tmux",
+        tmuxPaneId: "%202",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-2",
+      }],
+    }),
+  ];
+
+  const current = resolveCurrentAgent(agents, {
+    backend: "tmux",
+    tmuxPaneId: "%202",
+    tty: "/dev/ttys001",
+    termProgram: "tmux",
+    itermSessionId: null,
+    runtimeKind: "codex",
+    runtimeSessionId: "thread-1",
+  });
+
+  assert.deepEqual(current, {
+    agentId: "agent-terminal",
+    bindingKind: "session_bound",
+    matchesCurrentTerminal: true,
+    matchesCurrentRuntime: false,
+    terminalIdentity: "tmux:%202",
+  });
+});
+
+test("annotateAgents marks current and detached agents correctly", () => {
+  const agents: AgentWithTargets[] = [
+    makeAgentRecord({
+      agentId: "agent-current",
+      runtimeSessionId: "thread-current",
+      activationTargets: [{
+        targetId: "tgt-current",
+        kind: "terminal",
+        backend: "iterm2",
+        itermSessionId: "SESSION-1",
+        tty: "/dev/ttys009",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-current",
+      }],
+    }),
+    makeAgentRecord({
+      agentId: "agent-detached",
+      runtimeSessionId: null,
+    }),
+  ];
+
+  const annotated = annotateAgents(agents, {
+    backend: "iterm2",
+    tty: "/dev/ttys009",
+    termProgram: "iTerm.app",
+    itermSessionId: "SESSION-1",
+    runtimeKind: "codex",
+    runtimeSessionId: "thread-current",
+  });
+
+  assert.equal(annotated.currentAgentId, "agent-current");
+  assert.equal(annotated.agents[0]?.isCurrent, true);
+  assert.equal(annotated.agents[0]?.terminalIdentity, "iterm2:SESSION-1");
+  assert.equal(annotated.agents[0]?.bindingKind, "session_bound");
+  assert.equal(annotated.agents[1]?.isCurrent, false);
+  assert.equal(annotated.agents[1]?.bindingKind, "detached");
+  assert.equal(annotated.agents[1]?.terminalIdentity, null);
+});


### PR DESCRIPTION
## Summary
- default `subscription add` and `inbox read/watch/ack` to the current session agent
- add `agent current` and enrich `agent list` via current-agent annotations
- support `GET /agents?include_targets=true` for CLI-side current-agent resolution
- switch explicit target selection on those workflows to `--agent-id`
- return structured cross-session warnings for explicit session-bound overrides

## Testing
- `npm run build`
- `npm test`

## Breaking changes
- `agentinbox subscription add <agentId> <sourceId>` is removed
- `agentinbox inbox read <agentId>` is removed
- `agentinbox inbox watch <agentId>` is removed
- `agentinbox inbox ack <agentId> ...` is removed
- use `--agent-id <agentId>` for explicit targets on those commands

Closes #30
