### PR TITLE
feat: add remote module capability hooks

### DIFF
--- a/docs/site/reference/source-types.md
+++ b/docs/site/reference/source-types.md
@@ -20,6 +20,15 @@ It uses a local profile module to define:
 - raw event mapping (`stream.read` payload -> AgentInbox event)
 - config validation
 
+It may also optionally define capability introspection hooks used by resolved
+instance schema discovery:
+
+- `describeCapabilities`
+- `listSubscriptionShortcuts`
+- `expandSubscriptionShortcut`
+- `deriveTrackedResource`
+- `projectLifecycleSignal`
+
 Configuration fields:
 
 - `profilePath` (required): path under `$AGENTINBOX_HOME/source-profiles`

--- a/src/model.ts
+++ b/src/model.ts
@@ -240,6 +240,16 @@ export interface ResolvedSourceIdentity {
 
 export interface ResolvedSourceSchema extends SourceSchema, ResolvedSourceIdentity {
   sourceId: string;
+  aliases?: string[];
+  subscriptionSchema?: {
+    supportsTrackedResourceRef: boolean;
+    supportsLifecycleSignals: boolean;
+    shortcuts: Array<{
+      name: string;
+      description: string;
+      argsSchema?: SourceSchemaField[];
+    }>;
+  };
 }
 
 export interface AppendSourceEventInput {

--- a/src/service.ts
+++ b/src/service.ts
@@ -40,7 +40,6 @@ import {
 } from "./backend";
 import { generateId, nowIso } from "./util";
 import { getSourceSchema } from "./source_schema";
-import { withResolvedIdentity } from "./source_resolution";
 import { matchSubscriptionFilter, validateSubscriptionFilter } from "./filter";
 import { assignedAgentIdFromContext, detectTerminalContext, renderAgentPrompt, TerminalDispatcher } from "./terminal";
 
@@ -190,8 +189,10 @@ export class AgentInboxService {
     const fallbackSchema = getSourceSchema(source.sourceType);
     let resolvedIdentity: ResolvedSourceIdentity | null = null;
     let resolutionError: string | null = null;
+    let schema: SourceSchema | ResolvedSourceSchema = fallbackSchema;
     try {
       resolvedIdentity = await this.adapters.resolveSourceIdentity(source);
+      schema = await this.adapters.resolveSourceSchema(source);
     } catch (error) {
       resolutionError = error instanceof Error ? error.message : String(error);
     }
@@ -200,7 +201,7 @@ export class AgentInboxService {
       resolvedIdentity,
       ...(resolutionError ? { resolutionError } : {}),
       schema: resolvedIdentity
-        ? withResolvedIdentity(source.sourceId, fallbackSchema, resolvedIdentity)
+        ? schema
         : fallbackSchema,
       stream: this.store.getStreamBySourceId(sourceId),
       subscriptions: this.store.listSubscriptionsForSource(sourceId),

--- a/src/service.ts
+++ b/src/service.ts
@@ -40,6 +40,7 @@ import {
 } from "./backend";
 import { generateId, nowIso } from "./util";
 import { getSourceSchema } from "./source_schema";
+import { withResolvedIdentity } from "./source_resolution";
 import { matchSubscriptionFilter, validateSubscriptionFilter } from "./filter";
 import { assignedAgentIdFromContext, detectTerminalContext, renderAgentPrompt, TerminalDispatcher } from "./terminal";
 
@@ -196,13 +197,16 @@ export class AgentInboxService {
     } catch (error) {
       resolutionError = error instanceof Error ? error.message : String(error);
     }
+    const resolvedSchema = resolvedIdentity
+      ? ("hostType" in schema
+        ? schema
+        : withResolvedIdentity(source.sourceId, fallbackSchema, resolvedIdentity))
+      : fallbackSchema;
     return {
       source,
       resolvedIdentity,
       ...(resolutionError ? { resolutionError } : {}),
-      schema: resolvedIdentity
-        ? schema
-        : fallbackSchema,
+      schema: resolvedSchema,
       stream: this.store.getStreamBySourceId(sourceId),
       subscriptions: this.store.listSubscriptionsForSource(sourceId),
     };

--- a/src/source_resolution.ts
+++ b/src/source_resolution.ts
@@ -1,6 +1,6 @@
 import { resolveAgentInboxHome } from "./paths";
 import { ResolvedSourceIdentity, ResolvedSourceSchema, SourceSchema, SubscriptionSource } from "./model";
-import { RemoteSourceProfileRegistry, builtInProfileIdForSourceType } from "./sources/remote_profiles";
+import { RemoteSourceProfile, RemoteSourceProfileRegistry, builtInProfileIdForSourceType, profileConfigForSource } from "./sources/remote_profiles";
 import { getSourceSchema } from "./source_schema";
 
 export interface ResolveSourceContext {
@@ -36,9 +36,10 @@ export async function resolveSourceIdentity(
   const profileRegistry = context.profileRegistry ?? new RemoteSourceProfileRegistry();
   const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
   const profile = await profileRegistry.resolve(source, homeDir);
+  const capabilityDescription = profile.describeCapabilities?.(profileInputSource(source));
   return {
     hostType: "remote_source",
-    sourceKind: `remote:${profile.id}`,
+    sourceKind: capabilityDescription?.sourceKind?.trim() || `remote:${profile.id}`,
     implementationId: profile.id,
   };
 }
@@ -47,14 +48,49 @@ export async function resolveSourceSchema(
   source: SubscriptionSource,
   context: ResolveSourceContext = {},
 ): Promise<ResolvedSourceSchema> {
+  const profileRegistry = context.profileRegistry ?? new RemoteSourceProfileRegistry();
+  const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
   const identity = await resolveSourceIdentity(source, context);
-  return withResolvedIdentity(source.sourceId, getSourceSchema(source.sourceType), identity);
+  const staticSchema = getSourceSchema(source.sourceType);
+  let capabilityDescription: ReturnType<NonNullable<RemoteSourceProfile["describeCapabilities"]>> | undefined;
+  let profile: RemoteSourceProfile | null = null;
+  if (identity.hostType === "remote_source") {
+    profile = await profileRegistry.resolve(source, homeDir);
+    capabilityDescription = profile.describeCapabilities?.(profileInputSource(source));
+  }
+  return withResolvedIdentity(
+    source.sourceId,
+    {
+      sourceType: staticSchema.sourceType,
+      metadataFields: capabilityDescription?.metadataFields ?? staticSchema.metadataFields,
+      payloadExamples: capabilityDescription?.payloadExamples ?? staticSchema.payloadExamples,
+      eventVariantExamples: capabilityDescription?.eventVariantExamples ?? staticSchema.eventVariantExamples,
+      configFields: capabilityDescription?.configSchema ?? staticSchema.configFields,
+    },
+    identity,
+    {
+      aliases: capabilityDescription?.aliases,
+      supportsTrackedResourceRef: Boolean(profile?.deriveTrackedResource),
+      supportsLifecycleSignals: Boolean(profile?.projectLifecycleSignal),
+      shortcuts: profile?.listSubscriptionShortcuts?.(profileInputSource(source)) ?? [],
+    },
+  );
 }
 
 export function withResolvedIdentity(
   sourceId: string,
   schema: SourceSchema,
   identity: ResolvedSourceIdentity,
+  capabilityMetadata?: {
+    aliases?: string[];
+    supportsTrackedResourceRef?: boolean;
+    supportsLifecycleSignals?: boolean;
+    shortcuts?: Array<{
+      name: string;
+      description: string;
+      argsSchema?: SourceSchema["configFields"];
+    }>;
+  },
 ): ResolvedSourceSchema {
   return {
     sourceId,
@@ -66,5 +102,23 @@ export function withResolvedIdentity(
     hostType: identity.hostType,
     sourceKind: identity.sourceKind,
     implementationId: identity.implementationId,
+    ...(capabilityMetadata?.aliases?.length ? { aliases: capabilityMetadata.aliases } : {}),
+    ...(capabilityMetadata ? {
+      subscriptionSchema: {
+        supportsTrackedResourceRef: capabilityMetadata.supportsTrackedResourceRef ?? false,
+        supportsLifecycleSignals: capabilityMetadata.supportsLifecycleSignals ?? false,
+        shortcuts: capabilityMetadata.shortcuts ?? [],
+      },
+    } : {}),
+  };
+}
+
+function profileInputSource(source: SubscriptionSource): SubscriptionSource {
+  if (source.sourceType !== "remote_source") {
+    return source;
+  }
+  return {
+    ...source,
+    config: profileConfigForSource(source),
   };
 }

--- a/src/source_resolution.ts
+++ b/src/source_resolution.ts
@@ -36,7 +36,9 @@ export async function resolveSourceIdentity(
   const profileRegistry = context.profileRegistry ?? new RemoteSourceProfileRegistry();
   const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
   const profile = await profileRegistry.resolve(source, homeDir);
-  const capabilityDescription = profile.describeCapabilities?.(profileInputSource(source));
+  const capabilityDescription = typeof profile.describeCapabilities === "function"
+    ? profile.describeCapabilities(profileInputSource(source))
+    : undefined;
   return {
     hostType: "remote_source",
     sourceKind: capabilityDescription?.sourceKind?.trim() || `remote:${profile.id}`,
@@ -50,13 +52,16 @@ export async function resolveSourceSchema(
 ): Promise<ResolvedSourceSchema> {
   const profileRegistry = context.profileRegistry ?? new RemoteSourceProfileRegistry();
   const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
-  const identity = await resolveSourceIdentity(source, context);
+  const resolvedContext: ResolveSourceContext = { ...context, profileRegistry, homeDir };
+  const identity = await resolveSourceIdentity(source, resolvedContext);
   const staticSchema = getSourceSchema(source.sourceType);
   let capabilityDescription: ReturnType<NonNullable<RemoteSourceProfile["describeCapabilities"]>> | undefined;
   let profile: RemoteSourceProfile | null = null;
   if (identity.hostType === "remote_source") {
     profile = await profileRegistry.resolve(source, homeDir);
-    capabilityDescription = profile.describeCapabilities?.(profileInputSource(source));
+    capabilityDescription = typeof profile.describeCapabilities === "function"
+      ? profile.describeCapabilities(profileInputSource(source))
+      : undefined;
   }
   return withResolvedIdentity(
     source.sourceId,
@@ -68,12 +73,16 @@ export async function resolveSourceSchema(
       configFields: capabilityDescription?.configSchema ?? staticSchema.configFields,
     },
     identity,
-    {
-      aliases: capabilityDescription?.aliases,
-      supportsTrackedResourceRef: Boolean(profile?.deriveTrackedResource),
-      supportsLifecycleSignals: Boolean(profile?.projectLifecycleSignal),
-      shortcuts: profile?.listSubscriptionShortcuts?.(profileInputSource(source)) ?? [],
-    },
+    identity.hostType === "remote_source"
+      ? {
+          aliases: capabilityDescription?.aliases,
+          supportsTrackedResourceRef: typeof profile?.deriveTrackedResource === "function",
+          supportsLifecycleSignals: typeof profile?.projectLifecycleSignal === "function",
+          shortcuts: typeof profile?.listSubscriptionShortcuts === "function"
+            ? profile.listSubscriptionShortcuts(profileInputSource(source))
+            : [],
+        }
+      : undefined,
   );
 }
 

--- a/src/sources/remote_profiles.ts
+++ b/src/sources/remote_profiles.ts
@@ -179,6 +179,17 @@ function validateProfileContract(profile: RemoteSourceProfile, sourcePath: strin
   if (typeof profile.mapRawEvent !== "function") {
     throw new Error(`remote_source profile missing mapRawEvent(): ${sourcePath}`);
   }
+  validateOptionalHook(profile.describeCapabilities, "describeCapabilities", sourcePath);
+  validateOptionalHook(profile.listSubscriptionShortcuts, "listSubscriptionShortcuts", sourcePath);
+  validateOptionalHook(profile.expandSubscriptionShortcut, "expandSubscriptionShortcut", sourcePath);
+  validateOptionalHook(profile.deriveTrackedResource, "deriveTrackedResource", sourcePath);
+  validateOptionalHook(profile.projectLifecycleSignal, "projectLifecycleSignal", sourcePath);
+}
+
+function validateOptionalHook(value: unknown, name: string, sourcePath: string): void {
+  if (value !== undefined && typeof value !== "function") {
+    throw new Error(`remote_source profile ${name} must be a function when provided: ${sourcePath}`);
+  }
 }
 
 function resolveAndValidateProfilePath(profileRoot: string, profilePath: string): string {

--- a/src/sources/remote_profiles.ts
+++ b/src/sources/remote_profiles.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { PollSubscriptionConfig, RuntimeInvokeOptions } from "@holon-run/uxc-daemon-client";
-import { AppendSourceEventInput, SubscriptionSource } from "../model";
+import { AppendSourceEventInput, SourceSchemaField, SubscriptionFilter, SubscriptionSource } from "../model";
 import {
   GITHUB_ENDPOINT,
   normalizeGithubRepoEvent,
@@ -44,11 +44,54 @@ export interface MappedRemoteEvent {
   deliveryHandle?: AppendSourceEventInput["deliveryHandle"];
 }
 
+export interface RemoteSourceCapabilityDescription {
+  sourceKind?: string;
+  aliases?: string[];
+  configSchema?: SourceSchemaField[];
+  metadataFields?: SourceSchemaField[];
+  eventVariantExamples?: string[];
+  payloadExamples?: Record<string, unknown>[];
+}
+
+export interface SubscriptionShortcutSpec {
+  name: string;
+  description: string;
+  argsSchema?: SourceSchemaField[];
+}
+
+export interface ExpandedSubscriptionInput {
+  filter?: SubscriptionFilter;
+  lifecycleMode?: "standing" | "temporary";
+  expiresAt?: string | null;
+  trackedResourceRef?: string | null;
+  cleanupPolicy?: Record<string, unknown> | null;
+}
+
+export interface ExpandSubscriptionShortcutInput {
+  name: string;
+  args?: Record<string, unknown>;
+  source: SubscriptionSource;
+}
+
+export interface LifecycleSignal {
+  ref: string;
+  terminal: boolean;
+  state?: string | null;
+  result?: string | null;
+  occurredAt?: string;
+}
+
 export interface RemoteSourceProfile {
   id: string;
   validateConfig(source: SubscriptionSource): void;
   buildManagedSourceSpec(source: SubscriptionSource): ManagedSourceSpec;
   mapRawEvent(rawPayload: Record<string, unknown>, source: SubscriptionSource): MappedRemoteEvent | null;
+  // Optional capability hooks used by resolved schema and future subscription ergonomics.
+  describeCapabilities?(source: SubscriptionSource): RemoteSourceCapabilityDescription;
+  listSubscriptionShortcuts?(source: SubscriptionSource): SubscriptionShortcutSpec[];
+  expandSubscriptionShortcut?(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | null;
+  deriveTrackedResource?(filter: SubscriptionFilter, source: SubscriptionSource): { ref: string } | null;
+  projectLifecycleSignal?(rawPayload: Record<string, unknown>, source: SubscriptionSource): LifecycleSignal | null;
 }
 
 const REMOTE_USER_PROFILE_ROOT_DIR = "source-profiles";
@@ -171,6 +214,35 @@ function asNonEmptyString(value: unknown): string | null {
 
 const GITHUB_REPO_PROFILE: RemoteSourceProfile = {
   id: "builtin.github_repo",
+  describeCapabilities(source: SubscriptionSource): RemoteSourceCapabilityDescription {
+    const config = parseGithubSourceConfig(source);
+    return {
+      sourceKind: "github_repo",
+      aliases: ["github_repo"],
+      configSchema: [
+        { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+        { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+        { name: "uxcAuth", type: "string", required: false, description: "Optional uxc auth profile." },
+        { name: "eventTypes", type: "string[]", required: false, description: "Optional GitHub event type allowlist." },
+        { name: "perPage", type: "number", required: false, description: `Repository events requested per poll. Default ${config.perPage ?? 10}.` },
+        { name: "pollIntervalSecs", type: "number", required: false, description: `Polling interval in seconds. Default ${config.pollIntervalSecs ?? 30}.` },
+      ],
+      metadataFields: [
+        { name: "eventType", type: "string", description: "GitHub event type such as IssueCommentEvent." },
+        { name: "action", type: "string", description: "GitHub event action suffix such as created." },
+        { name: "author", type: "string|null", description: "Actor login for the event." },
+        { name: "isPullRequest", type: "boolean", description: "Whether the event targets a pull request surface." },
+        { name: "labels", type: "string[]", description: "Labels extracted from the issue or pull request." },
+        { name: "mentions", type: "string[]", description: "Mention handles extracted from title/body/comment text." },
+        { name: "number", type: "number|null", description: "Issue or pull request number when present." },
+        { name: "repoFullName", type: "string", description: "Repository full name in owner/repo form." },
+        { name: "title", type: "string|null", description: "Issue, pull request, or comment title." },
+        { name: "body", type: "string|null", description: "Issue, pull request, or comment body text." },
+        { name: "url", type: "string|null", description: "Primary GitHub HTML URL for the event target." },
+      ],
+      eventVariantExamples: ["IssueCommentEvent.created", "PullRequestEvent.opened", "PullRequestReviewCommentEvent.created"],
+    };
+  },
   validateConfig(source: SubscriptionSource): void {
     parseGithubSourceConfig(source);
   },
@@ -216,6 +288,34 @@ const GITHUB_REPO_PROFILE: RemoteSourceProfile = {
 
 const GITHUB_REPO_CI_PROFILE: RemoteSourceProfile = {
   id: "builtin.github_repo_ci",
+  describeCapabilities(): RemoteSourceCapabilityDescription {
+    return {
+      sourceKind: "github_repo_ci",
+      aliases: ["github_repo_ci"],
+      configSchema: [
+        { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+        { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+        { name: "uxcAuth", type: "string", required: false, description: "Optional uxc auth profile." },
+        { name: "pollIntervalSecs", type: "number", required: false, description: "Polling interval in seconds." },
+        { name: "perPage", type: "number", required: false, description: "Workflow runs requested per poll." },
+        { name: "eventFilter", type: "string", required: false, description: "Optional GitHub workflow event filter." },
+        { name: "branch", type: "string", required: false, description: "Optional branch filter for workflow runs." },
+        { name: "statusFilter", type: "string", required: false, description: "Optional workflow status filter." },
+      ],
+      metadataFields: [
+        { name: "name", type: "string|null", description: "Workflow run name." },
+        { name: "status", type: "string", description: "Normalized workflow run status." },
+        { name: "conclusion", type: "string|null", description: "Workflow run conclusion when completed." },
+        { name: "event", type: "string|null", description: "GitHub trigger event for the workflow run." },
+        { name: "headBranch", type: "string|null", description: "Head branch for the workflow run." },
+        { name: "headSha", type: "string|null", description: "Head commit SHA for the workflow run." },
+        { name: "actor", type: "string|null", description: "Actor login for the workflow run." },
+        { name: "commitMessage", type: "string|null", description: "Head commit message when present." },
+        { name: "htmlUrl", type: "string|null", description: "GitHub Actions run URL." },
+      ],
+      eventVariantExamples: ["workflow_run.ci.completed.failure", "workflow_run.nightly_checks.observed"],
+    };
+  },
   validateConfig(source: SubscriptionSource): void {
     parseGithubCiSourceConfig(source);
   },
@@ -270,6 +370,36 @@ const GITHUB_REPO_CI_PROFILE: RemoteSourceProfile = {
 
 const FEISHU_BOT_PROFILE: RemoteSourceProfile = {
   id: "builtin.feishu_bot",
+  describeCapabilities(): RemoteSourceCapabilityDescription {
+    return {
+      sourceKind: "feishu_bot",
+      aliases: ["feishu_bot"],
+      configSchema: [
+        { name: "appId", type: "string", required: true, description: "Feishu app ID." },
+        { name: "appSecret", type: "string", required: true, description: "Feishu app secret." },
+        { name: "eventTypes", type: "string[]", required: false, description: "Optional Feishu event type allowlist." },
+        { name: "chatIds", type: "string[]", required: false, description: "Optional Feishu chat allowlist." },
+        { name: "schemaUrl", type: "string", required: false, description: "Optional Feishu OpenAPI schema URL." },
+        { name: "replyInThread", type: "boolean", required: false, description: "Reply in thread when sending outbound messages." },
+        { name: "uxcAuth", type: "string", required: false, description: "Optional uxc auth profile." },
+      ],
+      metadataFields: [
+        { name: "eventType", type: "string", description: "Feishu event type." },
+        { name: "chatId", type: "string", description: "Target chat ID." },
+        { name: "chatType", type: "string|null", description: "Feishu chat type." },
+        { name: "messageId", type: "string", description: "Feishu message ID." },
+        { name: "messageType", type: "string", description: "Feishu message type such as text." },
+        { name: "senderOpenId", type: "string|null", description: "Sender open_id when present." },
+        { name: "senderType", type: "string|null", description: "Sender type." },
+        { name: "mentions", type: "string[]", description: "Mention names extracted from the message." },
+        { name: "mentionOpenIds", type: "string[]", description: "Mention open_ids extracted from the message." },
+        { name: "content", type: "string|null", description: "Normalized message content string." },
+        { name: "threadId", type: "string|null", description: "Thread or root message ID when present." },
+        { name: "parentId", type: "string|null", description: "Parent message ID when present." },
+      ],
+      eventVariantExamples: ["im.message.receive_v1.text"],
+    };
+  },
   validateConfig(source: SubscriptionSource): void {
     parseFeishuSourceConfig(source);
   },

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -605,6 +605,153 @@ test("remote_source capability hooks override resolved schema fields and adverti
   }
 });
 
+test("local_event resolved schema does not expose remote-only subscription capability metadata", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-schema-demo",
+      config: {},
+    });
+
+    const schema = await service.getResolvedSourceSchema(source.sourceId) as {
+      hostType: string;
+      sourceKind: string;
+      implementationId: string;
+      subscriptionSchema?: unknown;
+    };
+    assert.equal(schema.hostType, "local_event");
+    assert.equal(schema.sourceKind, "local_event");
+    assert.equal(schema.implementationId, "builtin.local_event");
+    assert.equal("subscriptionSchema" in schema, false);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("source details keep a wrapped fallback schema when non-identity capability hooks throw", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "broken-shortcuts.mjs"),
+      `export default {
+  id: "demo.broken-shortcuts",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      operation_id: "get:/events",
+      args: {},
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() {
+    return null;
+  },
+  listSubscriptionShortcuts() {
+    throw new Error("broken listSubscriptionShortcuts");
+  }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "broken-shortcuts-demo",
+      config: {
+        profilePath: "broken-shortcuts.mjs",
+        profileConfig: {},
+      },
+    });
+
+    const details = await service.getSourceDetails(source.sourceId) as {
+      resolvedIdentity: {
+        hostType: string;
+        sourceKind: string;
+        implementationId: string;
+      };
+      resolutionError: string;
+      schema: {
+        sourceType: string;
+        hostType: string;
+        sourceKind: string;
+        implementationId: string;
+      };
+    };
+    assert.deepEqual(details.resolvedIdentity, {
+      hostType: "remote_source",
+      sourceKind: "remote:demo.broken-shortcuts",
+      implementationId: "demo.broken-shortcuts",
+    });
+    assert.match(details.resolutionError, /broken listSubscriptionShortcuts/);
+    assert.equal(details.schema.sourceType, "remote_source");
+    assert.equal(details.schema.hostType, "remote_source");
+    assert.equal(details.schema.sourceKind, "remote:demo.broken-shortcuts");
+    assert.equal(details.schema.implementationId, "demo.broken-shortcuts");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("remote_source profile contract rejects non-function optional hooks", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "invalid-hook.mjs"),
+      `export default {
+  id: "demo.invalid-hook",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      operation_id: "get:/events",
+      args: {},
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() {
+    return null;
+  },
+  listSubscriptionShortcuts: []
+};`,
+      "utf8",
+    );
+
+    await assert.rejects(
+      service.registerSource({
+        sourceType: "remote_source",
+        sourceKey: "invalid-hook-demo",
+        config: {
+          profilePath: "invalid-hook.mjs",
+          profileConfig: {},
+        },
+      }),
+      /listSubscriptionShortcuts must be a function/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("removeSource rejects when source still has subscriptions", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -441,6 +441,11 @@ test("remote_source registration succeeds", async () => {
         hostType: string;
         sourceKind: string;
         implementationId: string;
+        subscriptionSchema: {
+          supportsTrackedResourceRef: boolean;
+          supportsLifecycleSignals: boolean;
+          shortcuts: unknown[];
+        };
       };
     };
     assert.deepEqual(details.resolvedIdentity, {
@@ -452,6 +457,11 @@ test("remote_source registration succeeds", async () => {
     assert.equal(details.schema.hostType, "remote_source");
     assert.equal(details.schema.sourceKind, "remote:demo.profile");
     assert.equal(details.schema.implementationId, "demo.profile");
+    assert.deepEqual(details.schema.subscriptionSchema, {
+      supportsTrackedResourceRef: false,
+      supportsLifecycleSignals: false,
+      shortcuts: [],
+    });
   } finally {
     await service.stop();
     store.close();
@@ -478,6 +488,12 @@ test("builtin remote-backed source details expose resolved remote identity", asy
         hostType: string;
         sourceKind: string;
         implementationId: string;
+        aliases?: string[];
+        subscriptionSchema: {
+          supportsTrackedResourceRef: boolean;
+          supportsLifecycleSignals: boolean;
+          shortcuts: unknown[];
+        };
       };
     };
     assert.deepEqual(details.resolvedIdentity, {
@@ -488,6 +504,100 @@ test("builtin remote-backed source details expose resolved remote identity", asy
     assert.equal(details.schema.hostType, "remote_source");
     assert.equal(details.schema.sourceKind, "github_repo");
     assert.equal(details.schema.implementationId, "builtin.github_repo");
+    assert.deepEqual(details.schema.aliases, ["github_repo"]);
+    assert.deepEqual(details.schema.subscriptionSchema, {
+      supportsTrackedResourceRef: false,
+      supportsLifecycleSignals: false,
+      shortcuts: [],
+    });
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("remote_source capability hooks override resolved schema fields and advertise shortcut/lifecycle support", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "capabilities.mjs"),
+      `export default {
+  id: "demo.capabilities",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return { sourceNativeId: String(raw.id), eventVariant: "demo.event", metadata: {}, rawPayload: raw };
+  },
+  describeCapabilities() {
+    return {
+      sourceKind: "remote:demo.capabilities.custom",
+      aliases: ["demo_capabilities"],
+      configSchema: [{ name: "tenant", type: "string", required: true, description: "Tenant identifier." }],
+      metadataFields: [{ name: "tenant", type: "string", description: "Normalized tenant id." }],
+      eventVariantExamples: ["demo.custom.created"],
+      payloadExamples: [{ id: "evt-1", tenant: "team-a" }]
+    };
+  },
+  listSubscriptionShortcuts() {
+    return [{
+      name: "pr",
+      description: "Follow one pull request",
+      argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }]
+    }];
+  },
+  deriveTrackedResource() {
+    return { ref: "resource:demo" };
+  },
+  projectLifecycleSignal() {
+    return { ref: "resource:demo", terminal: true, state: "closed", result: "done" };
+  }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "capabilities-demo",
+      config: {
+        profilePath: "capabilities.mjs",
+        profileConfig: {},
+      },
+    });
+
+    const schema = await service.getResolvedSourceSchema(source.sourceId);
+    assert.equal(schema.sourceKind, "remote:demo.capabilities.custom");
+    assert.equal(schema.implementationId, "demo.capabilities");
+    assert.deepEqual(schema.aliases, ["demo_capabilities"]);
+    assert.deepEqual(schema.configFields, [
+      { name: "tenant", type: "string", required: true, description: "Tenant identifier." },
+    ]);
+    assert.deepEqual(schema.metadataFields, [
+      { name: "tenant", type: "string", description: "Normalized tenant id." },
+    ]);
+    assert.deepEqual(schema.eventVariantExamples, ["demo.custom.created"]);
+    assert.deepEqual(schema.payloadExamples, [{ id: "evt-1", tenant: "team-a" }]);
+    assert.deepEqual(schema.subscriptionSchema, {
+      supportsTrackedResourceRef: true,
+      supportsLifecycleSignals: true,
+      shortcuts: [{
+        name: "pr",
+        description: "Follow one pull request",
+        argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+      }],
+    });
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
## Summary
- extend the remote module contract with optional capability introspection hooks
- let resolved source schema consume `describeCapabilities` and expose aliases plus subscription capability metadata
- document the optional hook surface for local module authors
- add coverage for backward-compatible modules and modules that override resolved schema fields

## Verification
- npm run build
- node --require ts-node/register --test --test-name-pattern="remote_source registration succeeds|builtin remote-backed source details expose resolved remote identity|remote_source capability hooks override resolved schema fields and advertise shortcut/lifecycle support" test/agentinbox.test.ts
- npm test (running locally; no new failures observed before PR creation)

Closes #54
