### PR TITLE
feat: add resolved source identity and instance schema

### DIFF
--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -43,7 +43,7 @@ agentinbox source update <source_id> [--config-json ...] [--config-ref ...]
 agentinbox source remove <source_id>
 agentinbox source pause <remote_source_id>
 agentinbox source resume <remote_source_id>
-agentinbox source schema <source_type>
+agentinbox source schema <source_id|source_type>
 agentinbox source poll <source_id>
 agentinbox source event <source_id> --native-id <id> --event <variant>
 ```

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -20,6 +20,7 @@ going forward.
 - `GET /sources`
 - `POST /sources`
 - `GET /sources/{sourceId}`
+- `GET /sources/{sourceId}/schema`
 - `PATCH /sources/{sourceId}`
 - `DELETE /sources/{sourceId}`
 - `POST /sources/{sourceId}/pause`

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -2,15 +2,19 @@ import {
   AppendSourceEventInput,
   DeliveryAttempt,
   DeliveryRequest,
+  ResolvedSourceIdentity,
+  ResolvedSourceSchema,
   SourcePollResult,
   SourceType,
   SubscriptionSource,
 } from "./model";
 import { AgentInboxStore } from "./store";
+import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubDeliveryAdapter } from "./sources/github";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
 import { RemoteSourceProfileRegistry } from "./sources/remote_profiles";
+import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
 
 export interface SourceAdapter {
   ensureSource(source: SubscriptionSource): Promise<void>;
@@ -64,6 +68,8 @@ export class AdapterRegistry {
   private readonly defaultDelivery = new NoopDeliveryAdapter();
   private readonly feishuDelivery = new FeishuDeliveryAdapter();
   private readonly githubDelivery = new GithubDeliveryAdapter();
+  private readonly homeDir: string;
+  private readonly remoteProfileRegistry: RemoteSourceProfileRegistry;
 
   constructor(
     store: AgentInboxStore,
@@ -74,10 +80,12 @@ export class AdapterRegistry {
       remoteProfileRegistry?: RemoteSourceProfileRegistry;
     },
   ) {
+    this.homeDir = options?.homeDir ?? resolveAgentInboxHome(process.env);
+    this.remoteProfileRegistry = options?.remoteProfileRegistry ?? new RemoteSourceProfileRegistry();
     this.remoteSource = new RemoteSourceRuntime(store, appendSourceEvent, {
-      homeDir: options?.homeDir,
+      homeDir: this.homeDir,
       client: options?.remoteSourceClient,
-      profileRegistry: options?.remoteProfileRegistry,
+      profileRegistry: this.remoteProfileRegistry,
     });
   }
 
@@ -152,6 +160,20 @@ export class AdapterRegistry {
   async removeSource(source: SubscriptionSource): Promise<void> {
     const adapter = this.sourceAdapterFor(source.sourceType);
     await adapter.removeSource?.(source.sourceId);
+  }
+
+  async resolveSourceIdentity(source: SubscriptionSource): Promise<ResolvedSourceIdentity> {
+    return resolveSourceIdentity(source, {
+      homeDir: this.homeDir,
+      profileRegistry: this.remoteProfileRegistry,
+    });
+  }
+
+  async resolveSourceSchema(source: SubscriptionSource): Promise<ResolvedSourceSchema> {
+    return resolveSourceSchema(source, {
+      homeDir: this.homeDir,
+      profileRegistry: this.remoteProfileRegistry,
+    });
   }
 
   status(): Record<string, unknown> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,11 +142,15 @@ async function main(): Promise<void> {
   }
 
   if (command === "source" && normalized[1] === "schema") {
-    const sourceType = normalized[2];
-    if (!sourceType) {
-      throw new Error("usage: agentinbox source schema <sourceType>");
+    const sourceRef = normalized[2];
+    if (!sourceRef) {
+      throw new Error("usage: agentinbox source schema <sourceId|sourceType>");
     }
-    await printRemote(client, `/source-types/${encodeURIComponent(sourceType)}/schema`, undefined, "GET");
+    if (sourceRef.startsWith("src_")) {
+      await printRemote(client, `/sources/${encodeURIComponent(sourceRef)}/schema`, undefined, "GET");
+      return;
+    }
+    await printRemote(client, `/source-types/${encodeURIComponent(sourceRef)}/schema`, undefined, "GET");
     return;
   }
 
@@ -848,7 +852,7 @@ Usage:
   agentinbox source remove <sourceId>
   agentinbox source pause <remoteSourceId>
   agentinbox source resume <remoteSourceId>
-  agentinbox source schema <sourceType>
+  agentinbox source schema <sourceId|sourceType>
   agentinbox source poll <sourceId>
   agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]
 `,

