### PR TITLE
fix: reject empty explicit subscription filters

### DIFF
--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -71,7 +71,8 @@ agentinbox subscription reset <subscription_id> --start-policy latest
 
 `subscription add` accepts exactly one of `--filter-json`, `--filter-file`, or
 `--filter-stdin`. The created subscription response echoes the normalized
-persisted `filter`.
+persisted `filter`. When `--filter-file` or `--filter-stdin` is selected, the
+supplied payload must be a non-empty JSON object.
 
 ## Inbox
 

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -71,8 +71,9 @@ agentinbox subscription reset <subscription_id> --start-policy latest
 
 `subscription add` accepts exactly one of `--filter-json`, `--filter-file`, or
 `--filter-stdin`. The created subscription response echoes the normalized
-persisted `filter`. When `--filter-file` or `--filter-stdin` is selected, the
-supplied payload must be a non-empty JSON object.
+persisted `filter`. When any explicit filter input mode is selected
+(`--filter-json`, `--filter-file`, or `--filter-stdin`), the supplied payload
+must be a non-empty JSON object.
 
 ## Inbox
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -728,11 +728,15 @@ function readSubscriptionFilter(args: string[]): Record<string, unknown> {
     return parseJsonArg(filterJson, "--filter-json");
   }
   if (filterFile != null) {
-    return parseJsonArg(fs.readFileSync(filterFile, "utf8"), `filter file ${filterFile}`);
+    return parseJsonArg(fs.readFileSync(filterFile, "utf8"), `filter file ${filterFile}`, {
+      requireNonEmpty: true,
+    });
   }
   if (filterStdin) {
     const stdin = fs.readFileSync(0, "utf8");
-    return parseJsonArg(stdin, "stdin filter");
+    return parseJsonArg(stdin, "stdin filter", {
+      requireNonEmpty: true,
+    });
   }
   return {};
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -725,17 +725,19 @@ function readSubscriptionFilter(args: string[]): Record<string, unknown> {
     throw new Error("subscription add accepts only one of --filter-json, --filter-file, or --filter-stdin");
   }
   if (filterJson != null) {
-    return parseJsonArg(filterJson, "--filter-json");
+    return parseJsonArg(filterJson, "--filter-json", {
+      requireNonEmptyObject: true,
+    });
   }
   if (filterFile != null) {
     return parseJsonArg(fs.readFileSync(filterFile, "utf8"), `filter file ${filterFile}`, {
-      requireNonEmpty: true,
+      requireNonEmptyObject: true,
     });
   }
   if (filterStdin) {
     const stdin = fs.readFileSync(0, "utf8");
     return parseJsonArg(stdin, "stdin filter", {
-      requireNonEmpty: true,
+      requireNonEmptyObject: true,
     });
   }
   return {};

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,9 +8,21 @@ export function generateId(prefix: string): string {
   return `${prefix}_${crypto.randomUUID()}`;
 }
 
