### PR TITLE
feat(cli): make subscription filter inputs robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Create a local source and publish an event:
 agentinbox source add local_event local-demo
 agentinbox subscription add <source_id>
 agentinbox subscription add <source_id> --agent-id <agent_id>
+agentinbox subscription add <source_id> --filter-file ./filter.json
+cat filter.json | agentinbox subscription add <source_id> --filter-stdin
 agentinbox source event <source_id> --native-id demo-1 --event local.demo
 agentinbox inbox read
 agentinbox inbox read --agent-id <agent_id>

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -96,6 +96,14 @@ agentinbox subscription add <source_id> --agent-id <agent_id> \
 agentinbox source poll <source_id>
 ```
 
+For larger filters with nested JSON or JEXL, prefer a file or stdin over shell
+quoting:
+
+```bash
+agentinbox subscription add <source_id> --filter-file ./filter.json
+cat filter.json | agentinbox subscription add <source_id> --filter-stdin
+```
+
 ## Terminal Support
 
 - `tmux`

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -49,12 +49,18 @@ agentinbox source event <source_id> --native-id <id> --event <variant>
 
 ```bash
 agentinbox subscription add <source_id> [--agent-id <agent_id>] [--filter-json ...]
+agentinbox subscription add <source_id> [--agent-id <agent_id>] --filter-file <path>
+agentinbox subscription add <source_id> [--agent-id <agent_id>] --filter-stdin
 agentinbox subscription list [--agent-id <agent_id>] [--source-id <source_id>]
 agentinbox subscription show <subscription_id>
 agentinbox subscription remove <subscription_id>
 agentinbox subscription lag <subscription_id>
 agentinbox subscription reset <subscription_id> --start-policy latest
 ```
+
+`subscription add` accepts exactly one of `--filter-json`, `--filter-file`, or
+`--filter-stdin`. The created subscription response echoes the normalized
+persisted `filter`.
 
 ## Inbox
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -217,10 +217,10 @@ async function main(): Promise<void> {
 
   if (command === "subscription" && normalized[1] === "add") {
     const args = normalized.slice(2);
-    const positionals = positionalArgs(args, ["--agent-id", "--filter-json", "--start-policy", "--start-offset", "--start-time"]);
+    const positionals = positionalArgs(args, ["--agent-id", "--filter-json", "--filter-file", "--start-policy", "--start-offset", "--start-time"]);
     const sourceId = positionals[0];
     if (!sourceId || positionals[1]) {
-      throw new Error("usage: agentinbox subscription add <sourceId> [--agent-id ID] [--filter-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
+      throw new Error("usage: agentinbox subscription add <sourceId> [--agent-id ID] [--filter-json JSON | --filter-file PATH | --filter-stdin] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
     }
     const selection = await selectAgentForCommand(client, {
       explicitAgentId: takeFlagValue(normalized, "--agent-id"),
@@ -229,7 +229,7 @@ async function main(): Promise<void> {
     const response = await requestRemote<Record<string, unknown>>(client, "/subscriptions", {
       agentId: selection.agentId,
       sourceId,
-      filter: parseJsonArg(takeFlagValue(normalized, "--filter-json")),
+      filter: readSubscriptionFilter(normalized),
       startPolicy: takeFlagValue(normalized, "--start-policy") ?? undefined,
       startOffset: parseOptionalNumber(takeFlagValue(normalized, "--start-offset")),
       startTime: takeFlagValue(normalized, "--start-time") ?? undefined,
@@ -677,6 +677,27 @@ function buildQuery(params: Record<string, string | undefined>): string {
   return query ? `?${query}` : "";
 }
 
+function readSubscriptionFilter(args: string[]): Record<string, unknown> {
+  const filterJson = takeFlagValue(args, "--filter-json");
+  const filterFile = takeFlagValue(args, "--filter-file");
+  const filterStdin = hasFlag(args, "--filter-stdin");
+  const configured = [filterJson != null, filterFile != null, filterStdin].filter(Boolean).length;
+  if (configured > 1) {
+    throw new Error("subscription add accepts only one of --filter-json, --filter-file, or --filter-stdin");
+  }
+  if (filterJson != null) {
+    return parseJsonArg(filterJson, "--filter-json");
+  }
+  if (filterFile != null) {
+    return parseJsonArg(fs.readFileSync(filterFile, "utf8"), `filter file ${filterFile}`);
+  }
+  if (filterStdin) {
+    const stdin = fs.readFileSync(0, "utf8");
+    return parseJsonArg(stdin, "stdin filter");
+  }
+  return {};
+}
+
 function withCommandMetadata<T extends Record<string, unknown>>(data: T, selection: AgentSelection): T & {
   agentId: string;
   autoRegistered?: true;
@@ -792,7 +813,7 @@ Usage:
     subscription: `agentinbox subscription
 
 Usage:
