### PR TITLE
feat: add source pause and resume lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ agentinbox subscription add <source_id>
 agentinbox subscription add <source_id> --agent-id <agent_id>
 agentinbox subscription add <source_id> --filter-file ./filter.json
 cat filter.json | agentinbox subscription add <source_id> --filter-stdin
-agentinbox source pause <source_id>
-agentinbox source resume <source_id>
+agentinbox source pause <remote_source_id>
+agentinbox source resume <remote_source_id>
 agentinbox source event <source_id> --native-id demo-1 --event local.demo
 agentinbox inbox read
 agentinbox inbox read --agent-id <agent_id>

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ agentinbox subscription add <source_id>
 agentinbox subscription add <source_id> --agent-id <agent_id>
 agentinbox subscription add <source_id> --filter-file ./filter.json
 cat filter.json | agentinbox subscription add <source_id> --filter-stdin
+agentinbox source pause <source_id>
+agentinbox source resume <source_id>
 agentinbox source event <source_id> --native-id demo-1 --event local.demo
 agentinbox inbox read
 agentinbox inbox read --agent-id <agent_id>

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -77,6 +77,8 @@ The shortest end-to-end flow is a local source:
 agentinbox source add local_event local-demo
 agentinbox subscription add <source_id>
 agentinbox subscription add <source_id> --agent-id <agent_id>
+agentinbox source pause <source_id>
+agentinbox source resume <source_id>
 agentinbox source event <source_id> \
   --native-id demo-1 \
   --event local.demo \
@@ -102,6 +104,15 @@ quoting:
 ```bash
 agentinbox subscription add <source_id> --filter-file ./filter.json
 cat filter.json | agentinbox subscription add <source_id> --filter-stdin
+```
+
+For remote-backed sources, use lifecycle commands instead of delete/recreate
+when you just want to stop delivery temporarily:
+
+```bash
+agentinbox source pause <source_id>
+agentinbox source poll <source_id>   # returns a paused note, does not resume
+agentinbox source resume <source_id>
 ```
 
 ## Terminal Support

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -77,8 +77,8 @@ The shortest end-to-end flow is a local source:
 agentinbox source add local_event local-demo
 agentinbox subscription add <source_id>
 agentinbox subscription add <source_id> --agent-id <agent_id>
-agentinbox source pause <source_id>
-agentinbox source resume <source_id>
+agentinbox source pause <remote_source_id>
+agentinbox source resume <remote_source_id>
 agentinbox source event <source_id> \
   --native-id demo-1 \
   --event local.demo \
@@ -107,12 +107,13 @@ cat filter.json | agentinbox subscription add <source_id> --filter-stdin
 ```
 
 For remote-backed sources, use lifecycle commands instead of delete/recreate
-when you just want to stop delivery temporarily:
+when you just want to stop delivery temporarily. These commands do not apply to
+`local_event` sources:
 
 ```bash
-agentinbox source pause <source_id>
-agentinbox source poll <source_id>   # returns a paused note, does not resume
-agentinbox source resume <source_id>
+agentinbox source pause <remote_source_id>
+agentinbox source poll <remote_source_id>   # returns a paused note, does not resume
+agentinbox source resume <remote_source_id>
 ```
 
 ## Terminal Support

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -40,16 +40,17 @@ agentinbox source add <source_type> <source_key> [--config-json ...]
 agentinbox source list
 agentinbox source show <source_id>
 agentinbox source remove <source_id>
-agentinbox source pause <source_id>
-agentinbox source resume <source_id>
+agentinbox source pause <remote_source_id>
+agentinbox source resume <remote_source_id>
 agentinbox source schema <source_type>
 agentinbox source poll <source_id>
 agentinbox source event <source_id> --native-id <id> --event <variant>
 ```
 