-export function parseJsonArg(raw?: string, source = "JSON argument"): Record<string, unknown> {
+export function parseJsonArg(
+  raw?: string,
+  source = "JSON argument",
+  options?: {
+    requireNonEmpty?: boolean;
+  },
+): Record<string, unknown> {
   if (!raw) {
+    if (options?.requireNonEmpty) {
+      throw new Error(`invalid ${source}: expected a non-empty JSON object`);
+    }
     return {};
+  }
+  if (options?.requireNonEmpty && raw.trim() === "") {
+    throw new Error(`invalid ${source}: expected a non-empty JSON object`);
   }
   let parsed: unknown;
   try {

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,16 +12,16 @@ export function parseJsonArg(
   raw?: string,
   source = "JSON argument",
   options?: {
-    requireNonEmpty?: boolean;
+    requireNonEmptyObject?: boolean;
   },
 ): Record<string, unknown> {
   if (!raw) {
-    if (options?.requireNonEmpty) {
+    if (options?.requireNonEmptyObject) {
       throw new Error(`invalid ${source}: expected a non-empty JSON object`);
     }
     return {};
   }
-  if (options?.requireNonEmpty && raw.trim() === "") {
+  if (options?.requireNonEmptyObject && raw.trim() === "") {
     throw new Error(`invalid ${source}: expected a non-empty JSON object`);
   }
   let parsed: unknown;
@@ -33,6 +33,9 @@ export function parseJsonArg(
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(`expected ${source} to be a JSON object`);
+  }
+  if (options?.requireNonEmptyObject && Object.keys(parsed as Record<string, unknown>).length === 0) {
+    throw new Error(`invalid ${source}: expected a non-empty JSON object`);
   }
   return parsed as Record<string, unknown>;
 }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -731,6 +731,27 @@ test("cli subscription add accepts filter-file and filter-stdin and echoes norma
     ], env);
     assert.notEqual(conflicting.status, 0);
     assert.match(conflicting.stderr, /only one of --filter-json, --filter-file, or --filter-stdin/);
+
+    const emptyFilePath = path.join(homeDir, "empty-filter.json");
+    fs.writeFileSync(emptyFilePath, "");
+    const emptyFile = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--filter-file",
+      emptyFilePath,
+    ], env);
+    assert.notEqual(emptyFile.status, 0);
+    assert.match(emptyFile.stderr, /invalid filter file .*empty-filter\.json: expected a non-empty JSON object/);
+
+    const emptyStdin = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--filter-stdin",
+    ], env, 25_000, "");
+    assert.notEqual(emptyStdin.status, 0);
+    assert.match(emptyStdin.stderr, /invalid stdin filter: expected a non-empty JSON object/);
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -732,6 +732,16 @@ test("cli subscription add accepts filter-file and filter-stdin and echoes norma
     assert.notEqual(conflicting.status, 0);
     assert.match(conflicting.stderr, /only one of --filter-json, --filter-file, or --filter-stdin/);
 
+    const emptyObjectJson = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--filter-json",
+      "{}",
+    ], env);
+    assert.notEqual(emptyObjectJson.status, 0);
+    assert.match(emptyObjectJson.stderr, /invalid --filter-json: expected a non-empty JSON object/);
+
     const emptyFilePath = path.join(homeDir, "empty-filter.json");
     fs.writeFileSync(emptyFilePath, "");
     const emptyFile = runCli([
@@ -744,6 +754,18 @@ test("cli subscription add accepts filter-file and filter-stdin and echoes norma
     assert.notEqual(emptyFile.status, 0);
     assert.match(emptyFile.stderr, /invalid filter file .*empty-filter\.json: expected a non-empty JSON object/);
 
+    const emptyObjectFilePath = path.join(homeDir, "empty-object-filter.json");
+    fs.writeFileSync(emptyObjectFilePath, "{}");
+    const emptyObjectFile = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--filter-file",
+      emptyObjectFilePath,
+    ], env);
+    assert.notEqual(emptyObjectFile.status, 0);
+    assert.match(emptyObjectFile.stderr, /invalid filter file .*empty-object-filter\.json: expected a non-empty JSON object/);
+
     const emptyStdin = runCli([
       "subscription",
       "add",
@@ -752,6 +774,15 @@ test("cli subscription add accepts filter-file and filter-stdin and echoes norma
     ], env, 25_000, "");
     assert.notEqual(emptyStdin.status, 0);
     assert.match(emptyStdin.stderr, /invalid stdin filter: expected a non-empty JSON object/);
+
+    const emptyObjectStdin = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--filter-stdin",
+    ], env, 25_000, "{}");
+    assert.notEqual(emptyObjectStdin.status, 0);
+    assert.match(emptyObjectStdin.stderr, /invalid stdin filter: expected a non-empty JSON object/);
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- reject empty explicit filter payloads for `--filter-file` and `--filter-stdin` instead of silently normalizing them to `{}`
- keep the no-filter default unchanged, so omitting filter flags still means an empty filter object
- add CLI regression coverage and document the explicit-input requirement

Closes #46

## Testing
- npm run build
- npm test