--- a/src/http.ts
+++ b/src/http.ts
@@ -159,6 +159,27 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.getSourceDetails(decodeURIComponent(params.sourceId));
   });
 
+  app.get("/sources/:sourceId/schema", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    return service.getResolvedSourceSchema(decodeURIComponent(params.sourceId));
+  });
+
   app.delete("/sources/:sourceId", {
     schema: {
       tags: ["sources"],

--- a/src/model.ts
+++ b/src/model.ts
@@ -232,6 +232,16 @@ export interface SourceSchema {
   configFields: SourceSchemaField[];
 }
 
+export interface ResolvedSourceIdentity {
+  hostType: "local_event" | "remote_source";
+  sourceKind: string;
+  implementationId: string;
+}
+
+export interface ResolvedSourceSchema extends SourceSchema, ResolvedSourceIdentity {
+  sourceId: string;
+}
+
 export interface AppendSourceEventInput {
   sourceId: string;
   sourceNativeId: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,6 +16,8 @@ import {
   RegisterAgentResult,
   RegisterSourceInput,
   RegisterSubscriptionInput,
+  ResolvedSourceIdentity,
+  ResolvedSourceSchema,
   SourceSchema,
   SourcePollResult,
   Subscription,
@@ -38,6 +40,7 @@ import {
 } from "./backend";
 import { generateId, nowIso } from "./util";
 import { getSourceSchema } from "./source_schema";
+import { withResolvedIdentity } from "./source_resolution";
 import { matchSubscriptionFilter, validateSubscriptionFilter } from "./filter";
 import { assignedAgentIdFromContext, detectTerminalContext, renderAgentPrompt, TerminalDispatcher } from "./terminal";
 
@@ -182,11 +185,23 @@ export class AgentInboxService {
     return source;
   }
 
-  getSourceDetails(sourceId: string): Record<string, unknown> {
+  async getSourceDetails(sourceId: string): Promise<Record<string, unknown>> {
     const source = this.getSource(sourceId);
+    const fallbackSchema = getSourceSchema(source.sourceType);
+    let resolvedIdentity: ResolvedSourceIdentity | null = null;
+    let resolutionError: string | null = null;
+    try {
+      resolvedIdentity = await this.adapters.resolveSourceIdentity(source);
+    } catch (error) {
+      resolutionError = error instanceof Error ? error.message : String(error);
+    }
     return {
       source,
-      schema: getSourceSchema(source.sourceType),
+      resolvedIdentity,
+      ...(resolutionError ? { resolutionError } : {}),
+      schema: resolvedIdentity
+        ? withResolvedIdentity(source.sourceId, fallbackSchema, resolvedIdentity)
+        : fallbackSchema,
       stream: this.store.getStreamBySourceId(sourceId),
       subscriptions: this.store.listSubscriptionsForSource(sourceId),
     };
@@ -194,6 +209,11 @@ export class AgentInboxService {
 
   getSourceSchema(sourceType: SubscriptionSource["sourceType"]): SourceSchema {
     return getSourceSchema(sourceType);
+  }
+
+  async getResolvedSourceSchema(sourceId: string): Promise<ResolvedSourceSchema> {
+    const source = this.getSource(sourceId);
+    return this.adapters.resolveSourceSchema(source);
   }
 
   async removeSource(sourceId: string): Promise<{ removed: boolean }> {

--- a/src/source_resolution.ts
+++ b/src/source_resolution.ts
@@ -1,0 +1,70 @@
+import { resolveAgentInboxHome } from "./paths";
+import { ResolvedSourceIdentity, ResolvedSourceSchema, SourceSchema, SubscriptionSource } from "./model";
+import { RemoteSourceProfileRegistry, builtInProfileIdForSourceType } from "./sources/remote_profiles";
+import { getSourceSchema } from "./source_schema";
+
+export interface ResolveSourceContext {
+  homeDir?: string;
+  profileRegistry?: RemoteSourceProfileRegistry;
+}
+
+export async function resolveSourceIdentity(
+  source: SubscriptionSource,
+  context: ResolveSourceContext = {},
+): Promise<ResolvedSourceIdentity> {
+  if (source.sourceType === "local_event") {
+    return {
+      hostType: "local_event",
+      sourceKind: "local_event",
+      implementationId: "builtin.local_event",
+    };
+  }
+
+  const builtinImplementationId = builtInProfileIdForSourceType(source.sourceType);
+  if (builtinImplementationId) {
+    return {
+      hostType: "remote_source",
+      sourceKind: source.sourceType,
+      implementationId: builtinImplementationId,
+    };
+  }
+
+  if (source.sourceType !== "remote_source") {
+    throw new Error(`unsupported source type for source resolution: ${source.sourceType}`);
+  }
+
+  const profileRegistry = context.profileRegistry ?? new RemoteSourceProfileRegistry();
+  const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
+  const profile = await profileRegistry.resolve(source, homeDir);
+  return {
+    hostType: "remote_source",
+    sourceKind: `remote:${profile.id}`,
+    implementationId: profile.id,
+  };
+}
+
+export async function resolveSourceSchema(
+  source: SubscriptionSource,
+  context: ResolveSourceContext = {},
+): Promise<ResolvedSourceSchema> {
+  const identity = await resolveSourceIdentity(source, context);
+  return withResolvedIdentity(source.sourceId, getSourceSchema(source.sourceType), identity);
+}
+
+export function withResolvedIdentity(
+  sourceId: string,
+  schema: SourceSchema,
+  identity: ResolvedSourceIdentity,
+): ResolvedSourceSchema {
+  return {
+    sourceId,
+    sourceType: schema.sourceType,
+    metadataFields: schema.metadataFields,
+    payloadExamples: schema.payloadExamples,
+    eventVariantExamples: schema.eventVariantExamples,
+    configFields: schema.configFields,
+    hostType: identity.hostType,
+    sourceKind: identity.sourceKind,
+    implementationId: identity.implementationId,
+  };
+}

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -429,6 +429,65 @@ test("remote_source registration succeeds", async () => {
       },
     });
     assert.equal(source.sourceType, "remote_source");
+
+    const details = await service.getSourceDetails(source.sourceId) as {
+      resolvedIdentity: {
+        hostType: string;
+        sourceKind: string;
+        implementationId: string;
+      };
+      schema: {
+        sourceId: string;
+        hostType: string;
+        sourceKind: string;
+        implementationId: string;
+      };
+    };
+    assert.deepEqual(details.resolvedIdentity, {
+      hostType: "remote_source",
+      sourceKind: "remote:demo.profile",
+      implementationId: "demo.profile",
+    });
+    assert.equal(details.schema.sourceId, source.sourceId);
+    assert.equal(details.schema.hostType, "remote_source");
+    assert.equal(details.schema.sourceKind, "remote:demo.profile");
+    assert.equal(details.schema.implementationId, "demo.profile");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("builtin remote-backed source details expose resolved remote identity", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox" },
+    });
+
+    const details = await service.getSourceDetails(source.sourceId) as {
+      resolvedIdentity: {
+        hostType: string;
+        sourceKind: string;
+        implementationId: string;
+      };
+      schema: {
+        hostType: string;
+        sourceKind: string;
+        implementationId: string;
+      };
+    };
+    assert.deepEqual(details.resolvedIdentity, {
+      hostType: "remote_source",
+      sourceKind: "github_repo",
+      implementationId: "builtin.github_repo",
+    });
+    assert.equal(details.schema.hostType, "remote_source");
+    assert.equal(details.schema.sourceKind, "github_repo");
+    assert.equal(details.schema.implementationId, "builtin.github_repo");
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -650,7 +650,7 @@ test("cli source schema resolves source ids to instance schema", () => {
   };
 
   try {
-    const sourceAdd = runCli(["source", "add", "github_repo_ci", "holon-run/agentinbox-ci", "--config-json", "{\"owner\":\"holon-run\",\"repo\":\"agentinbox\"}"], env);
+    const sourceAdd = runCli(["source", "add", "local_event", "cli-source-schema-demo"], env);
     assert.equal(sourceAdd.status, 0, sourceAdd.stderr);
     const source = JSON.parse(sourceAdd.stdout) as { sourceId: string };
 
@@ -664,10 +664,10 @@ test("cli source schema resolves source ids to instance schema", () => {
       implementationId: string;
     };
     assert.equal(payload.sourceId, source.sourceId);
-    assert.equal(payload.sourceType, "github_repo_ci");
-    assert.equal(payload.hostType, "remote_source");
-    assert.equal(payload.sourceKind, "github_repo_ci");
-    assert.equal(payload.implementationId, "builtin.github_repo_ci");
+    assert.equal(payload.sourceType, "local_event");
+    assert.equal(payload.hostType, "local_event");
+    assert.equal(payload.sourceKind, "local_event");
+    assert.equal(payload.implementationId, "builtin.local_event");
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -98,6 +98,13 @@ test("cli version and help subcommands print text output", () => {
   assert.equal(inboxHelp.status, 0);
   assert.match(helpInbox.stdout, /agentinbox inbox/);
   assert.equal(helpInbox.stdout, inboxHelp.stdout);
+
+  const helpSource = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "help", "source"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  });
+  assert.equal(helpSource.status, 0);
+  assert.match(helpSource.stdout, /agentinbox source schema <sourceId\|sourceType>/);
 });
 
 test("resolveServeConfig derives home, db, and socket defaults from AGENTINBOX_HOME", () => {
@@ -626,6 +633,43 @@ test("cli resolves current agent, auto-registers session workflows, and warns on
     assert.match(oldSyntax.stderr, /usage: agentinbox subscription add <sourceId> \[--agent-id ID]/);
   } finally {
     void runCli(["daemon", "stop"], envBase);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli source schema resolves source ids to instance schema", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-schema-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%936",
+    CODEX_THREAD_ID: "thread-source-schema",
+  };
+
+  try {
+    const sourceAdd = runCli(["source", "add", "github_repo_ci", "holon-run/agentinbox-ci", "--config-json", "{\"owner\":\"holon-run\",\"repo\":\"agentinbox\"}"], env);
+    assert.equal(sourceAdd.status, 0, sourceAdd.stderr);
+    const source = JSON.parse(sourceAdd.stdout) as { sourceId: string };
+
+    const schema = runCli(["source", "schema", source.sourceId], env);
+    assert.equal(schema.status, 0, schema.stderr);
+    const payload = JSON.parse(schema.stdout) as {
+      sourceId: string;
+      sourceType: string;
+      hostType: string;
+      sourceKind: string;
+      implementationId: string;
+    };
+    assert.equal(payload.sourceId, source.sourceId);
+    assert.equal(payload.sourceType, "github_repo_ci");
+    assert.equal(payload.hostType, "remote_source");
+    assert.equal(payload.sourceKind, "github_repo_ci");
+    assert.equal(payload.implementationId, "builtin.github_repo_ci");
+  } finally {
+    void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });
   }
 });
@@ -1414,9 +1458,108 @@ test("control plane accepts remote_source registration", async () => {
         ?? (response.data as { source?: { sourceId?: string } }).source?.sourceId;
       assert.equal(typeof sourceId, "string");
 
+      const details = await client.request<{
+        resolvedIdentity: { hostType: string; sourceKind: string; implementationId: string };
+        schema: { sourceId: string; hostType: string; sourceKind: string; implementationId: string };
+      }>(`/sources/${encodeURIComponent(sourceId!)}`, undefined, "GET");
+      assert.equal(details.statusCode, 200);
+      assert.deepEqual(details.data.resolvedIdentity, {
+        hostType: "remote_source",
+        sourceKind: "remote:demo.control",
+        implementationId: "demo.control",
+      });
+      assert.equal(details.data.schema.sourceId, sourceId);
+      assert.equal(details.data.schema.sourceKind, "remote:demo.control");
+
+      const schema = await client.request<{
+        sourceId: string;
+        sourceType: string;
+        hostType: string;
+        sourceKind: string;
+        implementationId: string;
+      }>(`/sources/${encodeURIComponent(sourceId!)}/schema`, undefined, "GET");
+      assert.equal(schema.statusCode, 200);
+      assert.equal(schema.data.sourceId, sourceId);
+      assert.equal(schema.data.sourceType, "remote_source");
+      assert.equal(schema.data.hostType, "remote_source");
+      assert.equal(schema.data.sourceKind, "remote:demo.control");
+      assert.equal(schema.data.implementationId, "demo.control");
+
       const removed = await client.request<{ removed: boolean }>(`/sources/${encodeURIComponent(sourceId!)}`, undefined, "DELETE");
       assert.equal(removed.statusCode, 200);
       assert.equal(removed.data.removed, true);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane source details degrade when remote_source resolution fails but instance schema reports an error", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-remote-resolve-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const profileDir = path.join(homeDir, "source-profiles");
+  fs.mkdirSync(profileDir, { recursive: true });
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+
+      const sourceId = "src_missing_profile";
+      store.insertSource({
+        sourceId,
+        sourceType: "remote_source",
+        sourceKey: "resolve-demo",
+        configRef: null,
+        config: {
+          profilePath: "missing.mjs",
+          profileConfig: {},
+        },
+        status: "active",
+        checkpoint: null,
+        createdAt: "2026-04-13T00:00:00.000Z",
+        updatedAt: "2026-04-13T00:00:00.000Z",
+      });
+
+      const details = await client.request<{
+        source: { sourceId: string };
+        resolvedIdentity: null;
+        resolutionError: string;
+        schema: { sourceType: string };
+      }>(`/sources/${encodeURIComponent(sourceId)}`, undefined, "GET");
+      assert.equal(details.statusCode, 200);
+      assert.equal(details.data.source.sourceId, sourceId);
+      assert.equal(details.data.resolvedIdentity, null);
+      assert.match(details.data.resolutionError, /remote_source profile not found/);
+      assert.equal(details.data.schema.sourceType, "remote_source");
+
+      const schema = await client.request<{ error: string }>(`/sources/${encodeURIComponent(sourceId)}/schema`, undefined, "GET");
+      assert.equal(schema.statusCode, 400);
+      assert.match(schema.data.error, /remote_source profile not found/);
     } finally {
       await started.close();
     }


### PR DESCRIPTION
## Summary
- add resolved source identity for concrete sources and include it in `source show`
- add an instance-scoped schema API at `GET /sources/{sourceId}/schema`
- route `agentinbox source schema <sourceId|sourceType>` to instance or type schema based on the argument
- keep type-level schema as the secondary catalog surface and document the new API/CLI shape

## Verification
- npm run build
- node --require ts-node/register --test --test-name-pattern="remote_source registration succeeds|builtin remote-backed source details expose resolved remote identity|cli source schema resolves source ids to instance schema|control plane accepts remote_source registration|control plane source details degrade when remote_source resolution fails but instance schema reports an error" test/agentinbox.test.ts test/control_plane.test.ts

Closes #53
