### PR TITLE
feat: add generic subscription shortcuts

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -13,7 +13,7 @@ import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubDeliveryAdapter } from "./sources/github";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
-import { LifecycleSignal, RemoteSourceProfileRegistry } from "./sources/remote_profiles";
+import { ExpandedSubscriptionInput, LifecycleSignal, RemoteSourceProfileRegistry } from "./sources/remote_profiles";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
 
 export interface SourceAdapter {
@@ -181,6 +181,16 @@ export class AdapterRegistry {
       return null;
     }
     return this.remoteSource.projectLifecycleSignal(source, rawPayload);
+  }
+
+  async expandSubscriptionShortcut(
+    source: SubscriptionSource,
+    input: { name: string; args?: Record<string, unknown> },
+  ): Promise<ExpandedSubscriptionInput | null> {
+    if (source.sourceType === "local_event") {
+      return null;
+    }
+    return this.remoteSource.expandSubscriptionShortcut(source, input);
   }
 
   status(): Record<string, unknown> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -267,6 +267,8 @@ async function main(): Promise<void> {
     const args = normalized.slice(2);
     const positionals = positionalArgs(args, [
       "--agent-id",
+      "--shortcut",
+      "--shortcut-args-json",
       "--filter-json",
       "--filter-file",
       "--tracked-resource-ref",
@@ -277,17 +279,28 @@ async function main(): Promise<void> {
     ]);
     const sourceId = positionals[0];
     if (!sourceId || positionals[1]) {
-      throw new Error("usage: agentinbox subscription add <sourceId> [--agent-id ID] [--filter-json JSON | --filter-file PATH | --filter-stdin] [--tracked-resource-ref REF] [--cleanup-policy-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
+      throw new Error("usage: agentinbox subscription add <sourceId> [--agent-id ID] [--shortcut NAME --shortcut-args-json JSON] [--filter-json JSON | --filter-file PATH | --filter-stdin] [--tracked-resource-ref REF] [--cleanup-policy-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
     }
     const selection = await selectAgentForCommand(client, {
       explicitAgentId: takeFlagValue(normalized, "--agent-id"),
       autoRegister: true,
     });
+    const shortcutName = takeFlagValue(normalized, "--shortcut");
+    const shortcutArgsJson = takeFlagValue(normalized, "--shortcut-args-json");
+    if (shortcutName && (hasFlag(normalized, "--filter-stdin") || takeFlagValue(normalized, "--filter-json") != null || takeFlagValue(normalized, "--filter-file") != null || takeFlagValue(normalized, "--tracked-resource-ref") != null || takeFlagValue(normalized, "--cleanup-policy-json") != null)) {
+      throw new Error("subscription add shortcut does not allow filter, trackedResourceRef, or cleanupPolicy flags");
+    }
     const cleanupPolicyJson = takeFlagValue(normalized, "--cleanup-policy-json");
     const response = await requestRemote<Record<string, unknown>>(client, "/subscriptions", {
       agentId: selection.agentId,
       sourceId,
-      filter: readSubscriptionFilter(normalized),
+      shortcut: shortcutName
+        ? {
+            name: shortcutName,
+            args: shortcutArgsJson != null ? parseJsonArg(shortcutArgsJson, "--shortcut-args-json") : {},
+          }
+        : undefined,
+      filter: shortcutName ? undefined : readSubscriptionFilter(normalized),
       trackedResourceRef: takeFlagValue(normalized, "--tracked-resource-ref") ?? undefined,
       cleanupPolicy: cleanupPolicyJson != null
         ? parseJsonArg(cleanupPolicyJson, "--cleanup-policy-json")
@@ -890,7 +903,7 @@ Usage:
     subscription: `agentinbox subscription
 
 Usage:
-  agentinbox subscription add <sourceId> [--agent-id ID] [--filter-json JSON | --filter-file PATH | --filter-stdin] [--tracked-resource-ref REF] [--cleanup-policy-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
+  agentinbox subscription add <sourceId> [--agent-id ID] [--shortcut NAME --shortcut-args-json JSON] [--filter-json JSON | --filter-file PATH | --filter-stdin] [--tracked-resource-ref REF] [--cleanup-policy-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
   agentinbox subscription list [--source-id ID] [--agent-id ID]
   agentinbox subscription show <subscriptionId>
   agentinbox subscription remove <subscriptionId>

--- a/src/http.ts
+++ b/src/http.ts
@@ -620,6 +620,15 @@ function buildFastifyServer(service: AgentInboxService) {
         properties: {
           agentId: { type: "string", minLength: 1 },
           sourceId: { type: "string", minLength: 1 },
+          shortcut: {
+            type: "object",
+            additionalProperties: false,
+            required: ["name"],
+            properties: {
+              name: { type: "string", minLength: 1 },
+              args: jsonObjectSchema,
+            },
+          },
           filter: jsonObjectSchema,
           trackedResourceRef: { type: "string" },
           cleanupPolicy: jsonObjectSchema,
@@ -638,7 +647,15 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.registerSubscription({
       agentId: String(body.agentId),
       sourceId: String(body.sourceId),
-      filter: (body.filter as Record<string, unknown> | undefined) ?? {},
+      shortcut: body.shortcut && typeof body.shortcut === "object"
+        ? {
+            name: String((body.shortcut as Record<string, unknown>).name),
+            args: ((body.shortcut as Record<string, unknown>).args as Record<string, unknown> | undefined) ?? undefined,
+          }
+        : undefined,
+      filter: body.filter && typeof body.filter === "object"
+        ? (body.filter as Record<string, unknown>)
+        : undefined,
       trackedResourceRef: optionalString(body.trackedResourceRef) ?? null,
       cleanupPolicy: (body.cleanupPolicy as Record<string, unknown> | undefined) as never,
       startPolicy: optionalString(body.startPolicy) as never,

--- a/src/http.ts
+++ b/src/http.ts
@@ -1125,6 +1125,8 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("unsupported terminal") ||
     message.startsWith("cleanupPolicy ") ||
     message.startsWith("trackedResourceRef ") ||
+    message.startsWith("subscription add shortcut") ||
+    message.startsWith("unknown subscription shortcut ") ||
     message.startsWith("expected boolean") ||
     message.startsWith("expected integer") ||
     message.startsWith("expected positive integer") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -226,6 +226,10 @@ export interface AddWebhookActivationTargetInput {
 export interface RegisterSubscriptionInput {
   agentId: string;
   sourceId: string;
+  shortcut?: {
+    name: string;
+    args?: Record<string, unknown>;
+  };
   filter?: SubscriptionFilter;
   trackedResourceRef?: string | null;
   cleanupPolicy?: CleanupPolicy | null;

--- a/src/service.ts
+++ b/src/service.ts
@@ -492,6 +492,26 @@ export class AgentInboxService {
   }
 
   async registerSubscription(input: RegisterSubscriptionInput): Promise<Subscription> {
+    if (input.shortcut) {
+      const source = this.store.getSource(input.sourceId);
+      if (!source) {
+        throw new Error(`unknown source: ${input.sourceId}`);
+      }
+      if (hasSubscriptionFieldOverride(input)) {
+        throw new Error("subscription add shortcut does not allow filter, trackedResourceRef, or cleanupPolicy overrides");
+      }
+      const expanded = await this.adapters.expandSubscriptionShortcut(source, input.shortcut);
+      if (!expanded) {
+        throw new Error(`unknown subscription shortcut ${input.shortcut.name} for source ${input.sourceId}`);
+      }
+      return this.registerSubscription({
+        ...input,
+        shortcut: undefined,
+        filter: expanded.filter,
+        trackedResourceRef: expanded.trackedResourceRef ?? null,
+        cleanupPolicy: expanded.cleanupPolicy,
+      });
+    }
     this.getAgent(input.agentId);
     const source = this.store.getSource(input.sourceId);
     if (!source) {
@@ -1646,6 +1666,13 @@ export class AgentInboxService {
       console.warn("offline agent gc failed:", error);
     }
   }
+}
+
+function hasSubscriptionFieldOverride(input: RegisterSubscriptionInput): boolean {
+  if (input.trackedResourceRef != null || input.cleanupPolicy != null) {
+    return true;
+  }
+  return input.filter != null && Object.keys(input.filter).length > 0;
 }
 
 function normalizeTrackedResourceRef(value: string | null | undefined): string | null {

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -4,6 +4,7 @@ import {
   DeliveryAttempt,
   DeliveryHandle,
   DeliveryRequest,
+  SourceSchemaField,
   SubscriptionFilter,
   SubscriptionSource,
 } from "../model";
@@ -192,6 +193,45 @@ export function deriveGithubTrackedResource(filter: SubscriptionFilter): { ref: 
     return null;
   }
   return { ref: `pr:${number}` };
+}
+
+export function githubSubscriptionShortcutSpec(): Array<{
+  name: string;
+  description: string;
+  argsSchema: SourceSchemaField[];
+}> {
+  return [{
+    name: "pr",
+    description: "Follow one pull request and auto-retire when it closes.",
+    argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+  }];
+}
+
+export function expandGithubSubscriptionShortcut(input: {
+  name: string;
+  args?: Record<string, unknown>;
+}): {
+  filter: SubscriptionFilter;
+  trackedResourceRef: string;
+  cleanupPolicy: { mode: "on_terminal" };
+} | null {
+  if (input.name !== "pr") {
+    return null;
+  }
+  const number = typeof input.args?.number === "number" ? input.args.number : null;
+  if (!number || !Number.isInteger(number) || number <= 0) {
+    throw new Error("subscription shortcut pr requires a positive integer number");
+  }
+  return {
+    filter: {
+      metadata: {
+        number,
+        isPullRequest: true,
+      },
+    },
+    trackedResourceRef: `pr:${number}`,
+    cleanupPolicy: { mode: "on_terminal" },
+  };
 }
 
 export function projectGithubLifecycleSignal(rawPayload: Record<string, unknown>): {

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -3,7 +3,7 @@ import { AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "..
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
 import { nowIso } from "../util";
-import { LifecycleSignal, ManagedSourceSpec, RemoteSourceProfileRegistry } from "./remote_profiles";
+import { ExpandedSubscriptionInput, LifecycleSignal, ManagedSourceSpec, RemoteSourceProfileRegistry } from "./remote_profiles";
 
 const REMOTE_SOURCE_TYPES = new Set<SubscriptionSource["sourceType"]>([
   "remote_source",
@@ -221,6 +221,24 @@ export class RemoteSourceRuntime {
       return null;
     }
     return profile.projectLifecycleSignal(rawPayload, profileInputSource(source));
+  }
+
+  async expandSubscriptionShortcut(
+    source: SubscriptionSource,
+    input: { name: string; args?: Record<string, unknown> },
+  ): Promise<ExpandedSubscriptionInput | null> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return null;
+    }
+    const profile = await this.profileRegistry.resolve(source, this.homeDir);
+    if (typeof profile.expandSubscriptionShortcut !== "function") {
+      return null;
+    }
+    return profile.expandSubscriptionShortcut({
+      name: input.name,
+      args: input.args,
+      source: profileInputSource(source),
+    });
   }
 
   private async syncAll(): Promise<void> {

--- a/src/sources/remote_profiles.ts
+++ b/src/sources/remote_profiles.ts
@@ -5,7 +5,9 @@ import { PollSubscriptionConfig, RuntimeInvokeOptions } from "@holon-run/uxc-dae
 import { AppendSourceEventInput, CleanupPolicy, SourceSchemaField, SubscriptionFilter, SubscriptionSource } from "../model";
 import {
   deriveGithubTrackedResource,
+  expandGithubSubscriptionShortcut,
   GITHUB_ENDPOINT,
+  githubSubscriptionShortcutSpec,
   normalizeGithubRepoEvent,
   parseGithubSourceConfig,
   projectGithubLifecycleSignal,
@@ -277,6 +279,12 @@ const GITHUB_REPO_PROFILE: RemoteSourceProfile = {
         "PullRequestReviewCommentEvent.created",
       ],
     };
+  },
+  listSubscriptionShortcuts(): SubscriptionShortcutSpec[] {
+    return githubSubscriptionShortcutSpec();
+  },
+  expandSubscriptionShortcut(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | null {
+    return expandGithubSubscriptionShortcut(input);
   },
   deriveTrackedResource(filter: SubscriptionFilter): { ref: string } | null {
     return deriveGithubTrackedResource(filter);

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -542,7 +542,11 @@ test("builtin remote-backed source details expose resolved remote identity", asy
     assert.deepEqual(details.schema.subscriptionSchema, {
       supportsTrackedResourceRef: true,
       supportsLifecycleSignals: true,
-      shortcuts: [],
+      shortcuts: [{
+        name: "pr",
+        description: "Follow one pull request and auto-retire when it closes.",
+        argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+      }],
     });
   } finally {
     await service.stop();
@@ -730,6 +734,84 @@ test("source details keep a wrapped fallback schema when non-identity capability
     assert.equal(details.schema.hostType, "remote_source");
     assert.equal(details.schema.sourceKind, "remote:demo.broken-shortcuts");
     assert.equal(details.schema.implementationId, "demo.broken-shortcuts");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("subscription add can expand a remote profile shortcut into standard subscription fields", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "shortcut-expand.mjs"),
+      `export default {
+  id: "demo.shortcut.expand",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() {
+    return null;
+  },
+  listSubscriptionShortcuts() {
+    return [{
+      name: "ticket",
+      description: "Follow one ticket",
+      argsSchema: [{ name: "id", type: "string", required: true, description: "Ticket id." }]
+    }];
+  },
+  expandSubscriptionShortcut(input) {
+    if (input.name !== "ticket") return null;
+    return {
+      filter: { metadata: { ticketId: input.args.id } },
+      trackedResourceRef: "ticket:" + input.args.id,
+      cleanupPolicy: { mode: "manual" }
+    };
+  }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "shortcut-expand-demo",
+      config: {
+        profilePath: "shortcut-expand.mjs",
+        profileConfig: {},
+      },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "shortcut-expand-thread",
+      tmuxPaneId: "%944",
+    });
+
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      shortcut: {
+        name: "ticket",
+        args: { id: "A-42" },
+      },
+      startPolicy: "earliest",
+    });
+
+    assert.deepEqual(subscription.filter, { metadata: { ticketId: "A-42" } });
+    assert.equal(subscription.trackedResourceRef, "ticket:A-42");
+    assert.deepEqual(subscription.cleanupPolicy, { mode: "manual" });
+    assert.equal(subscription.startPolicy, "earliest");
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1058,6 +1058,93 @@ test("control plane subscriptions accept generic shortcut invocation", async () 
   }
 });
 
+test("control plane shortcut validation errors return 400 instead of 500", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-shortcut-error-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const profileDir = path.join(homeDir, "source-profiles");
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(profileDir, "http-shortcut-error.mjs"),
+    `export default {
+  id: "demo.http.shortcut.error",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; },
+  expandSubscriptionShortcut(input) {
+    if (input.name !== "ticket") return null;
+    return {
+      filter: { metadata: { ticketId: input.args.id } },
+      trackedResourceRef: "ticket:" + input.args.id,
+      cleanupPolicy: { mode: "manual" }
+    };
+  }
+};`,
+    "utf8",
+  );
+
+  const store = await AgentInboxStore.open(dbPath);
+  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }), { homeDir });
+  const service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+  let started: Awaited<ReturnType<typeof startControlServer>> | null = null;
+
+  try {
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "http-shortcut-error-demo",
+      config: {
+        profilePath: "http-shortcut-error.mjs",
+        profileConfig: {},
+      },
+    });
+    const registered = service.registerAgent({
+      backend: "iterm2",
+      runtimeKind: "codex",
+      runtimeSessionId: "http-shortcut-error-thread",
+      mode: "agent_prompt",
+      termProgram: "iTerm.app",
+      itermSessionId: "http-shortcut-error-session",
+    });
+
+    started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    const client = new AgentInboxClient({
+      kind: "socket",
+      socketPath,
+      source: "flag",
+    });
+
+    const response = await client.request<Record<string, unknown>>("/subscriptions", {
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      shortcut: { name: "ticket", args: { id: "A-9" } },
+      filter: { metadata: { x: 1 } },
+    }, "POST");
+    assert.equal(response.statusCode, 400);
+    assert.match(String(response.data.error), /shortcut does not allow filter, trackedResourceRef, or cleanupPolicy/);
+  } finally {
+    if (started) {
+      await started.close();
+    }
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli source pause rejects unsupported local_event sources", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-pause-"));
   const env = {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1100,14 +1100,21 @@ test("control plane shortcut validation errors return 400 instead of 500", async
   let started: Awaited<ReturnType<typeof startControlServer>> | null = null;
 
   try {
-    const source = await service.registerSource({
-      sourceType: "remote_source",
+    const source = {
+      sourceId: "src_http_shortcut_error_demo",
+      sourceType: "remote_source" as const,
       sourceKey: "http-shortcut-error-demo",
+      configRef: null,
       config: {
         profilePath: "http-shortcut-error.mjs",
         profileConfig: {},
       },
-    });
+      status: "active" as const,
+      checkpoint: null,
+      createdAt: "2026-04-14T00:00:00.000Z",
+      updatedAt: "2026-04-14T00:00:00.000Z",
+    };
+    store.insertSource(source);
     const registered = service.registerAgent({
       backend: "iterm2",
       runtimeKind: "codex",

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -855,6 +855,205 @@ test("cli subscription add accepts filter-file and filter-stdin and echoes norma
   }
 });
 
+test("cli subscription add supports generic shortcut invocation", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-shortcut-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%932",
+    CODEX_THREAD_ID: "thread-shortcut",
+  };
+
+  try {
+    const profileDir = path.join(homeDir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "cli-shortcut.mjs"),
+      `export default {
+  id: "demo.cli.shortcut",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; },
+  listSubscriptionShortcuts() {
+    return [{ name: "ticket", description: "Follow one ticket", argsSchema: [{ name: "id", type: "string", required: true, description: "Ticket id." }] }];
+  },
+  expandSubscriptionShortcut(input) {
+    if (input.name !== "ticket") return null;
+    return {
+      filter: { metadata: { ticketId: input.args.id } },
+      trackedResourceRef: "ticket:" + input.args.id,
+      cleanupPolicy: { mode: "manual" }
+    };
+  }
+};`,
+      "utf8",
+    );
+    const sourceAdd = runCli([
+      "source",
+      "add",
+      "remote_source",
+      "cli-shortcut-demo",
+      "--config-json",
+      JSON.stringify({
+        profilePath: "cli-shortcut.mjs",
+        profileConfig: {},
+      }),
+    ], env);
+    assert.equal(sourceAdd.status, 0, sourceAdd.stderr);
+    const source = JSON.parse(sourceAdd.stdout) as { sourceId: string };
+
+    const added = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--shortcut",
+      "ticket",
+      "--shortcut-args-json",
+      "{\"id\":\"A-7\"}",
+    ], env);
+    assert.equal(added.status, 0, added.stderr);
+    const payload = JSON.parse(added.stdout) as {
+      filter: Record<string, unknown>;
+      trackedResourceRef: string | null;
+      cleanupPolicy: Record<string, unknown>;
+    };
+    assert.deepEqual(payload.filter, { metadata: { ticketId: "A-7" } });
+    assert.equal(payload.trackedResourceRef, "ticket:A-7");
+    assert.deepEqual(payload.cleanupPolicy, { mode: "manual" });
+
+    const conflicting = runCli([
+      "subscription",
+      "add",
+      source.sourceId,
+      "--shortcut",
+      "ticket",
+      "--shortcut-args-json",
+      "{\"id\":\"A-7\"}",
+      "--filter-json",
+      "{\"metadata\":{\"x\":1}}",
+    ], env);
+    assert.notEqual(conflicting.status, 0);
+    assert.match(conflicting.stderr, /shortcut does not allow filter, trackedResourceRef, or cleanupPolicy flags/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane subscriptions accept generic shortcut invocation", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-shortcut-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const profileDir = path.join(homeDir, "source-profiles");
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(profileDir, "http-shortcut.mjs"),
+    `export default {
+  id: "demo.http.shortcut",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; },
+  listSubscriptionShortcuts() {
+    return [{ name: "ticket", description: "Follow one ticket", argsSchema: [{ name: "id", type: "string", required: true, description: "Ticket id." }] }];
+  },
+  expandSubscriptionShortcut(input) {
+    if (input.name !== "ticket") return null;
+    return {
+      filter: { metadata: { ticketId: input.args.id } },
+      trackedResourceRef: "ticket:" + input.args.id,
+      cleanupPolicy: { mode: "manual" }
+    };
+  }
+};`,
+    "utf8",
+  );
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const source = await client.request<{ sourceId: string }>("/sources", {
+        sourceType: "remote_source",
+        sourceKey: "http-shortcut-demo",
+        config: {
+          profilePath: "http-shortcut.mjs",
+          profileConfig: {},
+        },
+      });
+      const registered = await client.request<{ agent: { agentId: string } }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "http-shortcut-thread",
+        tmuxPaneId: "%950",
+      });
+      const subscription = await client.request<{
+        filter: Record<string, unknown>;
+        trackedResourceRef: string | null;
+        cleanupPolicy: Record<string, unknown>;
+      }>("/subscriptions", {
+        agentId: registered.data.agent.agentId,
+        sourceId: source.data.sourceId,
+        shortcut: {
+          name: "ticket",
+          args: { id: "A-9" },
+        },
+      });
+      assert.equal(subscription.statusCode, 200);
+      assert.deepEqual(subscription.data.filter, { metadata: { ticketId: "A-9" } });
+      assert.equal(subscription.data.trackedResourceRef, "ticket:A-9");
+      assert.deepEqual(subscription.data.cleanupPolicy, { mode: "manual" });
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli source pause rejects unsupported local_event sources", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-pause-"));
   const env = {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -855,8 +855,9 @@ test("cli subscription add accepts filter-file and filter-stdin and echoes norma
   }
 });
 
