### PR TITLE
feat: support in-place source config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Create a local source and publish an event:
 ```bash
 agentinbox source add local_event local-demo
 agentinbox source update <source_id> --config-json '{"channel":"infra"}'
+agentinbox source update <source_id> --clear-config-ref
 agentinbox subscription add <source_id>
 agentinbox subscription add <source_id> --agent-id <agent_id>
 agentinbox subscription add <source_id> --filter-file ./filter.json

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Create a local source and publish an event:
 
 ```bash
 agentinbox source add local_event local-demo
+agentinbox source update <source_id> --config-json '{"channel":"infra"}'
 agentinbox subscription add <source_id>
 agentinbox subscription add <source_id> --agent-id <agent_id>
 agentinbox subscription add <source_id> --filter-file ./filter.json

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -113,6 +113,7 @@ place instead of removing and recreating it:
 ```bash
 agentinbox source update <source_id> \
   --config-json '{"owner":"holon-run","repo":"agentinbox","uxcAuth":"github-default","pollIntervalSecs":60}'
+agentinbox source update <source_id> --clear-config-ref
 ```
 
 For remote-backed sources, use lifecycle commands instead of delete/recreate

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -75,6 +75,7 @@ The shortest end-to-end flow is a local source:
 
 ```bash
 agentinbox source add local_event local-demo
+agentinbox source update <source_id> --config-json '{"channel":"infra"}'
 agentinbox subscription add <source_id>
 agentinbox subscription add <source_id> --agent-id <agent_id>
 agentinbox source pause <remote_source_id>
@@ -104,6 +105,14 @@ quoting:
 ```bash
 agentinbox subscription add <source_id> --filter-file ./filter.json
 cat filter.json | agentinbox subscription add <source_id> --filter-stdin
