### PR TITLE
feat: dogfood github pr lifecycle projection

### DIFF
--- a/docs/site/reference/source-types.md
+++ b/docs/site/reference/source-types.md
@@ -48,10 +48,10 @@ Builtin `github_repo` also exposes pull-request lifecycle hooks for the generic
 cleanup-policy pipeline:
 
 - `deriveTrackedResource` can derive `pr:<number>` from pull-request filters
-- `projectLifecycleSignal` treats `PullRequestEvent.closed` and
-  `PullRequestEvent.merged` as terminal PR lifecycle signals
-- merged PRs project `result = "merged"`; plain closes project
-  `result = "closed"`
+- `projectLifecycleSignal` treats `PullRequestEvent.closed` as the terminal PR
+  lifecycle signal
+- `terminalResult` is derived from the pull request `merged` flag:
+  merged PRs project `"merged"`; plain closes project `"closed"`
 
 ## `github_repo_ci`
 

--- a/docs/site/reference/source-types.md
+++ b/docs/site/reference/source-types.md
@@ -44,6 +44,15 @@ Configuration fields:
 - review comments
 - collaboration activity
 
+Builtin `github_repo` also exposes pull-request lifecycle hooks for the generic
+cleanup-policy pipeline:
+
+- `deriveTrackedResource` can derive `pr:<number>` from pull-request filters
+- `projectLifecycleSignal` treats `PullRequestEvent.closed` and
+  `PullRequestEvent.merged` as terminal PR lifecycle signals
+- merged PRs project `result = "merged"`; plain closes project
+  `result = "closed"`
+
 ## `github_repo_ci`
 
 `github_repo_ci` polls GitHub Actions workflow runs and is best suited for CI

--- a/src/source_schema.ts
+++ b/src/source_schema.ts
@@ -59,7 +59,7 @@ const SOURCE_SCHEMAS: Record<SourceType, SourceSchema> = {
       {
         id: "1234567892",
         type: "PullRequestEvent",
-        action: "merged",
+        action: "closed",
         actor: "jolestar",
         pull_request: { number: 72, title: "feat: add cleanup policy lifecycle engine", merged: true },
       },
@@ -68,7 +68,6 @@ const SOURCE_SCHEMAS: Record<SourceType, SourceSchema> = {
       "IssueCommentEvent.created",
       "PullRequestEvent.opened",
       "PullRequestEvent.closed",
-      "PullRequestEvent.merged",
       "PullRequestReviewEvent.created",
       "PullRequestReviewCommentEvent.created",
     ],

--- a/src/source_schema.ts
+++ b/src/source_schema.ts
@@ -56,8 +56,22 @@ const SOURCE_SCHEMAS: Record<SourceType, SourceSchema> = {
         pull_request: { number: 67, title: "feat: add remote module capability hooks" },
         review: { state: "commented", body: "review summary" },
       },
+      {
+        id: "1234567892",
+        type: "PullRequestEvent",
+        action: "merged",
+        actor: "jolestar",
+        pull_request: { number: 72, title: "feat: add cleanup policy lifecycle engine", merged: true },
+      },
     ],