-test("cli subscription add supports generic shortcut invocation", () => {
+test("cli subscription add supports generic shortcut invocation", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-shortcut-"));
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
   const env = {
     ...process.env,
     AGENTINBOX_HOME: homeDir,
@@ -868,6 +869,7 @@ test("cli subscription add supports generic shortcut invocation", () => {
   };
 
   try {
+    const store = await AgentInboxStore.open(dbPath);
     const profileDir = path.join(homeDir, "source-profiles");
     fs.mkdirSync(profileDir, { recursive: true });
     fs.writeFileSync(
@@ -901,19 +903,21 @@ test("cli subscription add supports generic shortcut invocation", () => {
 };`,
       "utf8",
     );
-    const sourceAdd = runCli([
-      "source",
-      "add",
-      "remote_source",
-      "cli-shortcut-demo",
-      "--config-json",
-      JSON.stringify({
+    const source = {
+      sourceId: "src_cli_shortcut_demo",
+      sourceType: "remote_source" as const,
+      sourceKey: "cli-shortcut-demo",
+      configRef: null,
+      config: {
         profilePath: "cli-shortcut.mjs",
         profileConfig: {},
-      }),
-    ], env);
-    assert.equal(sourceAdd.status, 0, sourceAdd.stderr);
-    const source = JSON.parse(sourceAdd.stdout) as { sourceId: string };
+      },
+      status: "active" as const,
+      checkpoint: null,
+      createdAt: "2026-04-14T00:00:00.000Z",
+      updatedAt: "2026-04-14T00:00:00.000Z",
+    };
+    store.insertSource(source);
 
     const added = runCli([
       "subscription",

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -4,6 +4,8 @@ import {
   deriveGithubTrackedResource,
   GithubDeliveryAdapter,
   GithubUxcClient,
+  githubSubscriptionShortcutSpec,
+  expandGithubSubscriptionShortcut,
   normalizeGithubRepoEvent,
   projectGithubLifecycleSignal,
   type GithubCallClient,
@@ -187,6 +189,27 @@ test("github pull request helpers derive tracked resources and terminal lifecycl
     action: "opened",
     pull_request: { number: 74 },
   }), null);
+});
+
+test("github subscription shortcut helpers expose and expand the builtin pr shortcut", async () => {
+  assert.deepEqual(githubSubscriptionShortcutSpec(), [{
+    name: "pr",
+    description: "Follow one pull request and auto-retire when it closes.",
+    argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+  }]);
+  assert.deepEqual(expandGithubSubscriptionShortcut({
+    name: "pr",
+    args: { number: 74 },
+  }), {
+    filter: {
+      metadata: {
+        number: 74,
+        isPullRequest: true,
+      },
+    },
+    trackedResourceRef: "pr:74",
+    cleanupPolicy: { mode: "on_terminal" },
+  });
 });
 
 test("github delivery adapter maps issue comments and review replies to uxc calls", async () => {


### PR DESCRIPTION
Closes #56

## Summary
- add generic subscription shortcut expansion to subscription registration
- expose a builtin GitHub `pr` shortcut through resolved source schema
- add CLI, HTTP, service, and regression coverage for shortcut invocation