+```
+
+If a source already exists and you only need to change its config, update it in
+place instead of removing and recreating it:
+
+```bash
+agentinbox source update <source_id> \
+  --config-json '{"owner":"holon-run","repo":"agentinbox","uxcAuth":"github-default","pollIntervalSecs":60}'
 ```
 
 For remote-backed sources, use lifecycle commands instead of delete/recreate

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -39,6 +39,7 @@ agentinbox agent remove <agent_id>
 agentinbox source add <source_type> <source_key> [--config-json ...]
 agentinbox source list
 agentinbox source show <source_id>
+agentinbox source update <source_id> [--config-json ...] [--config-ref ...]
 agentinbox source remove <source_id>
 agentinbox source pause <remote_source_id>
 agentinbox source resume <remote_source_id>
@@ -51,6 +52,9 @@ agentinbox source event <source_id> --native-id <id> --event <variant>
 stops the managed runtime without deleting its binding or stream checkpoint.
 Resume goes back through the normal ensure path. Manual `source poll` does not
 resume a paused source.
+
+`source update` replaces persisted `config` and/or `configRef` in place while
+preserving the existing `sourceId` and attached subscriptions.
 
 ## Subscriptions
 

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -20,6 +20,7 @@ going forward.
 - `GET /sources`
 - `POST /sources`
 - `GET /sources/{sourceId}`
+- `PATCH /sources/{sourceId}`
 - `DELETE /sources/{sourceId}`
 - `POST /sources/{sourceId}/pause`
 - `POST /sources/{sourceId}/resume`
@@ -81,6 +82,10 @@ going forward.
   `POST /sources/{sourceId}/events`.
 - `remote_source` is supported and requires `config.profilePath` (and optional
   `config.profileConfig`) when registering.
+- `PATCH /sources/{sourceId}` updates persisted `config` and/or `configRef`
+  without changing the `sourceId` or existing subscriptions. Active/error
+  sources are re-ensured after update; paused sources keep their paused
+  lifecycle state until explicitly resumed.
 - `POST /sources/{sourceId}/pause` and `POST /sources/{sourceId}/resume` apply
   only to managed remote sources. Pause stops the managed runtime without
   deleting its binding or stream state. Resume re-enters the normal ensure

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -14,6 +14,7 @@ import { RemoteSourceProfileRegistry } from "./sources/remote_profiles";
 
 export interface SourceAdapter {
   ensureSource(source: SubscriptionSource): Promise<void>;
+  validateSource?(source: SubscriptionSource): Promise<void>;
   pollSource?(sourceId: string): Promise<SourcePollResult>;
   pauseSource?(sourceId: string): Promise<void>;
   resumeSource?(sourceId: string): Promise<void>;
@@ -31,6 +32,10 @@ class NoopSourceAdapter implements SourceAdapter {
   constructor(private readonly sourceType: SourceType) {}
 
   async ensureSource(_source: SubscriptionSource): Promise<void> {
+    return;
+  }
+
+  async validateSource(_source: SubscriptionSource): Promise<void> {
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,15 +105,19 @@ async function main(): Promise<void> {
   if (command === "source" && normalized[1] === "update") {
     const sourceId = normalized[2];
     if (!sourceId) {
-      throw new Error("usage: agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF]");
+      throw new Error("usage: agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF | --clear-config-ref]");
     }
     const configRef = takeFlagValue(normalized, "--config-ref");
+    const clearConfigRef = hasFlag(normalized, "--clear-config-ref");
     const configJson = takeFlagValue(normalized, "--config-json");
-    if (configRef == null && configJson == null) {
-      throw new Error("usage: agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF]");
+    if (configRef != null && clearConfigRef) {
+      throw new Error("source update accepts only one of --config-ref or --clear-config-ref");
+    }
+    if (!clearConfigRef && configRef == null && configJson == null) {
+      throw new Error("usage: agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF | --clear-config-ref]");
     }
     await printRemote(client, `/sources/${encodeURIComponent(sourceId)}`, {
-      configRef: configRef ?? undefined,
+      ...(clearConfigRef ? { configRef: null } : (configRef != null ? { configRef } : {})),
       config: configJson != null ? parseJsonArg(configJson, "--config-json") : undefined,
     }, "PATCH");
     return;
@@ -828,7 +832,7 @@ Usage:
   agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]
   agentinbox source list
   agentinbox source show <sourceId>
-  agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF]
+  agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF | --clear-config-ref]
   agentinbox source remove <sourceId>
   agentinbox source pause <remoteSourceId>
   agentinbox source resume <remoteSourceId>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,6 +102,23 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "source" && normalized[1] === "update") {
+    const sourceId = normalized[2];
+    if (!sourceId) {
+      throw new Error("usage: agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF]");
+    }
+    const configRef = takeFlagValue(normalized, "--config-ref");
+    const configJson = takeFlagValue(normalized, "--config-json");
+    if (configRef == null && configJson == null) {
+      throw new Error("usage: agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF]");
+    }
+    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}`, {
+      configRef: configRef ?? undefined,
+      config: configJson != null ? parseJsonArg(configJson, "--config-json") : undefined,
+    }, "PATCH");
+    return;
+  }
+
   if (command === "source" && normalized[1] === "pause") {
     const sourceId = normalized[2];
     if (!sourceId) {
@@ -624,7 +641,7 @@ async function printRemote(
   client: AgentInboxClient,
   endpoint: string,
   body?: unknown,
-  method: "GET" | "POST" | "DELETE" = "POST",
+  method: "GET" | "POST" | "DELETE" | "PATCH" = "POST",
 ): Promise<void> {
   const response = await requestRemote(client, endpoint, body, method);
   console.log(jsonResponse(response.data));
@@ -634,7 +651,7 @@ async function requestRemote<T = unknown>(
   client: AgentInboxClient,
   endpoint: string,
   body?: unknown,
-  method: "GET" | "POST" | "DELETE" = "POST",
+  method: "GET" | "POST" | "DELETE" | "PATCH" = "POST",
 ): Promise<{ data: T }> {
   const response = await client.request<T>(endpoint, body, method);
   if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -811,6 +828,7 @@ Usage:
   agentinbox source add <type> <sourceKey> [--config-json JSON] [--config-ref REF]
   agentinbox source list
   agentinbox source show <sourceId>
+  agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF]
   agentinbox source remove <sourceId>
   agentinbox source pause <remoteSourceId>
   agentinbox source resume <remoteSourceId>

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,7 @@ export class AgentInboxClient {
   async request<T = unknown>(
     endpoint: string,
     body?: unknown,
-    method: "GET" | "POST" | "DELETE" = "POST",
+    method: "GET" | "POST" | "DELETE" | "PATCH" = "POST",
   ): Promise<AgentInboxResponse<T>> {
     if (this.transport.kind === "socket") {
       return requestViaSocket<T>(this.transport.socketPath, endpoint, body, method);
@@ -46,7 +46,7 @@ function requestViaSocket<T>(
   socketPath: string,
   endpoint: string,
   body: unknown,
-  method: "GET" | "POST" | "DELETE",
+  method: "GET" | "POST" | "DELETE" | "PATCH",
 ): Promise<AgentInboxResponse<T>> {
   return new Promise((resolve, reject) => {
     const payload = body ? JSON.stringify(body) : undefined;
@@ -78,7 +78,7 @@ function requestViaUrl<T>(
   baseUrl: string,
   endpoint: string,
   body: unknown,
-  method: "GET" | "POST" | "DELETE",
+  method: "GET" | "POST" | "DELETE" | "PATCH",
 ): Promise<AgentInboxResponse<T>> {
   return new Promise((resolve, reject) => {
     const url = new URL(normalizeEndpoint(endpoint), baseUrl);

--- a/src/http.ts
+++ b/src/http.ts
@@ -128,7 +128,7 @@ function buildFastifyServer(service: AgentInboxService) {
         properties: {
           sourceType: { type: "string", minLength: 1 },
           sourceKey: { type: "string", minLength: 1 },
-          configRef: { type: "string" },
+          configRef: { anyOf: [{ type: "string" }, { type: "null" }] },
           config: jsonObjectSchema,
         },
       },
@@ -194,7 +194,7 @@ function buildFastifyServer(service: AgentInboxService) {
         additionalProperties: false,
         minProperties: 1,
         properties: {
-          configRef: { type: "string" },
+          configRef: { anyOf: [{ type: "string" }, { type: "null" }] },
           config: jsonObjectSchema,
         },
       },

--- a/src/http.ts
+++ b/src/http.ts
@@ -179,6 +179,35 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.removeSource(decodeURIComponent(params.sourceId));
   });
 
+  app.patch("/sources/:sourceId", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        minProperties: 1,
+        properties: {
+          configRef: { type: "string" },
+          config: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    return service.updateSource(decodeURIComponent(params.sourceId), request.body as never);
+  });
+
   app.post("/sources/:sourceId/pause", {
     schema: {
       tags: ["sources"],

--- a/src/model.ts
+++ b/src/model.ts
@@ -175,6 +175,11 @@ export interface RegisterSourceInput {
   config?: Record<string, unknown>;
 }
 
+export interface UpdateSourceInput {
+  configRef?: string | null;
+  config?: Record<string, unknown>;
+}
+
 export interface RegisterAgentInput {
   agentId?: string | null;
   forceRebind?: boolean;

--- a/src/service.ts
+++ b/src/service.ts
@@ -22,6 +22,7 @@ import {
   SubscriptionPollResult,
   SubscriptionSource,
   TerminalActivationTarget,
+  UpdateSourceInput,
   WatchInboxOptions,
   WebhookActivationTarget,
 } from "./model";
@@ -207,6 +208,49 @@ export class AgentInboxService {
     await this.adapters.removeSource(source);
     this.store.deleteSource(sourceId);
     return { removed: true };
+  }
+
+  async updateSource(sourceId: string, input: UpdateSourceInput): Promise<{ updated: boolean; source: SubscriptionSource | null }> {
+    const source = this.store.getSource(sourceId);
+    if (!source) {
+      return { updated: false, source: null };
+    }
+    if (input.configRef == null && input.config == null) {
+      throw new Error("source update requires --config-json and/or --config-ref");
+    }
+
+    const previous = {
+      configRef: source.configRef ?? null,
+      config: source.config ?? {},
+      status: source.status,
+      checkpoint: source.checkpoint ?? null,
+    };
+
+    const updated = this.store.updateSourceDefinition(sourceId, {
+      configRef: input.configRef ?? previous.configRef,
+      config: input.config ?? previous.config,
+    });
+
+    if (updated.status !== "paused") {
+      try {
+        await this.adapters.sourceAdapterFor(updated.sourceType).ensureSource(updated);
+      } catch (error) {
+        this.store.updateSourceDefinition(sourceId, {
+          configRef: previous.configRef,
+          config: previous.config,
+        });
+        this.store.updateSourceRuntime(sourceId, {
+          status: previous.status,
+          checkpoint: previous.checkpoint,
+        });
+        throw error;
+      }
+    }
+
+    return {
+      updated: true,
+      source: this.getSource(sourceId),
+    };
   }
 
   async pauseSource(sourceId: string): Promise<{ paused: boolean; source: SubscriptionSource | null }> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -215,8 +215,10 @@ export class AgentInboxService {
     if (!source) {
       return { updated: false, source: null };
     }
-    if (input.configRef == null && input.config == null) {
-      throw new Error("source update requires --config-json and/or --config-ref");
+    const hasConfigRef = Object.prototype.hasOwnProperty.call(input, "configRef");
+    const hasConfig = Object.prototype.hasOwnProperty.call(input, "config");
+    if (!hasConfigRef && !hasConfig) {
+      throw new Error("source update requires configRef and/or config");
     }
 
     const previous = {
@@ -227,24 +229,26 @@ export class AgentInboxService {
     };
 
     const updated = this.store.updateSourceDefinition(sourceId, {
-      configRef: input.configRef ?? previous.configRef,
-      config: input.config ?? previous.config,
+      ...(hasConfigRef ? { configRef: input.configRef ?? null } : {}),
+      ...(hasConfig ? { config: input.config ?? {} } : {}),
     });
 
-    if (updated.status !== "paused") {
-      try {
+    try {
+      if (updated.status === "paused") {
+        await this.adapters.sourceAdapterFor(updated.sourceType).validateSource?.(updated);
+      } else {
         await this.adapters.sourceAdapterFor(updated.sourceType).ensureSource(updated);
-      } catch (error) {
-        this.store.updateSourceDefinition(sourceId, {
-          configRef: previous.configRef,
-          config: previous.config,
-        });
-        this.store.updateSourceRuntime(sourceId, {
-          status: previous.status,
-          checkpoint: previous.checkpoint,
-        });
-        throw error;
       }
+    } catch (error) {
+      this.store.updateSourceDefinition(sourceId, {
+        configRef: previous.configRef,
+        config: previous.config,
+      });
+      this.store.updateSourceRuntime(sourceId, {
+        status: previous.status,
+        checkpoint: previous.checkpoint,
+      });
+      throw error;
     }
 
     return {

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -113,6 +113,16 @@ export class RemoteSourceRuntime {
     await this.syncSource(source.sourceId, true);
   }
 
+  async validateSource(source: SubscriptionSource): Promise<void> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return;
+    }
+    const profile = await this.profileRegistry.resolve(source, this.homeDir);
+    const profileSource = profileInputSource(source);
+    profile.validateConfig(profileSource);
+    profile.buildManagedSourceSpec(profileSource);
+  }
+
   async start(): Promise<void> {
     if (this.interval) {
       return;

--- a/src/store.ts
+++ b/src/store.ts
@@ -275,8 +275,8 @@ export class AgentInboxStore {
       where source_id = ?
     `,
       [
-        input.configRef ?? current.configRef ?? null,
-        JSON.stringify(input.config ?? current.config ?? {}),
+        Object.prototype.hasOwnProperty.call(input, "configRef") ? input.configRef ?? null : current.configRef ?? null,
+        JSON.stringify(Object.prototype.hasOwnProperty.call(input, "config") ? input.config ?? {} : current.config ?? {}),
         nowIso(),
         sourceId,
       ],

--- a/src/store.ts
+++ b/src/store.ts
@@ -260,6 +260,31 @@ export class AgentInboxStore {
     return rows.map((row) => this.mapSource(row));
   }
 
+  updateSourceDefinition(
+    sourceId: string,
+    input: { configRef?: string | null; config?: Record<string, unknown> },
+  ): SubscriptionSource {
+    const current = this.getSource(sourceId);
+    if (!current) {
+      throw new Error(`unknown source: ${sourceId}`);
+    }
+    this.db.run(
+      `
+      update sources
+      set config_ref = ?, config_json = ?, updated_at = ?
+      where source_id = ?
+    `,
+      [
+        input.configRef ?? current.configRef ?? null,
+        JSON.stringify(input.config ?? current.config ?? {}),
+        nowIso(),
+        sourceId,
+      ],
+    );
+    this.persist();
+    return this.getSource(sourceId)!;
+  }
+
   updateSourceRuntime(
     sourceId: string,
     input: { status?: SubscriptionSource["status"]; checkpoint?: string | null },
@@ -275,8 +300,8 @@ export class AgentInboxStore {
       where source_id = ?
     `,
       [
-        input.status ?? current.status,
-        input.checkpoint ?? current.checkpoint ?? null,
+        Object.prototype.hasOwnProperty.call(input, "status") ? input.status ?? current.status : current.status,
+        Object.prototype.hasOwnProperty.call(input, "checkpoint") ? input.checkpoint ?? null : current.checkpoint ?? null,
         nowIso(),
         sourceId,
       ],

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -500,6 +500,12 @@ test("updateSource preserves source identity and existing subscriptions", async 
     assert.deepEqual(updated.source?.config, { channel: "infra", enabled: false });
     assert.equal(store.listSubscriptionsForSource(source.sourceId).length, 1);
     assert.equal(store.listSubscriptionsForSource(source.sourceId)[0]?.subscriptionId, subscription.subscriptionId);
+
+    const clearedRef = await service.updateSource(source.sourceId, {
+      configRef: null,
+    });
+    assert.equal(clearedRef.updated, true);
+    assert.equal(clearedRef.source?.configRef, null);
   } finally {
     await service.stop();
     store.close();

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -467,6 +467,46 @@ test("removeSource rejects when source still has subscriptions", async () => {
   }
 });
 
+test("updateSource preserves source identity and existing subscriptions", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "update-source-demo",
+      configRef: "config://before",
+      config: { channel: "engineering", enabled: true },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "update-source-thread",
+      tmuxPaneId: "%910",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    const updated = await service.updateSource(source.sourceId, {
+      configRef: "config://after",
+      config: { channel: "infra", enabled: false },
+    });
+
+    assert.equal(updated.updated, true);
+    assert.equal(updated.source?.sourceId, source.sourceId);
+    assert.equal(updated.source?.sourceKey, source.sourceKey);
+    assert.equal(updated.source?.configRef, "config://after");
+    assert.deepEqual(updated.source?.config, { channel: "infra", enabled: false });
+    assert.equal(store.listSubscriptionsForSource(source.sourceId).length, 1);
+    assert.equal(store.listSubscriptionsForSource(source.sourceId)[0]?.subscriptionId, subscription.subscriptionId);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("subscription remove deletes the subscription, its consumer, and transient runtime state", async () => {
   const dispatcher = new RecordingActivationDispatcher();
   const terminalDispatcher = new RecordingTerminalDispatcher();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -498,6 +498,63 @@ test("control plane pause and resume endpoints update source lifecycle", async (
   }
 });
 
+test("control plane can update source config while preserving source identity", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-source-update-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    await adapters.start();
+    await service.start();
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const sourceResponse = await client.request<{ sourceId: string }>("/sources", {
+        sourceType: "local_event",
+        sourceKey: "http-update-demo",
+        configRef: "config://before",
+        config: {
+          channel: "engineering",
+        },
+      });
+      assert.equal(sourceResponse.statusCode, 200);
+      const sourceId = sourceResponse.data.sourceId;
+
+      const updated = await client.request<{ updated: boolean; source: { sourceId: string; configRef: string; config: { channel: string } } }>(
+        `/sources/${encodeURIComponent(sourceId)}`,
+        {
+          configRef: "config://after",
+          config: {
+            channel: "infra",
+          },
+        },
+        "PATCH",
+      );
+      assert.equal(updated.statusCode, 200);
+      assert.equal(updated.data.updated, true);
+      assert.equal(updated.data.source.sourceId, sourceId);
+      assert.equal(updated.data.source.configRef, "config://after");
+      assert.deepEqual(updated.data.source.config, { channel: "infra" });
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli resolves current agent, auto-registers session workflows, and warns on cross-session targets", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-current-"));
   const envBase = {
@@ -691,6 +748,56 @@ test("cli source pause rejects unsupported local_event sources", () => {
     const resumed = runCli(["source", "resume", source.sourceId], env);
     assert.notEqual(resumed.status, 0);
     assert.match(resumed.stderr, /source type local_event does not support resume/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli source update patches config in place", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-update-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+  };
+
+  try {
+    const sourceAdd = runCli([
+      "source",
+      "add",
+      "local_event",
+      "cli-update-demo",
+      "--config-json",
+      "{\"channel\":\"engineering\"}",
+    ], env);
+    assert.equal(sourceAdd.status, 0, sourceAdd.stderr);
+    const source = JSON.parse(sourceAdd.stdout) as { sourceId: string };
+
+    const updated = runCli([
+      "source",
+      "update",
+      source.sourceId,
+      "--config-json",
+      "{\"channel\":\"infra\"}",
+      "--config-ref",
+      "config://cli-update",
+    ], env);
+    assert.equal(updated.status, 0, updated.stderr);
+    const updatedPayload = JSON.parse(updated.stdout) as {
+      updated: boolean;
+      source: {
+        sourceId: string;
+        configRef: string;
+        config: { channel: string };
+      };
+    };
+    assert.equal(updatedPayload.updated, true);
+    assert.equal(updatedPayload.source.sourceId, source.sourceId);
+    assert.equal(updatedPayload.source.configRef, "config://cli-update");
+    assert.deepEqual(updatedPayload.source.config, { channel: "infra" });
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -544,6 +544,17 @@ test("control plane can update source config while preserving source identity", 
       assert.equal(updated.data.source.sourceId, sourceId);
       assert.equal(updated.data.source.configRef, "config://after");
       assert.deepEqual(updated.data.source.config, { channel: "infra" });
+
+      const cleared = await client.request<{ updated: boolean; source: { configRef: string | null } }>(
+        `/sources/${encodeURIComponent(sourceId)}`,
+        {
+          configRef: null,
+        },
+        "PATCH",
+      );
+      assert.equal(cleared.statusCode, 200);
+      assert.equal(cleared.data.updated, true);
+      assert.equal(cleared.data.source.configRef, null);
     } finally {
       await started.close();
     }
@@ -798,6 +809,22 @@ test("cli source update patches config in place", () => {
     assert.equal(updatedPayload.source.sourceId, source.sourceId);
     assert.equal(updatedPayload.source.configRef, "config://cli-update");
     assert.deepEqual(updatedPayload.source.config, { channel: "infra" });
+
+    const clearedRef = runCli([
+      "source",
+      "update",
+      source.sourceId,
+      "--clear-config-ref",
+    ], env);
+    assert.equal(clearedRef.status, 0, clearedRef.stderr);
+    const clearedPayload = JSON.parse(clearedRef.stdout) as {
+      updated: boolean;
+      source: {
+        configRef: string | null;
+      };
+    };
+    assert.equal(clearedPayload.updated, true);
+    assert.equal(clearedPayload.source.configRef, null);
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -396,3 +396,75 @@ test("pauseSource stops managed source, preserves binding, and resume re-ensures
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("updateSource re-ensures active remote sources but does not resume paused ones", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "demo-update.mjs"),
+      `export default {
+  id: "demo.update",
+  validateConfig(source) {
+    if (!source.config?.tenant) throw new Error("tenant required");
+  },
+  buildManagedSourceSpec(source) {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      args: { tenant: source.config.tenant },
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return { sourceNativeId: "demo:" + raw.id, eventVariant: "demo.event", metadata: {}, rawPayload: raw };
+  }
+};`,
+      "utf8",
+    );
+
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "update-key",
+      config: {
+        profilePath: "demo-update.mjs",
+        profileConfig: { tenant: "team-a" },
+      },
+    });
+
+    assert.equal(fake.ensuredSources.length, 1);
+
+    const updatedActive = await service.updateSource(source.sourceId, {
+      config: {
+        profilePath: "demo-update.mjs",
+        profileConfig: { tenant: "team-b" },
+      },
+    });
+    assert.equal(updatedActive.updated, true);
+    assert.equal(updatedActive.source?.status, "active");
+    assert.equal(fake.ensuredSources.length, 2);
+
+    await service.pauseSource(source.sourceId);
+    const ensureCountBeforePausedUpdate = fake.ensuredSources.length;
+    const updatedPaused = await service.updateSource(source.sourceId, {
+      config: {
+        profilePath: "demo-update.mjs",
+        profileConfig: { tenant: "team-c" },
+      },
+    });
+    assert.equal(updatedPaused.updated, true);
+    assert.equal(updatedPaused.source?.status, "paused");
+    assert.equal(fake.ensuredSources.length, ensureCountBeforePausedUpdate);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -462,6 +462,18 @@ test("updateSource re-ensures active remote sources but does not resume paused o
     assert.equal(updatedPaused.updated, true);
     assert.equal(updatedPaused.source?.status, "paused");
     assert.equal(fake.ensuredSources.length, ensureCountBeforePausedUpdate);
+
+    await assert.rejects(
+      service.updateSource(source.sourceId, {
+        config: {
+          profilePath: "demo-update.mjs",
+          profileConfig: {},
+        },
+      }),
+      /tenant required/,
+    );
+    assert.equal(service.getSource(source.sourceId).status, "paused");
+    assert.equal(fake.ensuredSources.length, ensureCountBeforePausedUpdate);
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
## Summary
- add in-place source config updates through service, store, HTTP PATCH, and CLI `source update`
- preserve source identity and attached subscriptions while re-ensuring active/error sources and leaving paused sources paused
- document the new update flow and add regression coverage for service, remote runtime, control plane, and CLI behavior

Closes #44

## Testing
- npm run build
- npm test