-`source pause` stops a managed remote source without deleting its binding or
-stream checkpoint. `source resume` goes back through the normal ensure path.
-Manual `source poll` does not resume a paused source.
+`source pause` and `source resume` apply only to managed remote sources. Pause
+stops the managed runtime without deleting its binding or stream checkpoint.
+Resume goes back through the normal ensure path. Manual `source poll` does not
+resume a paused source.
 
 ## Subscriptions
 

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -40,10 +40,16 @@ agentinbox source add <source_type> <source_key> [--config-json ...]
 agentinbox source list
 agentinbox source show <source_id>
 agentinbox source remove <source_id>
+agentinbox source pause <source_id>
+agentinbox source resume <source_id>
 agentinbox source schema <source_type>
 agentinbox source poll <source_id>
 agentinbox source event <source_id> --native-id <id> --event <variant>
 ```
+
+`source pause` stops a managed remote source without deleting its binding or
+stream checkpoint. `source resume` goes back through the normal ensure path.
+Manual `source poll` does not resume a paused source.
 
 ## Subscriptions
 

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -21,6 +21,8 @@ going forward.
 - `POST /sources`
 - `GET /sources/{sourceId}`
 - `DELETE /sources/{sourceId}`
+- `POST /sources/{sourceId}/pause`
+- `POST /sources/{sourceId}/resume`
 - `GET /source-types/{sourceType}/schema`
 - `POST /sources/{sourceId}/poll`
 - `POST /sources/{sourceId}/events`
@@ -79,3 +81,7 @@ going forward.
   `POST /sources/{sourceId}/events`.
 - `remote_source` is supported and requires `config.profilePath` (and optional
   `config.profileConfig`) when registering.
+- `POST /sources/{sourceId}/pause` stops a managed remote source without
+  deleting its binding or stream state. `POST /sources/{sourceId}/resume`
+  re-enters the normal ensure path. `POST /sources/{sourceId}/poll` does not
+  implicitly resume a paused source.

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -81,7 +81,8 @@ going forward.
   `POST /sources/{sourceId}/events`.
 - `remote_source` is supported and requires `config.profilePath` (and optional
   `config.profileConfig`) when registering.
-- `POST /sources/{sourceId}/pause` stops a managed remote source without
-  deleting its binding or stream state. `POST /sources/{sourceId}/resume`
-  re-enters the normal ensure path. `POST /sources/{sourceId}/poll` does not
-  implicitly resume a paused source.
+- `POST /sources/{sourceId}/pause` and `POST /sources/{sourceId}/resume` apply
+  only to managed remote sources. Pause stops the managed runtime without
+  deleting its binding or stream state. Resume re-enters the normal ensure
+  path. `POST /sources/{sourceId}/poll` does not implicitly resume a paused
+  source.

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -130,11 +130,17 @@ export class AdapterRegistry {
 
   async pauseSource(source: SubscriptionSource): Promise<void> {
     const adapter = this.sourceAdapterFor(source.sourceType);
+    if (!adapter.pauseSource) {
+      throw new Error(`source type ${source.sourceType} does not support pause`);
+    }
     await adapter.pauseSource?.(source.sourceId);
   }
 
   async resumeSource(source: SubscriptionSource): Promise<void> {
     const adapter = this.sourceAdapterFor(source.sourceType);
+    if (!adapter.resumeSource) {
+      throw new Error(`source type ${source.sourceType} does not support resume`);
+    }
     await adapter.resumeSource?.(source.sourceId);
   }
 

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -15,6 +15,8 @@ import { RemoteSourceProfileRegistry } from "./sources/remote_profiles";
 export interface SourceAdapter {
   ensureSource(source: SubscriptionSource): Promise<void>;
   pollSource?(sourceId: string): Promise<SourcePollResult>;
+  pauseSource?(sourceId: string): Promise<void>;
+  resumeSource?(sourceId: string): Promise<void>;
   removeSource?(sourceId: string): Promise<void>;
   start?(): Promise<void>;
   stop?(): Promise<void>;
@@ -124,6 +126,16 @@ export class AdapterRegistry {
       };
     }
     return adapter.pollSource(source.sourceId);
+  }
+
+  async pauseSource(source: SubscriptionSource): Promise<void> {
+    const adapter = this.sourceAdapterFor(source.sourceType);
+    await adapter.pauseSource?.(source.sourceId);
+  }
+
+  async resumeSource(source: SubscriptionSource): Promise<void> {
+    const adapter = this.sourceAdapterFor(source.sourceType);
+    await adapter.resumeSource?.(source.sourceId);
   }
 
   async removeSource(source: SubscriptionSource): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,7 +105,7 @@ async function main(): Promise<void> {
   if (command === "source" && normalized[1] === "pause") {
     const sourceId = normalized[2];
     if (!sourceId) {
-      throw new Error("usage: agentinbox source pause <sourceId>");
+      throw new Error("usage: agentinbox source pause <remoteSourceId>");
     }
     await printRemote(client, `/sources/${encodeURIComponent(sourceId)}/pause`, {});
     return;
@@ -114,7 +114,7 @@ async function main(): Promise<void> {
   if (command === "source" && normalized[1] === "resume") {
     const sourceId = normalized[2];
     if (!sourceId) {
-      throw new Error("usage: agentinbox source resume <sourceId>");
+      throw new Error("usage: agentinbox source resume <remoteSourceId>");
     }
     await printRemote(client, `/sources/${encodeURIComponent(sourceId)}/resume`, {});
     return;
@@ -812,8 +812,8 @@ Usage:
   agentinbox source list
   agentinbox source show <sourceId>
   agentinbox source remove <sourceId>
-  agentinbox source pause <sourceId>
-  agentinbox source resume <sourceId>
+  agentinbox source pause <remoteSourceId>
+  agentinbox source resume <remoteSourceId>
   agentinbox source schema <sourceType>
   agentinbox source poll <sourceId>
   agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,6 +102,24 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "source" && normalized[1] === "pause") {
+    const sourceId = normalized[2];
+    if (!sourceId) {
+      throw new Error("usage: agentinbox source pause <sourceId>");
+    }
+    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}/pause`, {});
+    return;
+  }
+
+  if (command === "source" && normalized[1] === "resume") {
+    const sourceId = normalized[2];
+    if (!sourceId) {
+      throw new Error("usage: agentinbox source resume <sourceId>");
+    }
+    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}/resume`, {});
+    return;
+  }
+
   if (command === "source" && normalized[1] === "schema") {
     const sourceType = normalized[2];
     if (!sourceType) {
@@ -794,6 +812,8 @@ Usage:
   agentinbox source list
   agentinbox source show <sourceId>
   agentinbox source remove <sourceId>
+  agentinbox source pause <sourceId>
+  agentinbox source resume <sourceId>
   agentinbox source schema <sourceType>
   agentinbox source poll <sourceId>
   agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]

--- a/src/http.ts
+++ b/src/http.ts
@@ -179,6 +179,44 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.removeSource(decodeURIComponent(params.sourceId));
   });
 
+  app.post("/sources/:sourceId/pause", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    return service.pauseSource(decodeURIComponent(params.sourceId));
+  });
+
+  app.post("/sources/:sourceId/resume", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    return service.resumeSource(decodeURIComponent(params.sourceId));
+  });
+
   app.get("/source-types/:sourceType/schema", {
     schema: {
       tags: ["sources"],

--- a/src/service.ts
+++ b/src/service.ts
@@ -209,6 +209,36 @@ export class AgentInboxService {
     return { removed: true };
   }
 
+  async pauseSource(sourceId: string): Promise<{ paused: boolean; source: SubscriptionSource | null }> {
+    const source = this.store.getSource(sourceId);
+    if (!source) {
+      return { paused: false, source: null };
+    }
+    await this.adapters.pauseSource(source);
+    if (this.store.getSource(sourceId)?.status !== "paused") {
+      this.store.updateSourceRuntime(sourceId, { status: "paused" });
+    }
+    return {
+      paused: true,
+      source: this.getSource(sourceId),
+    };
+  }
+
+  async resumeSource(sourceId: string): Promise<{ resumed: boolean; source: SubscriptionSource | null }> {
+    const source = this.store.getSource(sourceId);
+    if (!source) {
+      return { resumed: false, source: null };
+    }
+    await this.adapters.resumeSource(source);
+    if (this.store.getSource(sourceId)?.status === "paused") {
+      this.store.updateSourceRuntime(sourceId, { status: "active" });
+    }
+    return {
+      resumed: true,
+      source: this.getSource(sourceId),
+    };
+  }
+
   registerAgent(input: RegisterAgentInput): RegisterAgentResult {
     validateNotifyLeaseMs(input.notifyLeaseMs);
     validateTerminalRegistration(input);

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -159,6 +159,8 @@ export class RemoteSourceRuntime {
     }
     const binding = managedBindingForSource(source);
     await this.client.sourceStop(binding.namespace, binding.sourceKey);
+    this.errorCounts.delete(sourceId);
+    this.nextRetryAt.delete(sourceId);
     const checkpoint = parseRemoteCheckpoint(source.checkpoint);
     this.store.updateSourceRuntime(sourceId, {
       status: "paused",
@@ -259,10 +261,10 @@ export class RemoteSourceRuntime {
       const profileSource = profileInputSource(source);
       profile.validateConfig(profileSource);
       const spec = profile.buildManagedSourceSpec(profileSource);
-      const managedSourceKey = `${source.sourceType}:${source.sourceKey}`;
+      const binding = managedBindingForSource(source);
       const ensured = await this.client.sourceEnsure({
-        namespace: MANAGED_SOURCE_NAMESPACE,
-        sourceKey: managedSourceKey,
+        namespace: binding.namespace,
+        sourceKey: binding.sourceKey,
         spec,
       });
 
@@ -361,11 +363,19 @@ function profileInputSource(source: SubscriptionSource): SubscriptionSource {
   };
 }
 
+function defaultManagedBindingForSource(source: SubscriptionSource): { namespace: string; sourceKey: string } {
+  return {
+    namespace: MANAGED_SOURCE_NAMESPACE,
+    sourceKey: `${source.sourceType}:${source.sourceKey}`,
+  };
+}
+
 function managedBindingForSource(source: SubscriptionSource): { namespace: string; sourceKey: string } {
   const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+  const defaultBinding = defaultManagedBindingForSource(source);
   return {
-    namespace: checkpoint.managedSource?.namespace ?? MANAGED_SOURCE_NAMESPACE,
-    sourceKey: checkpoint.managedSource?.sourceKey ?? `${source.sourceType}:${source.sourceKey}`,
+    namespace: checkpoint.managedSource?.namespace ?? defaultBinding.namespace,
+    sourceKey: checkpoint.managedSource?.sourceKey ?? defaultBinding.sourceKey,
   };
 }
 

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -135,7 +135,53 @@ export class RemoteSourceRuntime {
   }
 
   async pollSource(sourceId: string): Promise<SourcePollResult> {
+    const source = this.store.getSource(sourceId);
+    if (!source) {
+      throw new Error(`unknown source: ${sourceId}`);
+    }
+    if (source.status === "paused") {
+      return {
+        sourceId,
+        sourceType: source.sourceType,
+        appended: 0,
+        deduped: 0,
+        eventsRead: 0,
+        note: "source is paused; resume it before polling",
+      };
+    }
     return this.syncSource(sourceId, true);
+  }
+
+  async pauseSource(sourceId: string): Promise<void> {
+    const source = this.store.getSource(sourceId);
+    if (!source || !REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return;
+    }
+    const binding = managedBindingForSource(source);
+    await this.client.sourceStop(binding.namespace, binding.sourceKey);
+    const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+    this.store.updateSourceRuntime(sourceId, {
+      status: "paused",
+      checkpoint: JSON.stringify({
+        ...checkpoint,
+        ...(checkpoint.managedSource ? {
+          managedSource: {
+            namespace: binding.namespace,
+            sourceKey: binding.sourceKey,
+            streamId: checkpoint.managedSource.streamId,
+          },
+        } : {}),
+        lastError: null,
+      } satisfies RemoteSourceCheckpoint),
+    });
+  }
+
+  async resumeSource(sourceId: string): Promise<void> {
+    const source = this.store.getSource(sourceId);
+    if (!source || !REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return;
+    }
+    await this.syncSource(sourceId, true);
   }
 
   async removeSource(sourceId: string): Promise<void> {
@@ -143,10 +189,8 @@ export class RemoteSourceRuntime {
     if (!source || !REMOTE_SOURCE_TYPES.has(source.sourceType)) {
       return;
     }
-    const checkpoint = parseRemoteCheckpoint(source.checkpoint);
-    const namespace = checkpoint.managedSource?.namespace ?? MANAGED_SOURCE_NAMESPACE;
-    const sourceKey = checkpoint.managedSource?.sourceKey ?? `${source.sourceType}:${source.sourceKey}`;
-    await this.client.sourceDelete(namespace, sourceKey);
+    const binding = managedBindingForSource(source);
+    await this.client.sourceDelete(binding.namespace, binding.sourceKey);
   }
 
   status(): Record<string, unknown> {
@@ -254,8 +298,12 @@ export class RemoteSourceRuntime {
         deduped += result.deduped;
       }
 
+      const latestSource = this.store.getSource(sourceId);
+      if (!latestSource) {
+        throw new Error(`unknown source: ${sourceId}`);
+      }
       this.store.updateSourceRuntime(sourceId, {
-        status: "active",
+        status: latestSource.status === "paused" ? "paused" : "active",
         checkpoint: JSON.stringify({
           managedSource: {
             namespace: ensured.namespace,
@@ -288,7 +336,7 @@ export class RemoteSourceRuntime {
         this.errorCounts.set(sourceId, nextErrorCount);
         this.nextRetryAt.set(sourceId, Date.now() + computeErrorBackoffMs(DEFAULT_BACKOFF_BASE_SECS, nextErrorCount));
         this.store.updateSourceRuntime(sourceId, {
-          status: "error",
+          status: source.status === "paused" ? "paused" : "error",
           checkpoint: JSON.stringify({
             ...checkpoint,
             lastError: error instanceof Error ? error.message : String(error),
@@ -310,6 +358,14 @@ function profileInputSource(source: SubscriptionSource): SubscriptionSource {
   return {
     ...source,
     config: asRecord(config.profileConfig),
+  };
+}
+
+function managedBindingForSource(source: SubscriptionSource): { namespace: string; sourceKey: string } {
+  const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+  return {
+    namespace: checkpoint.managedSource?.namespace ?? MANAGED_SOURCE_NAMESPACE,
+    sourceKey: checkpoint.managedSource?.sourceKey ?? `${source.sourceType}:${source.sourceKey}`,
   };
 }
 

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -18,6 +18,8 @@ import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
 
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
+  public readonly ensuredSources: Array<{ namespace: string; sourceKey: string }> = [];
+  public readonly stoppedSources: Array<{ namespace: string; sourceKey: string }> = [];
   async sourceEnsure(args: { namespace: string; sourceKey: string; spec: unknown }): Promise<{
     namespace: string;
     source_key: string;
@@ -28,6 +30,7 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
     replaced_previous: boolean;
   }> {
     void args.spec;
+    this.ensuredSources.push({ namespace: args.namespace, sourceKey: args.sourceKey });
     return {
       namespace: args.namespace,
       source_key: args.sourceKey,
@@ -39,7 +42,8 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
     };
   }
 
-  async sourceStop(_namespace: string, _sourceKey: string): Promise<void> {
+  async sourceStop(namespace: string, sourceKey: string): Promise<void> {
+    this.stoppedSources.push({ namespace, sourceKey });
     return;
   }
 
@@ -403,6 +407,97 @@ test("control plane GET /agents can include activation target summaries", async 
   }
 });
 
+test("control plane pause and resume endpoints update source lifecycle", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-pause-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const fake = new FakeRemoteSourceClient();
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: fake,
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  const profileDir = path.join(homeDir, "source-profiles");
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(profileDir, "demo-pause.mjs"),
+    `export default {
+  id: "demo.pause",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return { sourceNativeId: "demo:" + raw.id, eventVariant: "demo.event", metadata: {}, rawPayload: raw };
+  }
+};`,
+    "utf8",
+  );
+
+  try {
+    await adapters.start();
+    await service.start();
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const sourceResponse = await client.request<{ sourceId: string }>("/sources", {
+        sourceType: "remote_source",
+        sourceKey: "pause-http-key",
+        config: {
+          profilePath: "demo-pause.mjs",
+          profileConfig: {},
+        },
+      });
+      assert.equal(sourceResponse.statusCode, 200);
+      const sourceId = sourceResponse.data.sourceId;
+
+      const paused = await client.request<{ paused: boolean; source: { status: string } }>(
+        `/sources/${encodeURIComponent(sourceId)}/pause`,
+        {},
+      );
+      assert.equal(paused.statusCode, 200);
+      assert.equal(paused.data.paused, true);
+      assert.equal(paused.data.source.status, "paused");
+      assert.deepEqual(fake.stoppedSources, [{
+        namespace: "agentinbox",
+        sourceKey: "remote_source:pause-http-key",
+      }]);
+
+      const resumed = await client.request<{ resumed: boolean; source: { status: string } }>(
+        `/sources/${encodeURIComponent(sourceId)}/resume`,
+        {},
+      );
+      assert.equal(resumed.statusCode, 200);
+      assert.equal(resumed.data.resumed, true);
+      assert.equal(resumed.data.source.status, "active");
+      assert.equal(fake.ensuredSources.length, 2);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli resolves current agent, auto-registers session workflows, and warns on cross-session targets", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-current-"));
   const envBase = {
@@ -568,6 +663,34 @@ test("cli subscription add accepts filter-file and filter-stdin and echoes norma
     ], env);
     assert.notEqual(conflicting.status, 0);
     assert.match(conflicting.stderr, /only one of --filter-json, --filter-file, or --filter-stdin/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli source pause and resume update source status", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-pause-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+  };
+
+  try {
+    const sourceAdd = runCli(["source", "add", "local_event", "cli-pause-demo"], env);
+    assert.equal(sourceAdd.status, 0, sourceAdd.stderr);
+    const source = JSON.parse(sourceAdd.stdout) as { sourceId: string };
+
+    const paused = runCli(["source", "pause", source.sourceId], env);
+    assert.equal(paused.status, 0, paused.stderr);
+    assert.equal((JSON.parse(paused.stdout) as { source: { status: string } }).source.status, "paused");
+
+    const resumed = runCli(["source", "resume", source.sourceId], env);
+    assert.equal(resumed.status, 0, resumed.stderr);
+    assert.equal((JSON.parse(resumed.stdout) as { source: { status: string } }).source.status, "active");
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -669,7 +669,7 @@ test("cli subscription add accepts filter-file and filter-stdin and echoes norma
   }
 });
 
-test("cli source pause and resume update source status", () => {
+test("cli source pause rejects unsupported local_event sources", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-pause-"));
   const env = {
     ...process.env,
@@ -685,12 +685,12 @@ test("cli source pause and resume update source status", () => {
     const source = JSON.parse(sourceAdd.stdout) as { sourceId: string };
 
     const paused = runCli(["source", "pause", source.sourceId], env);
-    assert.equal(paused.status, 0, paused.stderr);
-    assert.equal((JSON.parse(paused.stdout) as { source: { status: string } }).source.status, "paused");
+    assert.notEqual(paused.status, 0);
+    assert.match(paused.stderr, /source type local_event does not support pause/);
 
     const resumed = runCli(["source", "resume", source.sourceId], env);
-    assert.equal(resumed.status, 0, resumed.stderr);
-    assert.equal((JSON.parse(resumed.stdout) as { source: { status: string } }).source.status, "active");
+    assert.notEqual(resumed.status, 0);
+    assert.match(resumed.stderr, /source type local_event does not support resume/);
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -89,6 +89,7 @@ async function makeService(fake: FakeRemoteSourceClient): Promise<{
   dir: string;
   store: AgentInboxStore;
   service: AgentInboxService;
+  adapters: AdapterRegistry;
 }> {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-remote-source-test-"));
   const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
@@ -101,7 +102,7 @@ async function makeService(fake: FakeRemoteSourceClient): Promise<{
     stdout: "",
     stderr: "",
   })));
-  return { dir, store, service };
+  return { dir, store, service, adapters };
 }
 
 test("remote_source with local profile ingests stream events", async () => {
@@ -308,7 +309,7 @@ test("removeSource deletes managed source binding when no subscriptions remain",
 
 test("pauseSource stops managed source, preserves binding, and resume re-ensures it", async () => {
   const fake = new FakeRemoteSourceClient();
-  const { dir, store, service } = await makeService(fake);
+  const { dir, store, service, adapters } = await makeService(fake);
   try {
     const profileDir = path.join(dir, "source-profiles");
     fs.mkdirSync(profileDir, { recursive: true });
@@ -347,13 +348,35 @@ test("pauseSource stops managed source, preserves binding, and resume re-ensures
     const initialEnsureCount = fake.ensuredSources.length;
     assert.equal(initialEnsureCount, 1);
 
+    store.updateSourceRuntime(source.sourceId, {
+      checkpoint: JSON.stringify({
+        managedSource: {
+          namespace: "custom-agentinbox",
+          sourceKey: "custom:pause-key",
+          streamId: "stream:custom:pause-key",
+        },
+      }),
+    });
+
+    const remoteRuntime = (adapters as unknown as {
+      remoteSource: {
+        errorCounts: Map<string, number>;
+        nextRetryAt: Map<string, number>;
+      };
+    }).remoteSource;
+    remoteRuntime.errorCounts.set(source.sourceId, 2);
+    remoteRuntime.nextRetryAt.set(source.sourceId, Date.now() + 60_000);
+
     const paused = await service.pauseSource(source.sourceId);
     assert.equal(paused.paused, true);
     assert.equal(paused.source?.status, "paused");
     assert.deepEqual(fake.stoppedSources, [{
-      namespace: "agentinbox",
-      sourceKey: "remote_source:pause-key",
+      namespace: "custom-agentinbox",
+      sourceKey: "custom:pause-key",
     }]);
+    assert.equal(remoteRuntime.errorCounts.has(source.sourceId), false);
+    assert.equal(remoteRuntime.nextRetryAt.has(source.sourceId), false);
+    assert.deepEqual((service.status().adapters as { remote: { erroredSourceIds: string[] } }).remote.erroredSourceIds, []);
 
     const pausedPoll = await service.pollSource(source.sourceId);
     assert.equal(pausedPoll.note, "source is paused; resume it before polling");
@@ -364,8 +387,8 @@ test("pauseSource stops managed source, preserves binding, and resume re-ensures
     assert.equal(resumed.source?.status, "active");
     assert.equal(fake.ensuredSources.length, initialEnsureCount + 1);
     assert.deepEqual(fake.ensuredSources.at(-1), {
-      namespace: "agentinbox",
-      sourceKey: "remote_source:pause-key",
+      namespace: "custom-agentinbox",
+      sourceKey: "custom:pause-key",
     });
   } finally {
     await service.stop();

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -13,6 +13,8 @@ import { TerminalDispatcher } from "../src/terminal";
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   private readonly streams = new Map<string, Array<{ offset: number; raw_payload: unknown }>>();
   private readonly offsets = new Map<string, number>();
+  public readonly ensuredSources: Array<{ namespace: string; sourceKey: string }> = [];
+  public readonly stoppedSources: Array<{ namespace: string; sourceKey: string }> = [];
   public readonly deletedSources: Array<{ namespace: string; sourceKey: string }> = [];
 
   push(streamId: string, payload: unknown): void {
@@ -36,6 +38,7 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
     replaced_previous: boolean;
   }> {
     void args.spec;
+    this.ensuredSources.push({ namespace: args.namespace, sourceKey: args.sourceKey });
     const streamId = `stream:${args.sourceKey}`;
     return {
       namespace: args.namespace,
@@ -48,12 +51,13 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
     };
   }
 
-  async sourceStop(_namespace: string, _sourceKey: string): Promise<void> {
+  async sourceStop(namespace: string, sourceKey: string): Promise<void> {
+    this.stoppedSources.push({ namespace, sourceKey });
     return;
   }
 
-  async sourceDelete(_namespace: string, _sourceKey: string): Promise<void> {
-    this.deletedSources.push({ namespace: _namespace, sourceKey: _sourceKey });
+  async sourceDelete(namespace: string, sourceKey: string): Promise<void> {
+    this.deletedSources.push({ namespace, sourceKey });
     return;
   }
 
@@ -295,6 +299,74 @@ test("removeSource deletes managed source binding when no subscriptions remain",
     assert.equal(store.getSource(source.sourceId), null);
     assert.equal(fake.deletedSources.length, 1);
     assert.equal(fake.deletedSources[0]?.sourceKey, "remote_source:remove-key");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("pauseSource stops managed source, preserves binding, and resume re-ensures it", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "demo-pause.mjs"),
+      `export default {
+  id: "demo.pause",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return { sourceNativeId: "demo:" + raw.id, eventVariant: "demo.event", metadata: {}, rawPayload: raw };
+  }
+};`,
+      "utf8",
+    );
+
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "pause-key",
+      config: {
+        profilePath: "demo-pause.mjs",
+        profileConfig: {},
+      },
+    });
+    const initialEnsureCount = fake.ensuredSources.length;
+    assert.equal(initialEnsureCount, 1);
+
+    const paused = await service.pauseSource(source.sourceId);
+    assert.equal(paused.paused, true);
+    assert.equal(paused.source?.status, "paused");
+    assert.deepEqual(fake.stoppedSources, [{
+      namespace: "agentinbox",
+      sourceKey: "remote_source:pause-key",
+    }]);
+
+    const pausedPoll = await service.pollSource(source.sourceId);
+    assert.equal(pausedPoll.note, "source is paused; resume it before polling");
+    assert.equal(fake.ensuredSources.length, initialEnsureCount);
+
+    const resumed = await service.resumeSource(source.sourceId);
+    assert.equal(resumed.resumed, true);
+    assert.equal(resumed.source?.status, "active");
+    assert.equal(fake.ensuredSources.length, initialEnsureCount + 1);
+    assert.deepEqual(fake.ensuredSources.at(-1), {
+      namespace: "agentinbox",
+      sourceKey: "remote_source:pause-key",
+    });
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
## Summary
- add first-class source pause/resume service, HTTP, and CLI lifecycle commands
- stop paused remote sources via uxc source.stop, keep managed binding/checkpoint intact, and require explicit resume before polling again
- document the new lifecycle and add coverage for remote runtime, control plane, and CLI flows

Closes #42

## Testing
- npm run build
- npm test