### PR TITLE
feat: add cleanup policy lifecycle engine

### DIFF
--- a/drizzle/migrations/0003_subscription_lifecycle_retirements.sql
+++ b/drizzle/migrations/0003_subscription_lifecycle_retirements.sql
@@ -1,0 +1,14 @@
+create table if not exists subscription_lifecycle_retirements (
+  subscription_id text primary key,
+  source_id text not null,
+  tracked_resource_ref text not null,
+  retire_at text not null,
+  terminal_state text,
+  terminal_result text,
+  terminal_occurred_at text,
+  created_at text not null,
+  updated_at text not null
+);
+
+create index if not exists idx_subscription_lifecycle_retirements_retire_at
+  on subscription_lifecycle_retirements(retire_at);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -48,6 +48,18 @@ export const subscriptions = sqliteTable("subscriptions", {
   createdAt: text("created_at").notNull(),
 });
 
+export const subscriptionLifecycleRetirements = sqliteTable("subscription_lifecycle_retirements", {
+  subscriptionId: text("subscription_id").primaryKey(),
+  sourceId: text("source_id").notNull(),
+  trackedResourceRef: text("tracked_resource_ref").notNull(),
+  retireAt: text("retire_at").notNull(),
+  terminalState: text("terminal_state"),
+  terminalResult: text("terminal_result"),
+  terminalOccurredAt: text("terminal_occurred_at"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
 export const activationTargets = sqliteTable("activation_targets", {
   targetId: text("target_id").primaryKey(),
   agentId: text("agent_id").notNull(),

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -2,18 +2,18 @@ import {
   AppendSourceEventInput,
   DeliveryAttempt,
   DeliveryRequest,
+  SubscriptionSource,
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
   SourcePollResult,
   SourceType,
-  SubscriptionSource,
 } from "./model";
 import { AgentInboxStore } from "./store";
 import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubDeliveryAdapter } from "./sources/github";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
-import { RemoteSourceProfileRegistry } from "./sources/remote_profiles";
+import { LifecycleSignal, RemoteSourceProfileRegistry } from "./sources/remote_profiles";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
 
 export interface SourceAdapter {
@@ -174,6 +174,13 @@ export class AdapterRegistry {
       homeDir: this.homeDir,
       profileRegistry: this.remoteProfileRegistry,
     });
+  }
+
+  async projectLifecycleSignal(source: SubscriptionSource, rawPayload: Record<string, unknown>): Promise<LifecycleSignal | null> {
+    if (source.sourceType === "local_event") {
+      return null;
+    }
+    return this.remoteSource.projectLifecycleSignal(source, rawPayload);
   }
 
   status(): Record<string, unknown> {

--- a/src/model.ts
+++ b/src/model.ts
@@ -72,6 +72,18 @@ export interface Subscription {
   createdAt: string;
 }
 
+export interface SubscriptionLifecycleRetirement {
+  subscriptionId: string;
+  sourceId: string;
+  trackedResourceRef: string;
+  retireAt: string;
+  terminalState?: string | null;
+  terminalResult?: string | null;
+  terminalOccurredAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 interface ActivationTargetBase {
   targetId: string;
   agentId: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -22,6 +22,7 @@ import {
   SourcePollResult,
   Subscription,
   CleanupPolicy,
+  SubscriptionLifecycleRetirement,
   SubscriptionPollResult,
   SubscriptionSource,
   TerminalActivationTarget,
@@ -44,6 +45,7 @@ import { getSourceSchema } from "./source_schema";
 import { withResolvedIdentity } from "./source_resolution";
 import { matchSubscriptionFilter, validateSubscriptionFilter } from "./filter";
 import { assignedAgentIdFromContext, detectTerminalContext, renderAgentPrompt, TerminalDispatcher } from "./terminal";
+import { LifecycleSignal } from "./sources/remote_profiles";
 
 const DEFAULT_SUBSCRIPTION_POLL_LIMIT = 100;
 const DEFAULT_ACTIVATION_WINDOW_MS = 3_000;
@@ -53,6 +55,7 @@ const DEFAULT_NOTIFY_RETRY_MS = 5_000;
 const DEFAULT_ACKED_RETENTION_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_OFFLINE_AGENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_GC_INTERVAL_MS = 60 * 1000;
+const DEFAULT_LIFECYCLE_SYNC_INTERVAL_MS = 2_000;
 const WEBHOOK_ACTIVATION_MODES = new Set<WebhookActivationTarget["mode"]>(["activation_only", "activation_with_items"]);
 const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
 interface ActivationPolicy {
@@ -127,7 +130,7 @@ export class AgentInboxService {
       void this.syncActivationDispatchStates();
       void this.runAckedInboxGcIfDue();
       void this.syncLifecycleGc();
-    }, 2_000);
+    }, DEFAULT_LIFECYCLE_SYNC_INTERVAL_MS);
     await this.syncAllSubscriptions();
     await this.syncActivationDispatchStates();
     await this.runAckedInboxGcIfDue(true);
@@ -590,6 +593,9 @@ export class AgentInboxService {
       streamId: stream.streamId,
       events: [input],
     });
+    void this.maybeScheduleLifecycleFromAppendedEvent(source, input).catch((error) => {
+      console.warn(`lifecycle scheduling failed for ${source.sourceId}/${input.sourceNativeId}:`, error);
+    });
     return toAppendResult(result);
   }
 
@@ -754,13 +760,15 @@ export class AgentInboxService {
     };
   }
 
-  gc(): { deleted: number; retentionMs: number; removedAgents: number } {
+  gc(): { deleted: number; retentionMs: number; removedAgents: number; removedSubscriptions: number } {
     const acked = this.gcAckedInboxItems();
-    const lifecycle = this.gcOfflineAgents();
+    const lifecycle = this.runLifecycleCleanupPass(Date.now());
+    const offlineAgents = this.gcOfflineAgents();
     return {
       deleted: acked.deleted,
       retentionMs: acked.retentionMs,
-      removedAgents: lifecycle.removedAgents,
+      removedAgents: offlineAgents.removedAgents,
+      removedSubscriptions: lifecycle.removedSubscriptions,
     };
   }
 
@@ -807,9 +815,11 @@ export class AgentInboxService {
       let inboxItemsCreated = 0;
       let lastProcessedOffset: number | null = null;
       const insertedItems: InboxItem[] = [];
+      const lifecycleSignals = new Map<string, LifecycleSignal>();
       try {
         for (const event of batch.events) {
           lastProcessedOffset = event.offset;
+          await this.collectLifecycleSignal(source, event.rawPayload, lifecycleSignals, event.occurredAt);
           const match = await matchSubscriptionFilter(subscription.filter, {
             metadata: event.metadata,
             payload: event.rawPayload,
@@ -882,6 +892,9 @@ export class AgentInboxService {
           consumerId: consumer.consumerId,
           committedOffset: lastProcessedOffset,
         });
+      }
+      for (const signal of lifecycleSignals.values()) {
+        this.scheduleLifecycleRetirements(source, signal);
       }
 
       return {
@@ -986,6 +999,73 @@ export class AgentInboxService {
       streamKey: streamKeyForSource(source.sourceType, source.sourceKey),
       backend: "sqlite",
     });
+  }
+
+  private async maybeScheduleLifecycleFromAppendedEvent(
+    source: SubscriptionSource,
+    input: Pick<AppendSourceEventInput, "rawPayload" | "occurredAt">,
+  ): Promise<void> {
+    const signals = new Map<string, LifecycleSignal>();
+    await this.collectLifecycleSignal(source, input.rawPayload ?? {}, signals, input.occurredAt ?? undefined);
+    for (const signal of signals.values()) {
+      this.scheduleLifecycleRetirements(source, signal);
+    }
+  }
+
+  private async collectLifecycleSignal(
+    source: SubscriptionSource,
+    rawPayload: Record<string, unknown>,
+    signals: Map<string, LifecycleSignal>,
+    fallbackOccurredAt?: string,
+  ): Promise<void> {
+    const signal = await this.adapters.projectLifecycleSignal(source, rawPayload);
+    if (!signal || !signal.terminal) {
+      return;
+    }
+    const normalized = normalizeLifecycleSignal(signal, fallbackOccurredAt);
+    if (!normalized) {
+      return;
+    }
+    const existing = signals.get(normalized.ref);
+    if (!existing) {
+      signals.set(normalized.ref, normalized);
+      return;
+    }
+    const existingAt = Date.parse(existing.occurredAt ?? "");
+    const normalizedAt = Date.parse(normalized.occurredAt ?? "");
+    if (Number.isNaN(existingAt) || (!Number.isNaN(normalizedAt) && normalizedAt > existingAt)) {
+      signals.set(normalized.ref, normalized);
+    }
+  }
+
+  private scheduleLifecycleRetirements(source: SubscriptionSource, signal: LifecycleSignal): void {
+    if (!signal.terminal) {
+      return;
+    }
+    const signalOccurredAt = signal.occurredAt ?? nowIso();
+    const signalOccurredAtMs = Date.parse(signalOccurredAt);
+    const subscriptions = this.store.listSubscriptionsForSource(source.sourceId);
+    for (const subscription of subscriptions) {
+      if (!subscription.trackedResourceRef || subscription.trackedResourceRef !== signal.ref) {
+        continue;
+      }
+      const retireAt = lifecycleRetireAtForSignal(subscription.cleanupPolicy, signalOccurredAtMs);
+      if (!retireAt) {
+        continue;
+      }
+      const now = nowIso();
+      this.store.upsertSubscriptionLifecycleRetirement({
+        subscriptionId: subscription.subscriptionId,
+        sourceId: source.sourceId,
+        trackedResourceRef: signal.ref,
+        retireAt,
+        terminalState: signal.state ?? null,
+        terminalResult: signal.result ?? null,
+        terminalOccurredAt: signalOccurredAt,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
   }
 
   private notifyInboxWatchers(agentId: string, items: InboxItem[]): void {
@@ -1149,6 +1229,7 @@ export class AgentInboxService {
       // state so future subscriptions do not inherit a stale notified window.
       this.store.deleteActivationDispatchState(state.agentId, state.targetId);
     }
+    this.store.deleteSubscriptionLifecycleRetirement(subscription.subscriptionId);
   }
 
   private async flushAllPendingNotifications(): Promise<void> {
@@ -1443,6 +1524,44 @@ export class AgentInboxService {
     });
   }
 
+  private runLifecycleCleanupPass(nowMs: number): { removedSubscriptions: number } {
+    const now = new Date(nowMs).toISOString();
+    const removed = new Set<string>();
+
+    for (const subscription of this.store.listSubscriptions()) {
+      if (removed.has(subscription.subscriptionId)) {
+        continue;
+      }
+      const deadline = lifecycleDeadlineAt(subscription.cleanupPolicy);
+      if (!deadline || deadline > now) {
+        continue;
+      }
+      if (this.store.deleteSubscription(subscription.subscriptionId)) {
+        removed.add(subscription.subscriptionId);
+        this.clearSubscriptionRuntimeState(subscription);
+      }
+    }
+
+    const dueRetirements = this.store.listSubscriptionLifecycleRetirementsDue(now);
+    for (const retirement of dueRetirements) {
+      if (removed.has(retirement.subscriptionId)) {
+        this.store.deleteSubscriptionLifecycleRetirement(retirement.subscriptionId);
+        continue;
+      }
+      const subscription = this.store.getSubscription(retirement.subscriptionId);
+      if (!subscription) {
+        this.store.deleteSubscriptionLifecycleRetirement(retirement.subscriptionId);
+        continue;
+      }
+      if (this.store.deleteSubscription(retirement.subscriptionId)) {
+        removed.add(retirement.subscriptionId);
+        this.clearSubscriptionRuntimeState(subscription);
+      }
+    }
+
+    return { removedSubscriptions: removed.size };
+  }
+
   private gcOfflineAgents(now = Date.now()): { removedAgents: number } {
     const cutoffIso = new Date(now - DEFAULT_OFFLINE_AGENT_TTL_MS).toISOString();
     const agents = this.store.listOfflineAgentsOlderThan(cutoffIso);
@@ -1473,6 +1592,7 @@ export class AgentInboxService {
         console.warn(`subscription poll failed for ${subscription.subscriptionId}:`, error);
       }
     }
+    this.runLifecycleCleanupPass(Date.now());
   }
 
   private async syncActivationDispatchStates(): Promise<void> {
@@ -1495,6 +1615,12 @@ export class AgentInboxService {
   }
 
   private async syncLifecycleGc(): Promise<void> {
+    try {
+      this.runLifecycleCleanupPass(Date.now());
+    } catch (error) {
+      console.warn("subscription lifecycle gc failed:", error);
+    }
+
     const now = Date.now();
     if (now - this.lastOfflineAgentGcAt < DEFAULT_GC_INTERVAL_MS) {
       return;
@@ -1562,6 +1688,59 @@ function normalizeGracePeriodSecs(value: number): number {
     throw new Error("cleanupPolicy gracePeriodSecs must be a non-negative integer");
   }
   return value;
+}
+
+function normalizeLifecycleSignal(signal: LifecycleSignal, fallbackOccurredAt?: string): LifecycleSignal | null {
+  const ref = typeof signal.ref === "string" ? signal.ref.trim() : "";
+  if (ref.length === 0) {
+    return null;
+  }
+  return {
+    ref,
+    terminal: signal.terminal,
+    state: signal.state ?? null,
+    result: signal.result ?? null,
+    occurredAt: normalizeLifecycleOccurredAt(signal.occurredAt, fallbackOccurredAt),
+  };
+}
+
+function normalizeLifecycleOccurredAt(value?: string, fallback?: string): string {
+  if (value && isValidIsoTimestamp(value)) {
+    return value;
+  }
+  if (fallback && isValidIsoTimestamp(fallback)) {
+    return fallback;
+  }
+  return nowIso();
+}
+
+function lifecycleRetireAtForSignal(cleanupPolicy: CleanupPolicy, signalOccurredAtMs: number): string | null {
+  if (cleanupPolicy.mode === "manual" || cleanupPolicy.mode === "at") {
+    return null;
+  }
+  if (cleanupPolicy.mode === "on_terminal") {
+    return lifecycleSignalRetireAt(signalOccurredAtMs, cleanupPolicy.gracePeriodSecs ?? null);
+  }
+  return minIsoTimestamps(
+    cleanupPolicy.at,
+    lifecycleSignalRetireAt(signalOccurredAtMs, cleanupPolicy.gracePeriodSecs ?? null),
+  );
+}
+
+function lifecycleSignalRetireAt(signalOccurredAtMs: number, gracePeriodSecs: number | null): string {
+  const graceMs = Math.max(0, gracePeriodSecs ?? 0) * 1000;
+  return new Date(signalOccurredAtMs + graceMs).toISOString();
+}
+
+function lifecycleDeadlineAt(cleanupPolicy: CleanupPolicy): string | null {
+  if (cleanupPolicy.mode === "at" || cleanupPolicy.mode === "on_terminal_or_at") {
+    return cleanupPolicy.at;
+  }
+  return null;
+}
+
+function minIsoTimestamps(left: string, right: string): string {
+  return Date.parse(left) <= Date.parse(right) ? left : right;
 }
 
 function isValidIsoTimestamp(value: unknown): value is string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -892,7 +892,7 @@ export class AgentInboxService {
         });
       }
       for (const signal of lifecycleSignals.values()) {
-        this.scheduleLifecycleRetirements(source, signal);
+        this.scheduleLifecycleRetirements(source, subscription, signal);
       }
 
       return {
@@ -1025,34 +1025,35 @@ export class AgentInboxService {
     }
   }
 
-  private scheduleLifecycleRetirements(source: SubscriptionSource, signal: LifecycleSignal): void {
+  private scheduleLifecycleRetirements(
+    source: SubscriptionSource,
+    subscription: Subscription,
+    signal: LifecycleSignal,
+  ): void {
     if (!signal.terminal) {
+      return;
+    }
+    if (!subscription.trackedResourceRef || subscription.trackedResourceRef !== signal.ref) {
       return;
     }
     const signalOccurredAt = signal.occurredAt ?? nowIso();
     const signalOccurredAtMs = Date.parse(signalOccurredAt);
-    const subscriptions = this.store.listSubscriptionsForSource(source.sourceId);
-    for (const subscription of subscriptions) {
-      if (!subscription.trackedResourceRef || subscription.trackedResourceRef !== signal.ref) {
-        continue;
-      }
-      const retireAt = lifecycleRetireAtForSignal(subscription.cleanupPolicy, signalOccurredAtMs);
-      if (!retireAt) {
-        continue;
-      }
-      const now = nowIso();
-      this.store.upsertSubscriptionLifecycleRetirement({
-        subscriptionId: subscription.subscriptionId,
-        sourceId: source.sourceId,
-        trackedResourceRef: signal.ref,
-        retireAt,
-        terminalState: signal.state ?? null,
-        terminalResult: signal.result ?? null,
-        terminalOccurredAt: signalOccurredAt,
-        createdAt: now,
-        updatedAt: now,
-      });
+    const retireAt = lifecycleRetireAtForSignal(subscription.cleanupPolicy, signalOccurredAtMs);
+    if (!retireAt) {
+      return;
     }
+    const now = nowIso();
+    this.store.upsertSubscriptionLifecycleRetirement({
+      subscriptionId: subscription.subscriptionId,
+      sourceId: source.sourceId,
+      trackedResourceRef: signal.ref,
+      retireAt,
+      terminalState: signal.state ?? null,
+      terminalResult: signal.result ?? null,
+      terminalOccurredAt: signalOccurredAt,
+      createdAt: now,
+      updatedAt: now,
+    });
   }
 
   private notifyInboxWatchers(agentId: string, items: InboxItem[]): void {

--- a/src/service.ts
+++ b/src/service.ts
@@ -55,7 +55,7 @@ const DEFAULT_NOTIFY_RETRY_MS = 5_000;
 const DEFAULT_ACKED_RETENTION_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_OFFLINE_AGENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_GC_INTERVAL_MS = 60 * 1000;
-const DEFAULT_LIFECYCLE_SYNC_INTERVAL_MS = 2_000;
+const DEFAULT_SYNC_INTERVAL_MS = 2_000;
 const WEBHOOK_ACTIVATION_MODES = new Set<WebhookActivationTarget["mode"]>(["activation_only", "activation_with_items"]);
 const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
 interface ActivationPolicy {
@@ -99,6 +99,7 @@ export class AgentInboxService {
   private syncInterval: NodeJS.Timeout | null = null;
   private stopping = false;
   private lastAckedInboxGcAt = 0;
+  private lastLifecycleCleanupAt = 0;
   private lastOfflineAgentGcAt = 0;
 
   constructor(
@@ -130,7 +131,7 @@ export class AgentInboxService {
       void this.syncActivationDispatchStates();
       void this.runAckedInboxGcIfDue();
       void this.syncLifecycleGc();
-    }, DEFAULT_LIFECYCLE_SYNC_INTERVAL_MS);
+    }, DEFAULT_SYNC_INTERVAL_MS);
     await this.syncAllSubscriptions();
     await this.syncActivationDispatchStates();
     await this.runAckedInboxGcIfDue(true);
@@ -1525,7 +1526,7 @@ export class AgentInboxService {
   }
 
   private runLifecycleCleanupPass(nowMs: number): { removedSubscriptions: number } {
-    const now = new Date(nowMs).toISOString();
+    this.lastLifecycleCleanupAt = nowMs;
     const removed = new Set<string>();
 
     for (const subscription of this.store.listSubscriptions()) {
@@ -1533,7 +1534,11 @@ export class AgentInboxService {
         continue;
       }
       const deadline = lifecycleDeadlineAt(subscription.cleanupPolicy);
-      if (!deadline || deadline > now) {
+      if (!deadline) {
+        continue;
+      }
+      const deadlineMs = Date.parse(deadline);
+      if (Number.isNaN(deadlineMs) || deadlineMs > nowMs) {
         continue;
       }
       if (this.store.deleteSubscription(subscription.subscriptionId)) {
@@ -1542,7 +1547,7 @@ export class AgentInboxService {
       }
     }
 
-    const dueRetirements = this.store.listSubscriptionLifecycleRetirementsDue(now);
+    const dueRetirements = this.store.listSubscriptionLifecycleRetirementsDue(new Date(nowMs).toISOString());
     for (const retirement of dueRetirements) {
       if (removed.has(retirement.subscriptionId)) {
         this.store.deleteSubscriptionLifecycleRetirement(retirement.subscriptionId);
@@ -1592,7 +1597,6 @@ export class AgentInboxService {
         console.warn(`subscription poll failed for ${subscription.subscriptionId}:`, error);
       }
     }
-    this.runLifecycleCleanupPass(Date.now());
   }
 
   private async syncActivationDispatchStates(): Promise<void> {
@@ -1615,13 +1619,15 @@ export class AgentInboxService {
   }
 
   private async syncLifecycleGc(): Promise<void> {
-    try {
-      this.runLifecycleCleanupPass(Date.now());
-    } catch (error) {
-      console.warn("subscription lifecycle gc failed:", error);
+    const now = Date.now();
+    if (now - this.lastLifecycleCleanupAt >= DEFAULT_GC_INTERVAL_MS) {
+      try {
+        this.runLifecycleCleanupPass(now);
+      } catch (error) {
+        console.warn("subscription lifecycle gc failed:", error);
+      }
     }
 
-    const now = Date.now();
     if (now - this.lastOfflineAgentGcAt < DEFAULT_GC_INTERVAL_MS) {
       return;
     }
@@ -1659,7 +1665,7 @@ function normalizeCleanupPolicy(input: CleanupPolicy | null): CleanupPolicy {
     if ("gracePeriodSecs" in input) {
       throw new Error("cleanupPolicy mode at does not allow gracePeriodSecs");
     }
-    return { mode: "at", at: input.at };
+    return { mode: "at", at: canonicalIsoTimestamp(input.at) };
   }
   if (input.mode === "on_terminal") {
     if ("at" in input) {
@@ -1676,7 +1682,7 @@ function normalizeCleanupPolicy(input: CleanupPolicy | null): CleanupPolicy {
     }
     return {
       mode: "on_terminal_or_at",
-      at: input.at,
+      at: canonicalIsoTimestamp(input.at),
       ...(input.gracePeriodSecs != null ? { gracePeriodSecs: normalizeGracePeriodSecs(input.gracePeriodSecs) } : {}),
     };
   }
@@ -1740,7 +1746,11 @@ function lifecycleDeadlineAt(cleanupPolicy: CleanupPolicy): string | null {
 }
 
 function minIsoTimestamps(left: string, right: string): string {
-  return Date.parse(left) <= Date.parse(right) ? left : right;
+  return new Date(Math.min(Date.parse(left), Date.parse(right))).toISOString();
+}
+
+function canonicalIsoTimestamp(value: string): string {
+  return new Date(value).toISOString();
 }
 
 function isValidIsoTimestamp(value: unknown): value is string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -594,9 +594,6 @@ export class AgentInboxService {
       streamId: stream.streamId,
       events: [input],
     });
-    void this.maybeScheduleLifecycleFromAppendedEvent(source, input).catch((error) => {
-      console.warn(`lifecycle scheduling failed for ${source.sourceId}/${input.sourceNativeId}:`, error);
-    });
     return toAppendResult(result);
   }
 
@@ -1000,17 +997,6 @@ export class AgentInboxService {
       streamKey: streamKeyForSource(source.sourceType, source.sourceKey),
       backend: "sqlite",
     });
-  }
-
-  private async maybeScheduleLifecycleFromAppendedEvent(
-    source: SubscriptionSource,
-    input: Pick<AppendSourceEventInput, "rawPayload" | "occurredAt">,
-  ): Promise<void> {
-    const signals = new Map<string, LifecycleSignal>();
-    await this.collectLifecycleSignal(source, input.rawPayload ?? {}, signals, input.occurredAt ?? undefined);
-    for (const signal of signals.values()) {
-      this.scheduleLifecycleRetirements(source, signal);
-    }
   }
 
   private async collectLifecycleSignal(

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -3,7 +3,7 @@ import { AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "..
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
 import { nowIso } from "../util";
-import { ManagedSourceSpec, RemoteSourceProfileRegistry } from "./remote_profiles";
+import { LifecycleSignal, ManagedSourceSpec, RemoteSourceProfileRegistry } from "./remote_profiles";
 
 const REMOTE_SOURCE_TYPES = new Set<SubscriptionSource["sourceType"]>([
   "remote_source",
@@ -210,6 +210,17 @@ export class RemoteSourceRuntime {
       activeSourceIds: Array.from(this.inFlight.values()).sort(),
       erroredSourceIds: Array.from(this.errorCounts.keys()).sort(),
     };
+  }
+
+  async projectLifecycleSignal(source: SubscriptionSource, rawPayload: Record<string, unknown>): Promise<LifecycleSignal | null> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return null;
+    }
+    const profile = await this.profileRegistry.resolve(source, this.homeDir);
+    if (typeof profile.projectLifecycleSignal !== "function") {
+      return null;
+    }
+    return profile.projectLifecycleSignal(rawPayload, profileInputSource(source));
   }
 
   private async syncAll(): Promise<void> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -493,6 +493,11 @@ export class AgentInboxStore {
       return null;
     }
     this.inTransaction(() => {
+      this.db.run(
+        "delete from consumer_commits where consumer_id in (select consumer_id from consumers where subscription_id = ?)",
+        [subscriptionId],
+      );
+      this.db.run("delete from consumers where subscription_id = ?", [subscriptionId]);
       this.db.run("delete from subscription_lifecycle_retirements where subscription_id = ?", [subscriptionId]);
       this.db.run("delete from subscriptions where subscription_id = ?", [subscriptionId]);
     });

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,6 +22,7 @@ import {
   ListInboxItemsOptions,
   RegisterAgentInput,
   Subscription,
+  SubscriptionLifecycleRetirement,
   SubscriptionFilter,
   SubscriptionSource,
   SubscriptionStartPolicy,
@@ -44,6 +45,21 @@ function parseJson<T>(value: string | null): T {
     return {} as T;
   }
   return JSON.parse(value) as T;
+}
+
+function earlierLifecycleRetirement(
+  left: SubscriptionLifecycleRetirement,
+  right: SubscriptionLifecycleRetirement,
+): SubscriptionLifecycleRetirement {
+  const leftAt = Date.parse(left.retireAt);
+  const rightAt = Date.parse(right.retireAt);
+  if (!Number.isNaN(leftAt) && !Number.isNaN(rightAt) && leftAt <= rightAt) {
+    return {
+      ...left,
+      updatedAt: right.updatedAt,
+    };
+  }
+  return right;
 }
 
 export class AgentInboxStore {
@@ -476,9 +492,74 @@ export class AgentInboxStore {
     if (!subscription) {
       return null;
     }
-    this.db.run("delete from subscriptions where subscription_id = ?", [subscriptionId]);
+    this.inTransaction(() => {
+      this.db.run("delete from subscription_lifecycle_retirements where subscription_id = ?", [subscriptionId]);
+      this.db.run("delete from subscriptions where subscription_id = ?", [subscriptionId]);
+    });
     this.persist();
     return subscription;
+  }
+
+  getSubscriptionLifecycleRetirement(subscriptionId: string): SubscriptionLifecycleRetirement | null {
+    const row = this.getOne(
+      "select * from subscription_lifecycle_retirements where subscription_id = ?",
+      [subscriptionId],
+    );
+    return row ? this.mapSubscriptionLifecycleRetirement(row) : null;
+  }
+
+  listSubscriptionLifecycleRetirements(): SubscriptionLifecycleRetirement[] {
+    const rows = this.getAll("select * from subscription_lifecycle_retirements order by retire_at asc, created_at asc");
+    return rows.map((row) => this.mapSubscriptionLifecycleRetirement(row));
+  }
+
+  listSubscriptionLifecycleRetirementsDue(cutoffIso: string): SubscriptionLifecycleRetirement[] {
+    const rows = this.getAll(
+      "select * from subscription_lifecycle_retirements where retire_at <= ? order by retire_at asc, created_at asc",
+      [cutoffIso],
+    );
+    return rows.map((row) => this.mapSubscriptionLifecycleRetirement(row));
+  }
+
+  upsertSubscriptionLifecycleRetirement(retirement: SubscriptionLifecycleRetirement): SubscriptionLifecycleRetirement {
+    const existing = this.getSubscriptionLifecycleRetirement(retirement.subscriptionId);
+    const next = existing
+      ? earlierLifecycleRetirement(existing, retirement)
+      : retirement;
+    this.db.run(
+      `
+      insert into subscription_lifecycle_retirements (
+        subscription_id, source_id, tracked_resource_ref, retire_at, terminal_state, terminal_result, terminal_occurred_at, created_at, updated_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      on conflict(subscription_id) do update set
+        source_id = excluded.source_id,
+        tracked_resource_ref = excluded.tracked_resource_ref,
+        retire_at = excluded.retire_at,
+        terminal_state = excluded.terminal_state,
+        terminal_result = excluded.terminal_result,
+        terminal_occurred_at = excluded.terminal_occurred_at,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at
+    `,
+      [
+        next.subscriptionId,
+        next.sourceId,
+        next.trackedResourceRef,
+        next.retireAt,
+        next.terminalState ?? null,
+        next.terminalResult ?? null,
+        next.terminalOccurredAt ?? null,
+        next.createdAt,
+        next.updatedAt,
+      ],
+    );
+    this.persist();
+    return this.getSubscriptionLifecycleRetirement(retirement.subscriptionId)!;
+  }
+
+  deleteSubscriptionLifecycleRetirement(subscriptionId: string): void {
+    this.db.run("delete from subscription_lifecycle_retirements where subscription_id = ?", [subscriptionId]);
+    this.persist();
   }
 
   getActivationTarget(targetId: string): ActivationTarget | null {
@@ -692,6 +773,10 @@ export class AgentInboxStore {
         ]);
         this.db.run("delete from consumers where subscription_id = ?", [subscription.subscriptionId]);
       }
+      this.db.run(
+        "delete from subscription_lifecycle_retirements where subscription_id in (select subscription_id from subscriptions where agent_id = ?)",
+        [agentId],
+      );
       this.db.run("delete from subscriptions where agent_id = ?", [agentId]);
       this.db.run("delete from activation_dispatch_states where agent_id = ?", [agentId]);
       this.db.run("delete from activation_targets where agent_id = ?", [agentId]);
@@ -1206,6 +1291,7 @@ export class AgentInboxStore {
       agents: this.count("agents"),
       offlineAgents: this.count("agents where status = 'offline'"),
       subscriptions: this.count("subscriptions"),
+      subscriptionLifecycleRetirements: this.count("subscription_lifecycle_retirements"),
       inboxes: this.count("inboxes"),
       activationTargets: this.count("activation_targets"),
       offlineActivationTargets: this.count("activation_targets where status = 'offline'"),
@@ -1308,6 +1394,20 @@ export class AgentInboxStore {
       startOffset: row.start_offset != null ? Number(row.start_offset) : null,
       startTime: row.start_time ? String(row.start_time) : null,
       createdAt: String(row.created_at),
+    };
+  }
+
+  private mapSubscriptionLifecycleRetirement(row: Record<string, unknown>): SubscriptionLifecycleRetirement {
+    return {
+      subscriptionId: String(row.subscription_id),
+      sourceId: String(row.source_id),
+      trackedResourceRef: String(row.tracked_resource_ref),
+      retireAt: String(row.retire_at),
+      terminalState: row.terminal_state ? String(row.terminal_state) : null,
+      terminalResult: row.terminal_result ? String(row.terminal_result) : null,
+      terminalOccurredAt: row.terminal_occurred_at ? String(row.terminal_occurred_at) : null,
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
     };
   }
 

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -1674,6 +1674,81 @@ test("terminal target goes offline when dispatch fails and probe confirms disapp
   }
 });
 
+test("gc does not retire subscriptions before they consume a terminal event", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "lifecycle-race.mjs"),
+      `export default {
+  id: "demo.lifecycle.race",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    return { sourceNativeId: String(raw.id), eventVariant: "demo.lifecycle", metadata: {}, rawPayload: raw };
+  },
+  projectLifecycleSignal(raw) {
+    return raw.state === "closed" ? { ref: String(raw.ref), terminal: true, state: "closed" } : null;
+  }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "lifecycle-race-demo",
+      config: {
+        profilePath: "lifecycle-race.mjs",
+        profileConfig: {},
+      },
+    });
+    const agent = await registerTmuxAgent(service, "lifecycle-race");
+    const subscription = await service.registerSubscription({
+      agentId: agent.agentId,
+      sourceId: source.sourceId,
+      trackedResourceRef: "pr:77",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: { payload: { ref: "pr:77" } },
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "evt-terminal-race",
+      eventVariant: "demo.lifecycle",
+      metadata: {},
+      rawPayload: { id: "evt-terminal-race", ref: "pr:77", state: "closed" },
+      occurredAt: "2020-06-01T00:00:00.000Z",
+    });
+
+    const firstGc = service.gc();
+    assert.equal(firstGc.removedSubscriptions, 0);
+    assert.ok(store.getSubscription(subscription.subscriptionId));
+    assert.equal(store.getSubscriptionLifecycleRetirement(subscription.subscriptionId), null);
+
+    await service.pollSubscription(subscription.subscriptionId);
+    assert.ok(store.getSubscriptionLifecycleRetirement(subscription.subscriptionId));
+
+    const secondGc = service.gc();
+    assert.equal(secondGc.removedSubscriptions, 1);
+    assert.equal(store.getSubscription(subscription.subscriptionId), null);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("agent remove cascades local runtime state but keeps shared sources", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -1749,6 +1749,94 @@ test("gc does not retire subscriptions before they consume a terminal event", as
   }
 });
 
+test("gc does not retire sibling subscriptions sharing a trackedResourceRef before they consume the terminal event", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "lifecycle-shared-ref.mjs"),
+      `export default {
+  id: "demo.lifecycle.shared-ref",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    return { sourceNativeId: String(raw.id), eventVariant: "demo.lifecycle", metadata: {}, rawPayload: raw };
+  },
+  projectLifecycleSignal(raw) {
+    return raw.state === "closed" ? { ref: String(raw.ref), terminal: true, state: "closed" } : null;
+  }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "lifecycle-shared-ref-demo",
+      config: {
+        profilePath: "lifecycle-shared-ref.mjs",
+        profileConfig: {},
+      },
+    });
+    const agentA = await registerTmuxAgent(service, "lifecycle-shared-ref-a");
+    const agentB = await registerTmuxAgent(service, "lifecycle-shared-ref-b");
+    const subscriptionA = await service.registerSubscription({
+      agentId: agentA.agentId,
+      sourceId: source.sourceId,
+      trackedResourceRef: "pr:77",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: { payload: { ref: "pr:77" } },
+      startPolicy: "earliest",
+    });
+    const subscriptionB = await service.registerSubscription({
+      agentId: agentB.agentId,
+      sourceId: source.sourceId,
+      trackedResourceRef: "pr:77",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: { payload: { ref: "pr:77" } },
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "evt-terminal-shared",
+      eventVariant: "demo.lifecycle",
+      metadata: {},
+      rawPayload: { id: "evt-terminal-shared", ref: "pr:77", state: "closed" },
+      occurredAt: "2020-06-01T00:00:00.000Z",
+    });
+
+    await service.pollSubscription(subscriptionA.subscriptionId);
+    assert.ok(store.getSubscriptionLifecycleRetirement(subscriptionA.subscriptionId));
+    assert.equal(store.getSubscriptionLifecycleRetirement(subscriptionB.subscriptionId), null);
+
+    const firstGc = service.gc();
+    assert.equal(firstGc.removedSubscriptions, 1);
+    assert.equal(store.getSubscription(subscriptionA.subscriptionId), null);
+    assert.ok(store.getSubscription(subscriptionB.subscriptionId));
+
+    await service.pollSubscription(subscriptionB.subscriptionId);
+    assert.ok(store.getSubscriptionLifecycleRetirement(subscriptionB.subscriptionId));
+
+    const secondGc = service.gc();
+    assert.equal(secondGc.removedSubscriptions, 1);
+    assert.equal(store.getSubscription(subscriptionB.subscriptionId), null);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("agent remove cascades local runtime state but keeps shared sources", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -1126,6 +1126,7 @@ test("gc removes subscriptions whose cleanupPolicy deadline has passed", async (
     const result = service.gc();
     assert.equal(result.removedSubscriptions, 1);
     assert.equal(store.getSubscription(subscription.subscriptionId), null);
+    assert.equal(store.getConsumerBySubscriptionId(subscription.subscriptionId), null);
   } finally {
     await service.stop();
     store.close();
@@ -1220,6 +1221,8 @@ test("terminal lifecycle signals schedule retirements and gc removes matching su
     assert.equal(gc.removedSubscriptions, 2);
     assert.equal(store.getSubscription(subA.subscriptionId), null);
     assert.equal(store.getSubscription(subB.subscriptionId), null);
+    assert.equal(store.getConsumerBySubscriptionId(subA.subscriptionId), null);
+    assert.equal(store.getConsumerBySubscriptionId(subB.subscriptionId), null);
     assert.ok(store.getSubscription(subOther.subscriptionId));
   } finally {
     await service.stop();
@@ -1302,6 +1305,7 @@ test("terminal lifecycle retirements honor gracePeriodSecs until gc reaches reti
     const secondGc = service.gc();
     assert.equal(secondGc.removedSubscriptions, 1);
     assert.equal(store.getSubscription(subscription.subscriptionId), null);
+    assert.equal(store.getConsumerBySubscriptionId(subscription.subscriptionId), null);
   } finally {
     await service.stop();
     store.close();

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -162,7 +162,7 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 3);
+    assert.equal(state.appliedCount, 4);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 0);
@@ -179,7 +179,7 @@ test("store upgrades a legacy v12 database with backup and forward migration", a
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 3);
+    assert.equal(state.appliedCount, 4);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 1);
@@ -1100,6 +1100,208 @@ test("subscription register rejects invalid cleanupPolicy combinations", async (
       }),
       /cleanupPolicy mode at requires a valid ISO8601 at timestamp/,
     );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("gc removes subscriptions whose cleanupPolicy deadline has passed", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const agent = await registerTmuxAgent(service, "cleanup-deadline");
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "cleanup-deadline-demo",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agentId,
+      sourceId: source.sourceId,
+      cleanupPolicy: { mode: "at", at: "2020-01-01T00:00:00.000Z" },
+      startPolicy: "latest",
+    });
+
+    const result = service.gc();
+    assert.equal(result.removedSubscriptions, 1);
+    assert.equal(store.getSubscription(subscription.subscriptionId), null);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("terminal lifecycle signals schedule retirements and gc removes matching subscriptions after delivery", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "lifecycle-demo.mjs"),
+      `export default {
+  id: "demo.lifecycle",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    return { sourceNativeId: String(raw.id), eventVariant: "demo.lifecycle", metadata: { ref: raw.ref }, rawPayload: raw };
+  },
+  projectLifecycleSignal(raw) {
+    if (raw.state !== "closed") return null;
+    return { ref: String(raw.ref), terminal: true, state: "closed", result: raw.result ?? null };
+  }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "lifecycle-demo",
+      config: {
+        profilePath: "lifecycle-demo.mjs",
+        profileConfig: {},
+      },
+    });
+    const agentA = await registerTmuxAgent(service, "lifecycle-a");
+    const agentB = await registerTmuxAgent(service, "lifecycle-b");
+    const subA = await service.registerSubscription({
+      agentId: agentA.agentId,
+      sourceId: source.sourceId,
+      trackedResourceRef: "pr:1",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: { payload: { ref: "pr:1" } },
+      startPolicy: "earliest",
+    });
+    const subB = await service.registerSubscription({
+      agentId: agentB.agentId,
+      sourceId: source.sourceId,
+      trackedResourceRef: "pr:1",
+      cleanupPolicy: { mode: "on_terminal_or_at", at: "2030-01-01T00:00:00.000Z" },
+      filter: { payload: { ref: "pr:1" } },
+      startPolicy: "earliest",
+    });
+    const subOther = await service.registerSubscription({
+      agentId: agentA.agentId,
+      sourceId: source.sourceId,
+      trackedResourceRef: "pr:2",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: { payload: { ref: "pr:2" } },
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "evt-terminal-1",
+      eventVariant: "demo.lifecycle",
+      metadata: { ref: "pr:1" },
+      rawPayload: { id: "evt-terminal-1", ref: "pr:1", state: "closed", result: "merged" },
+      occurredAt: "2020-06-01T00:00:00.000Z",
+    });
+
+    await service.pollSubscription(subA.subscriptionId);
+    await service.pollSubscription(subB.subscriptionId);
+    await service.pollSubscription(subOther.subscriptionId);
+
+    assert.equal(service.listInboxItems(agentA.agentId).length, 1);
+    assert.equal(service.listInboxItems(agentB.agentId).length, 1);
+    assert.equal(store.listSubscriptionLifecycleRetirements().length, 2);
+
+    const gc = service.gc();
+    assert.equal(gc.removedSubscriptions, 2);
+    assert.equal(store.getSubscription(subA.subscriptionId), null);
+    assert.equal(store.getSubscription(subB.subscriptionId), null);
+    assert.ok(store.getSubscription(subOther.subscriptionId));
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("terminal lifecycle retirements honor gracePeriodSecs until gc reaches retireAt", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "lifecycle-grace.mjs"),
+      `export default {
+  id: "demo.lifecycle.grace",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    return { sourceNativeId: String(raw.id), eventVariant: "demo.lifecycle", metadata: {}, rawPayload: raw };
+  },
+  projectLifecycleSignal(raw) {
+    return raw.state === "closed" ? { ref: String(raw.ref), terminal: true, state: "closed" } : null;
+  }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "lifecycle-grace-demo",
+      config: {
+        profilePath: "lifecycle-grace.mjs",
+        profileConfig: {},
+      },
+    });
+    const agent = await registerTmuxAgent(service, "lifecycle-grace");
+    const subscription = await service.registerSubscription({
+      agentId: agent.agentId,
+      sourceId: source.sourceId,
+      trackedResourceRef: "pr:9",
+      cleanupPolicy: { mode: "on_terminal", gracePeriodSecs: 3600 },
+      filter: { payload: { ref: "pr:9" } },
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "evt-terminal-grace",
+      eventVariant: "demo.lifecycle",
+      metadata: {},
+      rawPayload: { id: "evt-terminal-grace", ref: "pr:9", state: "closed" },
+      occurredAt: "2026-06-01T00:00:00.000Z",
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+
+    const scheduled = store.getSubscriptionLifecycleRetirement(subscription.subscriptionId);
+    assert.ok(scheduled);
+    assert.equal(scheduled?.retireAt, "2026-06-01T01:00:00.000Z");
+
+    const firstGc = service.gc();
+    assert.equal(firstGc.removedSubscriptions, 0);
+    assert.ok(store.getSubscription(subscription.subscriptionId));
+
+    store.upsertSubscriptionLifecycleRetirement({
+      ...scheduled!,
+      retireAt: "2020-01-01T00:00:00.000Z",
+      updatedAt: nowIso(),
+    });
+    const secondGc = service.gc();
+    assert.equal(secondGc.removedSubscriptions, 1);
+    assert.equal(store.getSubscription(subscription.subscriptionId), null);
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
Closes #59

## Summary
- add generic lifecycle signal projection for remote-backed sources
- add cleanup-policy-driven terminal retire queue and deadline cleanup pass
- cover deadline, immediate terminal retire, and grace-period retire in service tests

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "gc removes subscriptions whose cleanupPolicy deadline has passed|terminal lifecycle signals schedule retirements and gc removes matching subscriptions after delivery|terminal lifecycle retirements honor gracePeriodSecs until gc reaches retireAt" test/agentinbox.test.ts