-  agentinbox subscription add <sourceId> [--agent-id ID] [--filter-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
+  agentinbox subscription add <sourceId> [--agent-id ID] [--filter-json JSON | --filter-file PATH | --filter-stdin] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
   agentinbox subscription list [--source-id ID] [--agent-id ID]
   agentinbox subscription show <subscriptionId>
   agentinbox subscription remove <subscriptionId>

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,13 +8,19 @@ export function generateId(prefix: string): string {
   return `${prefix}_${crypto.randomUUID()}`;
 }
 
-export function parseJsonArg(raw?: string): Record<string, unknown> {
+export function parseJsonArg(raw?: string, source = "JSON argument"): Record<string, unknown> {
   if (!raw) {
     return {};
   }
-  const parsed = JSON.parse(raw) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`invalid ${source}: ${message}`);
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("expected a JSON object");
+    throw new Error(`expected ${source} to be a JSON object`);
   }
   return parsed as Record<string, unknown>;
 }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -62,13 +62,14 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   }
 }
 
-function runCli(args: string[], env: NodeJS.ProcessEnv, timeout = 25_000) {
+function runCli(args: string[], env: NodeJS.ProcessEnv, timeout = 25_000, input?: string) {
   const repoDir = path.resolve(__dirname, "..");
   return spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", ...args], {
     cwd: repoDir,
     env,
     encoding: "utf8",
     timeout,
+    input,
   });
 }
 
@@ -462,6 +463,113 @@ test("cli resolves current agent, auto-registers session workflows, and warns on
     assert.match(oldSyntax.stderr, /usage: agentinbox subscription add <sourceId> \[--agent-id ID]/);
   } finally {
     void runCli(["daemon", "stop"], envBase);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli subscription add accepts filter-file and filter-stdin and echoes normalized filter", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-filter-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%931",
+    CODEX_THREAD_ID: "thread-filter",
+  };
+
+  try {
+    const sourceAdd = runCli(["source", "add", "local_event", "cli-filter-demo"], env);
+    assert.equal(sourceAdd.status, 0, sourceAdd.stderr);
+    const source = JSON.parse(sourceAdd.stdout) as { sourceId: string };
+
+    const filterFilePath = path.join(homeDir, "filter.json");
+    fs.writeFileSync(filterFilePath, JSON.stringify({
+      metadata: {
+        status: "completed",
+        nested: {
+          branch: "main",
+        },
+      },
+      expr: "metadata.status != 'queued'",
+    }, null, 2));
+
+    const fromFile = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--filter-file",
+      filterFilePath,
+    ], env);
+    assert.equal(fromFile.status, 0, fromFile.stderr);
+    const fileResult = JSON.parse(fromFile.stdout) as {
+      filter: {
+        metadata: {
+          status: string;
+          nested: {
+            branch: string;
+          };
+        };
+        expr: string;
+      };
+    };
+    assert.deepEqual(fileResult.filter, {
+      metadata: {
+        status: "completed",
+        nested: {
+          branch: "main",
+        },
+      },
+      expr: "metadata.status != 'queued'",
+    });
+
+    const fromStdin = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--filter-stdin",
+    ], env, 25_000, JSON.stringify({
+      payload: {
+        review: {
+          state: "changes_requested",
+        },
+      },
+      expr: "payload.review.state == 'changes_requested'",
+    }));
+    assert.equal(fromStdin.status, 0, fromStdin.stderr);
+    const stdinResult = JSON.parse(fromStdin.stdout) as {
+      filter: {
+        payload: {
+          review: {
+            state: string;
+          };
+        };
+        expr: string;
+      };
+    };
+    assert.deepEqual(stdinResult.filter, {
+      payload: {
+        review: {
+          state: "changes_requested",
+        },
+      },
+      expr: "payload.review.state == 'changes_requested'",
+    });
+
+    const conflicting = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--filter-json",
+      "{\"metadata\":{\"status\":\"completed\"}}",
+      "--filter-file",
+      filterFilePath,
+    ], env);
+    assert.notEqual(conflicting.status, 0);
+    assert.match(conflicting.stderr, /only one of --filter-json, --filter-file, or --filter-stdin/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- add `--filter-file` and `--filter-stdin` for `agentinbox subscription add`
- keep `--filter-json` but enforce that only one filter input mode is used
- improve JSON-object parsing errors so the failing input surface is explicit
- document file/stdin filter input and verify the CLI echoes the normalized persisted filter

## Testing
- `npm run build`
- `npm test -- --test test/control_plane.test.ts`

Closes #35
