### PR TITLE
fix: reject unsupported inbox read flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -352,7 +352,8 @@ async function main(): Promise<void> {
 
   if (command === "inbox" && normalized[1] === "read") {
     const args = normalized.slice(2);
-    if (positionalArgs(args, ["--agent-id", "--after-item"]).length > 0) {
+    const allowedFlags = ["--agent-id", "--after-item", "--include-acked"];
+    if (positionalArgs(args, ["--agent-id", "--after-item"]).length > 0 || unexpectedFlags(args, allowedFlags).length > 0) {
       throw new Error("usage: agentinbox inbox read [--agent-id ID] [--after-item ID] [--include-acked]");
     }
     const selection = await selectAgentForCommand(client, {
@@ -794,6 +795,11 @@ function positionalArgs(args: string[], flagsWithValues: string[]): string[] {
     positionals.push(token);
   }
   return positionals;
+}
+
+function unexpectedFlags(args: string[], allowedFlags: string[]): string[] {
+  const allowed = new Set(allowedFlags);
+  return args.filter((token) => token.startsWith("--") && !allowed.has(token));
 }
 
 function printHelp(path: string[] = []): void {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -630,6 +630,28 @@ test("cli resolves current agent, auto-registers session workflows, and warns on
   }
 });
 
+test("cli inbox read rejects unsupported flags like --ack", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-read-flags-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%941",
+    CODEX_THREAD_ID: "thread-read-flags",
+  };
+
+  try {
+    const read = runCli(["inbox", "read", "--ack"], env);
+    assert.notEqual(read.status, 0);
+    assert.match(read.stderr, /usage: agentinbox inbox read \[--agent-id ID] \[--after-item ID] \[--include-acked]/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli subscription add accepts filter-file and filter-stdin and echoes normalized filter", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-filter-"));
   const env = {


### PR DESCRIPTION
## Summary
- reject unsupported flags for `agentinbox inbox read` so `--ack` fails fast instead of being silently ignored
- keep inbox acknowledgement explicit via `inbox ack`, matching the current product boundary
- add a CLI regression test for the unsupported-flag case

## Verification
- npm run build
- manual check: `node -r ts-node/register src/cli.ts inbox read --ack` exits non-zero and prints usage

Closes #61
