### PR TITLE
feat: add source remove cascade cleanup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,11 +94,16 @@ async function main(): Promise<void> {
   }
 
   if (command === "source" && normalized[1] === "remove") {
-    const sourceId = normalized[2];
-    if (!sourceId) {
-      throw new Error("usage: agentinbox source remove <sourceId>");
+    const args = normalized.slice(2);
+    const positionals = positionalArgs(args, ["--with-subscriptions"]);
+    const sourceId = positionals[0];
+    if (!sourceId || positionals[1]) {
+      throw new Error("usage: agentinbox source remove <sourceId> [--with-subscriptions]");
     }
-    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}`, undefined, "DELETE");
+    const query = buildQuery({
+      with_subscriptions: hasFlag(normalized, "--with-subscriptions") ? "true" : undefined,
+    });
+    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}${query}`, undefined, "DELETE");
     return;
   }
 
@@ -863,7 +868,7 @@ Usage:
   agentinbox source list
   agentinbox source show <sourceId>
   agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF | --clear-config-ref]
-  agentinbox source remove <sourceId>
+  agentinbox source remove <sourceId> [--with-subscriptions]
   agentinbox source pause <remoteSourceId>
   agentinbox source resume <remoteSourceId>
   agentinbox source schema <sourceId|sourceType>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,8 +94,8 @@ async function main(): Promise<void> {
   }
 
   if (command === "source" && normalized[1] === "remove") {
-    const args = normalized.slice(2);
-    const positionals = positionalArgs(args, ["--with-subscriptions"]);
+    const removeArgs = normalized.slice(2);
+    const positionals = positionalArgs(removeArgs, ["--with-subscriptions"]);
     const sourceId = positionals[0];
     if (!sourceId || positionals[1]) {
       throw new Error("usage: agentinbox source remove <sourceId> [--with-subscriptions]");

--- a/src/http.ts
+++ b/src/http.ts
@@ -194,7 +194,12 @@ function buildFastifyServer(service: AgentInboxService) {
         type: "object",
         additionalProperties: false,
         properties: {
-          with_subscriptions: { anyOf: [{ type: "boolean" }, { type: "string" }] },
+          with_subscriptions: {
+            anyOf: [
+              { type: "boolean" },
+              { type: "string", enum: ["true", "false", "1", "0"] },
+            ],
+          },
         },
       },
       response: {

--- a/src/http.ts
+++ b/src/http.ts
@@ -190,6 +190,13 @@ function buildFastifyServer(service: AgentInboxService) {
           sourceId: { type: "string", minLength: 1 },
         },
       },
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          with_subscriptions: { anyOf: [{ type: "boolean" }, { type: "string" }] },
+        },
+      },
       response: {
         200: jsonObjectSchema,
         400: errorResponseSchema,
@@ -197,7 +204,10 @@ function buildFastifyServer(service: AgentInboxService) {
     },
   }, async (request) => {
     const params = request.params as { sourceId: string };
-    return service.removeSource(decodeURIComponent(params.sourceId));
+    const query = request.query as { with_subscriptions?: boolean | string };
+    return service.removeSource(decodeURIComponent(params.sourceId), {
+      withSubscriptions: query.with_subscriptions === true || query.with_subscriptions === "true" || query.with_subscriptions === "1",
+    });
   });
 
   app.patch("/sources/:sourceId", {

--- a/src/service.ts
+++ b/src/service.ts
@@ -224,18 +224,41 @@ export class AgentInboxService {
     return this.adapters.resolveSourceSchema(source);
   }
 
-  async removeSource(sourceId: string): Promise<{ removed: boolean }> {
+  async removeSource(
+    sourceId: string,
+    options: { withSubscriptions?: boolean } = {},
+  ): Promise<{ removed: boolean; sourceId: string; removedSubscriptions: number; pausedSource: boolean }> {
     const source = this.store.getSource(sourceId);
     if (!source) {
-      return { removed: false };
+      return { removed: false, sourceId, removedSubscriptions: 0, pausedSource: false };
     }
     const subscriptions = this.store.listSubscriptionsForSource(sourceId);
-    if (subscriptions.length > 0) {
+    if (subscriptions.length > 0 && !options.withSubscriptions) {
       throw new Error("source remove requires no active subscriptions");
+    }
+    let pausedSource = false;
+    if (options.withSubscriptions) {
+      try {
+        await this.pauseSource(sourceId);
+        pausedSource = true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes("does not support pause")) {
+          throw error;
+        }
+      }
+      for (const subscription of subscriptions) {
+        await this.removeSubscription(subscription.subscriptionId);
+      }
     }
     await this.adapters.removeSource(source);
     this.store.deleteSource(sourceId);
-    return { removed: true };
+    return {
+      removed: true,
+      sourceId,
+      removedSubscriptions: subscriptions.length,
+      pausedSource,
+    };
   }
 
   async updateSource(sourceId: string, input: UpdateSourceInput): Promise<{ updated: boolean; source: SubscriptionSource | null }> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -234,18 +234,16 @@ export class AgentInboxService {
     }
     const subscriptions = this.store.listSubscriptionsForSource(sourceId);
     if (subscriptions.length > 0 && !options.withSubscriptions) {
-      throw new Error("source remove requires no active subscriptions");
+      throw new Error(
+        "source remove requires no active subscriptions; retry with --with-subscriptions or with_subscriptions=true",
+      );
     }
     let pausedSource = false;
     if (options.withSubscriptions) {
-      try {
+      const sourceAdapter = this.adapters.sourceAdapterFor(source.sourceType);
+      if (sourceAdapter.pauseSource) {
         await this.pauseSource(sourceId);
         pausedSource = true;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (!message.includes("does not support pause")) {
-          throw error;
-        }
       }
       for (const subscription of subscriptions) {
         await this.removeSubscription(subscription.subscriptionId);

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -817,6 +817,42 @@ test("removeSource rejects when source still has subscriptions", async () => {
   }
 });
 
+test("removeSource --with-subscriptions removes source together with dependent subscriptions", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "remove-with-subscriptions-demo",
+      config: {},
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "remove-with-subscriptions-thread",
+      tmuxPaneId: "%902",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    const removed = await service.removeSource(source.sourceId, { withSubscriptions: true });
+
+    assert.equal(removed.removed, true);
+    assert.equal(removed.sourceId, source.sourceId);
+    assert.equal(removed.removedSubscriptions, 1);
+    assert.equal(removed.pausedSource, false);
+    assert.equal(store.getSource(source.sourceId), null);
+    assert.equal(store.getSubscription(subscription.subscriptionId), null);
+    assert.equal(store.getConsumerBySubscriptionId(subscription.subscriptionId), null);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("updateSource preserves source identity and existing subscriptions", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1588,6 +1588,78 @@ test("control plane source details degrade when remote_source resolution fails b
   }
 });
 
+test("control plane source remove accepts with_subscriptions for explicit cascade cleanup", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-control-plane-remove-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const source = await client.request<{ sourceId: string }>("/sources", {
+        sourceType: "local_event",
+        sourceKey: "control-plane-remove-cascade",
+        config: {},
+      });
+      const registered = await client.request<{ agent: { agentId: string } }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "control-plane-remove-cascade-thread",
+        tmuxPaneId: "%320",
+      });
+      const subscription = await client.request<{ subscriptionId: string }>("/subscriptions", {
+        agentId: registered.data.agent.agentId,
+        sourceId: source.data.sourceId,
+      });
+
+      const removed = await client.request<{
+        removed: boolean;
+        sourceId: string;
+        removedSubscriptions: number;
+        pausedSource: boolean;
+      }>(`/sources/${encodeURIComponent(source.data.sourceId)}?with_subscriptions=true`, undefined, "DELETE");
+
+      assert.equal(removed.statusCode, 200);
+      assert.equal(removed.data.removed, true);
+      assert.equal(removed.data.sourceId, source.data.sourceId);
+      assert.equal(removed.data.removedSubscriptions, 1);
+      assert.equal(removed.data.pausedSource, false);
+
+      const missingSubscription = await client.request(
+        `/subscriptions/${encodeURIComponent(subscription.data.subscriptionId)}`,
+        undefined,
+        "GET",
+      );
+      assert.equal(missingSubscription.statusCode, 404);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 async function waitFor<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: NodeJS.Timeout | null = null;
   const timeout = new Promise<never>((_, reject) => {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1660,6 +1660,55 @@ test("control plane source remove accepts with_subscriptions for explicit cascad
   }
 });
 
+test("control plane source remove rejects invalid with_subscriptions query values", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-rm-invalid-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const source = await client.request<{ sourceId: string }>("/sources", {
+        sourceType: "local_event",
+        sourceKey: "control-plane-remove-invalid",
+        config: {},
+      });
+
+      const invalid = await client.request(
+        `/sources/${encodeURIComponent(source.data.sourceId)}?with_subscriptions=yes`,
+        undefined,
+        "DELETE",
+      );
+      assert.equal(invalid.statusCode, 400);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 async function waitFor<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: NodeJS.Timeout | null = null;
   const timeout = new Promise<never>((_, reject) => {

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -533,6 +533,72 @@ test("removeSource deletes managed source binding when no subscriptions remain",
   }
 });
 
+test("remote_source remove --with-subscriptions stops remote binding and deletes dependent subscriptions", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "demo-remove-cascade.mjs"),
+      `export default {
+  id: "demo.remove.cascade",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return { sourceNativeId: "demo:" + raw.id, eventVariant: "demo.event", metadata: {}, rawPayload: raw };
+  }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "remove-cascade-key",
+      config: {
+        profilePath: "demo-remove-cascade.mjs",
+        profileConfig: {},
+      },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "remote-remove-cascade-thread",
+      tmuxPaneId: "%905",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    const removed = await service.removeSource(source.sourceId, { withSubscriptions: true });
+    assert.equal(removed.removed, true);
+    assert.equal(removed.removedSubscriptions, 1);
+    assert.equal(removed.pausedSource, true);
+    assert.equal(store.getSource(source.sourceId), null);
+    assert.equal(store.getSubscription(subscription.subscriptionId), null);
+    assert.equal(fake.stoppedSources.length, 1);
+    assert.equal(fake.stoppedSources[0]?.sourceKey, "remote_source:remove-cascade-key");
+    assert.equal(fake.deletedSources.length, 1);
+    assert.equal(fake.deletedSources[0]?.sourceKey, "remote_source:remove-cascade-key");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function checkpointKeyForPayload(
   payload: unknown,
   strategy: NonNullable<ManagedSourceSpec["poll_config"]>["checkpoint_strategy"],


### PR DESCRIPTION
Closes #52

## Summary
- add an explicit `source remove --with-subscriptions` cleanup path
- keep default source removal safe when subscriptions still exist
- return removal summaries including removed subscription count and whether the source was paused first

## Validation
- `npm run build`
- `node --require ts-node/register --test --test-name-pattern "removeSource rejects when source still has subscriptions|removeSource --with-subscriptions removes source together with dependent subscriptions|remote_source remove --with-subscriptions stops remote binding and deletes dependent subscriptions|control plane source remove accepts with_subscriptions for explicit cascade cleanup" test/agentinbox.test.ts test/remote_source.test.ts test/control_plane.test.ts`