-    eventVariantExamples: ["IssueCommentEvent.created", "PullRequestEvent.opened", "PullRequestReviewEvent.created", "PullRequestReviewCommentEvent.created"],
+    eventVariantExamples: [
+      "IssueCommentEvent.created",
+      "PullRequestEvent.opened",
+      "PullRequestEvent.closed",
+      "PullRequestEvent.merged",
+      "PullRequestReviewEvent.created",
+      "PullRequestReviewCommentEvent.created",
+    ],
     configFields: [
       { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
       { name: "repo", type: "string", required: true, description: "GitHub repository name." },

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -188,7 +188,7 @@ export function deriveGithubTrackedResource(filter: SubscriptionFilter): { ref: 
   const payload = asRecord(filter.payload);
   const number = asNumber(metadata.number) ?? asNumber(payload.number) ?? asNumber(payload.ref);
   const isPullRequest = asBoolean(metadata.isPullRequest);
-  if (!number || isPullRequest === false) {
+  if (!number || isPullRequest !== true) {
     return null;
   }
   return { ref: `pr:${number}` };

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -4,6 +4,7 @@ import {
   DeliveryAttempt,
   DeliveryHandle,
   DeliveryRequest,
+  SubscriptionFilter,
   SubscriptionSource,
 } from "../model";
 
@@ -176,8 +177,48 @@ export function normalizeGithubRepoEvent(
       pull_request: pullRequest,
       review,
       comment,
+      merged: asBoolean(pullRequest.merged),
     },
     deliveryHandle,
+  };
+}
+
+export function deriveGithubTrackedResource(filter: SubscriptionFilter): { ref: string } | null {
+  const metadata = asRecord(filter.metadata);
+  const payload = asRecord(filter.payload);
+  const number = asNumber(metadata.number) ?? asNumber(payload.number) ?? asNumber(payload.ref);
+  const isPullRequest = asBoolean(metadata.isPullRequest);
+  if (!number || isPullRequest === false) {
+    return null;
+  }
+  return { ref: `pr:${number}` };
+}
+
+export function projectGithubLifecycleSignal(rawPayload: Record<string, unknown>): {
+  ref: string;
+  terminal: boolean;
+  state: string;
+  result: string;
+} | null {
+  const eventType = asString(rawPayload.type);
+  if (eventType !== "PullRequestEvent") {
+    return null;
+  }
+  const action = asString(rawPayload.action);
+  if (action !== "closed" && action !== "merged") {
+    return null;
+  }
+  const pullRequest = asRecord(rawPayload.pull_request);
+  const number = asNumber(pullRequest.number);
+  if (!number) {
+    return null;
+  }
+  const merged = action === "merged" || asBoolean(rawPayload.merged) === true || asBoolean(pullRequest.merged) === true;
+  return {
+    ref: `pr:${number}`,
+    terminal: true,
+    state: "closed",
+    result: merged ? "merged" : "closed",
   };
 }
 
@@ -293,6 +334,10 @@ function asString(value: unknown): string | null {
 
 function asNumber(value: unknown): number | null {
   return typeof value === "number" ? value : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
 }
 
 function asStringArray(value: unknown): string[] | null {

--- a/src/sources/remote_profiles.ts
+++ b/src/sources/remote_profiles.ts
@@ -4,9 +4,11 @@ import { pathToFileURL } from "node:url";
 import { PollSubscriptionConfig, RuntimeInvokeOptions } from "@holon-run/uxc-daemon-client";
 import { AppendSourceEventInput, CleanupPolicy, SourceSchemaField, SubscriptionFilter, SubscriptionSource } from "../model";
 import {
+  deriveGithubTrackedResource,
   GITHUB_ENDPOINT,
   normalizeGithubRepoEvent,
   parseGithubSourceConfig,
+  projectGithubLifecycleSignal,
 } from "./github";
 import {
   DEFAULT_GITHUB_CI_PER_PAGE,
@@ -259,9 +261,29 @@ const GITHUB_REPO_PROFILE: RemoteSourceProfile = {
           pull_request: { number: 67, title: "feat: add remote module capability hooks" },
           review: { state: "commented", body: "review summary" },
         },
+        {
+          id: "1234567892",
+          type: "PullRequestEvent",
+          action: "merged",
+          actor: "jolestar",
+          pull_request: { number: 72, title: "feat: add cleanup policy lifecycle engine", merged: true },
+        },
       ],
-      eventVariantExamples: ["IssueCommentEvent.created", "PullRequestEvent.opened", "PullRequestReviewEvent.created", "PullRequestReviewCommentEvent.created"],
+      eventVariantExamples: [
+        "IssueCommentEvent.created",
+        "PullRequestEvent.opened",
+        "PullRequestEvent.closed",
+        "PullRequestEvent.merged",
+        "PullRequestReviewEvent.created",
+        "PullRequestReviewCommentEvent.created",
+      ],
     };
+  },
+  deriveTrackedResource(filter: SubscriptionFilter): { ref: string } | null {
+    return deriveGithubTrackedResource(filter);
+  },
+  projectLifecycleSignal(rawPayload: Record<string, unknown>) {
+    return projectGithubLifecycleSignal(rawPayload);
   },
   validateConfig(source: SubscriptionSource): void {
     parseGithubSourceConfig(source);

--- a/src/sources/remote_profiles.ts
+++ b/src/sources/remote_profiles.ts
@@ -264,7 +264,7 @@ const GITHUB_REPO_PROFILE: RemoteSourceProfile = {
         {
           id: "1234567892",
           type: "PullRequestEvent",
-          action: "merged",
+          action: "closed",
           actor: "jolestar",
           pull_request: { number: 72, title: "feat: add cleanup policy lifecycle engine", merged: true },
         },
@@ -273,7 +273,6 @@ const GITHUB_REPO_PROFILE: RemoteSourceProfile = {
         "IssueCommentEvent.created",
         "PullRequestEvent.opened",
         "PullRequestEvent.closed",
-        "PullRequestEvent.merged",
         "PullRequestReviewEvent.created",
         "PullRequestReviewCommentEvent.created",
       ],

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -540,8 +540,8 @@ test("builtin remote-backed source details expose resolved remote identity", asy
     assert.equal(details.schema.implementationId, "builtin.github_repo");
     assert.deepEqual(details.schema.aliases, ["github_repo"]);
     assert.deepEqual(details.schema.subscriptionSchema, {
-      supportsTrackedResourceRef: false,
-      supportsLifecycleSignals: false,
+      supportsTrackedResourceRef: true,
+      supportsLifecycleSignals: true,
       shortcuts: [],
     });
   } finally {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -1,7 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { GithubDeliveryAdapter, GithubUxcClient, normalizeGithubRepoEvent, type GithubCallClient } from "../src/sources/github";
-import { DeliveryAttempt, SubscriptionSource } from "../src/model";
+import {
+  deriveGithubTrackedResource,
+  GithubDeliveryAdapter,
+  GithubUxcClient,
+  normalizeGithubRepoEvent,
+  projectGithubLifecycleSignal,
+  type GithubCallClient,
+} from "../src/sources/github";
+import { DeliveryAttempt, SubscriptionSource, SubscriptionFilter } from "../src/model";
 
 class FakeUxcClient implements GithubCallClient {
   public calls: Array<Record<string, unknown>> = [];
@@ -104,6 +111,81 @@ test("normalizeGithubRepoEvent includes PullRequestReviewEvent by default", asyn
   });
   assert.equal(normalized.deliveryHandle?.surface, "issue_comment");
   assert.equal(normalized.deliveryHandle?.targetRef, "holon-run/agentinbox#67");
+});
+
+test("normalizeGithubRepoEvent preserves pull request merged state for lifecycle hooks", async () => {
+  const source: SubscriptionSource = {
+    sourceId: "src_pr",
+    sourceType: "github_repo",
+    sourceKey: "holon-run/agentinbox",
+    config: { owner: "holon-run", repo: "agentinbox" },
+    configRef: null,
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const normalized = normalizeGithubRepoEvent(source, { owner: "holon-run", repo: "agentinbox" }, {
+    id: "300",
+    type: "PullRequestEvent",
+    created_at: "2026-04-14T04:39:12Z",
+    actor: { login: "jolestar" },
+    repo: { name: "holon-run/agentinbox" },
+    payload: {
+      action: "closed",
+      pull_request: {
+        number: 72,
+        title: "feat: add cleanup policy lifecycle engine",
+        merged: true,
+      },
+    },
+  });
+
+  assert.ok(normalized);
+  assert.equal(normalized.eventVariant, "PullRequestEvent.closed");
+  assert.equal(normalized.rawPayload?.merged, true);
+  assert.deepEqual(normalized.rawPayload?.pull_request, {
+    number: 72,
+    title: "feat: add cleanup policy lifecycle engine",
+    merged: true,
+  });
+});
+
+test("github pull request helpers derive tracked resources and terminal lifecycle results", async () => {
+  const filter: SubscriptionFilter = {
+    metadata: {
+      number: 72,
+      isPullRequest: true,
+    },
+  };
+  assert.deepEqual(deriveGithubTrackedResource(filter), { ref: "pr:72" });
+  assert.equal(deriveGithubTrackedResource({ metadata: { number: 72, isPullRequest: false } }), null);
+
+  assert.deepEqual(projectGithubLifecycleSignal({
+    type: "PullRequestEvent",
+    action: "closed",
+    pull_request: { number: 72, merged: true },
+  }), {
+    ref: "pr:72",
+    terminal: true,
+    state: "closed",
+    result: "merged",
+  });
+  assert.deepEqual(projectGithubLifecycleSignal({
+    type: "PullRequestEvent",
+    action: "closed",
+    pull_request: { number: 73, merged: false },
+  }), {
+    ref: "pr:73",
+    terminal: true,
+    state: "closed",
+    result: "closed",
+  });
+  assert.equal(projectGithubLifecycleSignal({
+    type: "PullRequestEvent",
+    action: "opened",
+    pull_request: { number: 74 },
+  }), null);
 });
 
 test("github delivery adapter maps issue comments and review replies to uxc calls", async () => {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -159,6 +159,7 @@ test("github pull request helpers derive tracked resources and terminal lifecycl
     },
   };
   assert.deepEqual(deriveGithubTrackedResource(filter), { ref: "pr:72" });
+  assert.equal(deriveGithubTrackedResource({ metadata: { number: 72 } }), null);
   assert.equal(deriveGithubTrackedResource({ metadata: { number: 72, isPullRequest: false } }), null);
 
   assert.deepEqual(projectGithubLifecycleSignal({

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -377,7 +377,7 @@ test("github_repo pull request subscriptions retire through the generic lifecycl
     fake.push("stream:github_repo:holon-run/agentinbox", {
       id: "300",
       type: "PullRequestEvent",
-      created_at: "2026-04-14T04:39:12Z",
+      created_at: "2020-04-14T04:39:12Z",
       actor: { login: "jolestar" },
       repo: { name: "holon-run/agentinbox" },
       payload: {

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -351,6 +351,71 @@ test("github_repo source materializes PullRequestReviewEvent items for PR filter
   }
 });
 
+test("github_repo pull request subscriptions retire through the generic lifecycle engine", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const source = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox" },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "remote-github-lifecycle-thread",
+      tmuxPaneId: "%904",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      trackedResourceRef: "pr:72",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: { metadata: { number: 72, isPullRequest: true } },
+      startPolicy: "earliest",
+    });
+    fake.push("stream:github_repo:holon-run/agentinbox", {
+      id: "300",
+      type: "PullRequestEvent",
+      created_at: "2026-04-14T04:39:12Z",
+      actor: { login: "jolestar" },
+      repo: { name: "holon-run/agentinbox" },
+      payload: {
+        action: "closed",
+        pull_request: {
+          number: 72,
+          title: "feat: add cleanup policy lifecycle engine",
+          merged: true,
+          html_url: "https://github.com/holon-run/agentinbox/pull/72",
+        },
+      },
+    });
+
+    const sourcePoll = await service.pollSource(source.sourceId);
+    const subscriptionPoll = await service.pollSubscription(subscription.subscriptionId);
+    const items = service.listInboxItems(agent.agent.agentId);
+    const retirement = store.getSubscriptionLifecycleRetirement(subscription.subscriptionId);
+
+    assert.equal(sourcePoll.appended, 1);
+    assert.equal(subscriptionPoll.inboxItemsCreated, 1);
+    assert.equal(items.length, 1);
+    assert.equal(items[0]?.eventVariant, "PullRequestEvent.closed");
+    assert.equal(items[0]?.metadata?.number, 72);
+    assert.ok(retirement);
+    assert.equal(retirement?.trackedResourceRef, "pr:72");
+    assert.equal(retirement?.terminalState, "closed");
+    assert.equal(retirement?.terminalResult, "merged");
+
+    const gc = service.gc();
+    assert.equal(gc.removedSubscriptions, 1);
+    assert.equal(store.getSubscription(subscription.subscriptionId), null);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("github_repo_ci builtin profile emits status transitions for one workflow run id", async () => {
   const fake = new FakeRemoteSourceClient();
   const { dir, store, service } = await makeService(fake);


### PR DESCRIPTION
Closes #60

## Summary
- add builtin github pull-request tracked-resource and lifecycle projection hooks
- propagate merged-state through normalized github pull request events
- cover github-backed auto-retire through the generic cleanup-policy lifecycle engine

## Validation
- `npm run build`
- `node --require ts-node/register --test --test-name-pattern "normalizeGithubRepoEvent|github pull request helpers derive tracked resources and terminal lifecycle results|github_repo source materializes PullRequestReviewEvent items for PR filters|github_repo pull request subscriptions retire through the generic lifecycle engine|builtin remote-backed source details expose resolved remote identity" test/github.test.ts test/remote_source.test.ts test/agentinbox.test.ts`