### PR TITLE
feat: add source schema preview

### DIFF
--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -44,6 +44,7 @@ agentinbox source remove <source_id>
 agentinbox source pause <remote_source_id>
 agentinbox source resume <remote_source_id>
 agentinbox source schema <source_id|source_type>
+agentinbox source schema preview <source_kind|source_type> [--config-json ...] [--config-ref ...]
 agentinbox source poll <source_id>
 agentinbox source event <source_id> --native-id <id> --event <variant>
 ```
@@ -55,6 +56,11 @@ resume a paused source.
 
 `source update` replaces persisted `config` and/or `configRef` in place while
 preserving the existing `sourceId` and attached subscriptions.
+
+`source schema preview` resolves a schema before source registration. Builtin
+remote-backed kinds can be previewed directly, for example `github_repo`.
+User-defined remote modules can be previewed with either `remote_source` or
+`remote:<moduleId>` plus `--config-json '{"profilePath":"...","profileConfig":{}}'`.
 
 ## Subscriptions
 

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -21,6 +21,7 @@ going forward.
 - `POST /sources`
 - `GET /sources/{sourceId}`
 - `GET /sources/{sourceId}/schema`
+- `POST /sources/schema-preview`
 - `PATCH /sources/{sourceId}`
 - `DELETE /sources/{sourceId}`
 - `POST /sources/{sourceId}/pause`
@@ -101,6 +102,10 @@ going forward.
   `POST /sources/{sourceId}/events`.
 - `remote_source` is supported and requires `config.profilePath` (and optional
   `config.profileConfig`) when registering.
+- `POST /sources/schema-preview` previews resolved schema without persisting a
+  source. It accepts `sourceRef` plus optional `config` and `configRef`. For a
+  user-defined remote implementation, use either `remote_source` with
+  `config.profilePath`, or `remote:<moduleId>` with the same config payload.
 - `PATCH /sources/{sourceId}` updates persisted `config` and/or `configRef`
   without changing the `sourceId` or existing subscriptions. Active/error
   sources are re-ensured after update; paused sources keep their paused

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,6 +147,18 @@ async function main(): Promise<void> {
   }
 
   if (command === "source" && normalized[1] === "schema") {
+    if (normalized[2] === "preview") {
+      const sourceRef = normalized[3];
+      if (!sourceRef) {
+        throw new Error("usage: agentinbox source schema preview <sourceKind|sourceType> [--config-json JSON] [--config-ref REF]");
+      }
+      await printRemote(client, "/sources/schema-preview", {
+        sourceRef,
+        configRef: takeFlagValue(normalized, "--config-ref") ?? undefined,
+        config: parseJsonArg(takeFlagValue(normalized, "--config-json")),
+      });
+      return;
+    }
     const sourceRef = normalized[2];
     if (!sourceRef) {
       throw new Error("usage: agentinbox source schema <sourceId|sourceType>");
@@ -885,6 +897,7 @@ Usage:
   agentinbox source pause <remoteSourceId>
   agentinbox source resume <remoteSourceId>
   agentinbox source schema <sourceId|sourceType>
+  agentinbox source schema preview <sourceKind|sourceType> [--config-json JSON] [--config-ref REF]
   agentinbox source poll <sourceId>
   agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]
 `,

--- a/src/http.ts
+++ b/src/http.ts
@@ -3,7 +3,7 @@ import Fastify from "fastify";
 import swagger from "@fastify/swagger";
 import { summarizeActivationTarget } from "./current_agent";
 import { AgentInboxService } from "./service";
-import { ActivationMode, DeliveryHandle, WatchInboxOptions } from "./model";
+import { ActivationMode, DeliveryHandle, PreviewSourceSchemaInput, WatchInboxOptions } from "./model";
 import { jsonResponse } from "./util";
 
 function sendSse(res: http.ServerResponse, event: string, data: unknown): void {
@@ -300,6 +300,26 @@ function buildFastifyServer(service: AgentInboxService) {
     const params = request.params as { sourceType: string };
     return service.getSourceSchema(decodeURIComponent(params.sourceType) as never);
   });
+
+  app.post("/sources/schema-preview", {
+    schema: {
+      tags: ["sources"],
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["sourceRef"],
+        properties: {
+          sourceRef: { type: "string", minLength: 1 },
+          configRef: { anyOf: [{ type: "string" }, { type: "null" }] },
+          config: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => service.previewSourceSchema(request.body as PreviewSourceSchemaInput));
 
   app.post("/sources/:sourceId/poll", {
     schema: {
@@ -1125,6 +1145,8 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("unsupported terminal") ||
     message.startsWith("cleanupPolicy ") ||
     message.startsWith("trackedResourceRef ") ||
+    message.startsWith("unknown source kind or type for preview") ||
+    message.startsWith("preview source kind ") ||
     message.startsWith("subscription add shortcut") ||
     message.startsWith("unknown subscription shortcut ") ||
     message.startsWith("expected boolean") ||

--- a/src/http.ts
+++ b/src/http.ts
@@ -1145,6 +1145,7 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("unsupported terminal") ||
     message.startsWith("cleanupPolicy ") ||
     message.startsWith("trackedResourceRef ") ||
+    message.startsWith("preview failed: ") ||
     message.startsWith("unknown source kind or type for preview") ||
     message.startsWith("preview source kind ") ||
     message.startsWith("subscription add shortcut") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -238,6 +238,12 @@ export interface RegisterSubscriptionInput {
   startTime?: string | null;
 }
 
+export interface PreviewSourceSchemaInput {
+  sourceRef: string;
+  configRef?: string | null;
+  config?: Record<string, unknown>;
+}
+
 export interface SourceSchemaField {
   name: string;
   type: string;
@@ -272,6 +278,8 @@ export interface ResolvedSourceSchema extends SourceSchema, ResolvedSourceIdenti
     }>;
   };
 }
+
+export interface SourceSchemaPreview extends Omit<ResolvedSourceSchema, "sourceId"> {}
 
 export interface AppendSourceEventInput {
   sourceId: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -227,19 +227,27 @@ export class AgentInboxService {
   }
 
   async previewSourceSchema(input: PreviewSourceSchemaInput): Promise<SourceSchemaPreview> {
-    const source = buildPreviewSource(input);
-    await this.adapters.sourceAdapterFor(source.sourceType).validateSource?.(source);
-    const schema = await this.adapters.resolveSourceSchema(source);
-    if (input.sourceRef.startsWith("remote:")) {
-      const expectedImplementationId = input.sourceRef.slice("remote:".length);
-      if (schema.implementationId !== expectedImplementationId) {
-        throw new Error(
-          `preview source kind ${input.sourceRef} resolved to implementation ${schema.implementationId}`,
-        );
+    try {
+      const source = buildPreviewSource(input);
+      await this.adapters.sourceAdapterFor(source.sourceType).validateSource?.(source);
+      const schema = await this.adapters.resolveSourceSchema(source);
+      if (input.sourceRef.startsWith("remote:")) {
+        const expectedImplementationId = input.sourceRef.slice("remote:".length);
+        if (schema.implementationId !== expectedImplementationId) {
+          throw new Error(
+            `preview source kind ${input.sourceRef} resolved to implementation ${schema.implementationId}`,
+          );
+        }
       }
+      const { sourceId: _sourceId, ...preview } = schema;
+      return preview;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.startsWith("preview failed: ") || message.startsWith("preview source kind ")) {
+        throw error;
+      }
+      throw new Error(`preview failed: ${message}`);
     }
-    const { sourceId: _sourceId, ...preview } = schema;
-    return preview;
   }
 
   async removeSource(

--- a/src/service.ts
+++ b/src/service.ts
@@ -12,6 +12,7 @@ import {
   Inbox,
   InboxItem,
   InboxWatchEvent,
+  PreviewSourceSchemaInput,
   RegisterAgentInput,
   RegisterAgentResult,
   RegisterSourceInput,
@@ -19,6 +20,7 @@ import {
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
   SourceSchema,
+  SourceSchemaPreview,
   SourcePollResult,
   Subscription,
   CleanupPolicy,
@@ -222,6 +224,22 @@ export class AgentInboxService {
   async getResolvedSourceSchema(sourceId: string): Promise<ResolvedSourceSchema> {
     const source = this.getSource(sourceId);
     return this.adapters.resolveSourceSchema(source);
+  }
+
+  async previewSourceSchema(input: PreviewSourceSchemaInput): Promise<SourceSchemaPreview> {
+    const source = buildPreviewSource(input);
+    await this.adapters.sourceAdapterFor(source.sourceType).validateSource?.(source);
+    const schema = await this.adapters.resolveSourceSchema(source);
+    if (input.sourceRef.startsWith("remote:")) {
+      const expectedImplementationId = input.sourceRef.slice("remote:".length);
+      if (schema.implementationId !== expectedImplementationId) {
+        throw new Error(
+          `preview source kind ${input.sourceRef} resolved to implementation ${schema.implementationId}`,
+        );
+      }
+    }
+    const { sourceId: _sourceId, ...preview } = schema;
+    return preview;
   }
 
   async removeSource(
@@ -1673,6 +1691,32 @@ function hasSubscriptionFieldOverride(input: RegisterSubscriptionInput): boolean
     return true;
   }
   return input.filter != null && Object.keys(input.filter).length > 0;
+}
+
+function buildPreviewSource(input: PreviewSourceSchemaInput): SubscriptionSource {
+  const sourceType = sourceTypeForPreviewRef(input.sourceRef);
+  const now = nowIso();
+  return {
+    sourceId: "__preview__",
+    sourceType,
+    sourceKey: `preview:${input.sourceRef}`,
+    configRef: input.configRef ?? null,
+    config: input.config ?? {},
+    status: "active",
+    checkpoint: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function sourceTypeForPreviewRef(sourceRef: string): SubscriptionSource["sourceType"] {
+  if (sourceRef === "local_event" || sourceRef === "remote_source" || sourceRef === "github_repo" || sourceRef === "github_repo_ci" || sourceRef === "feishu_bot") {
+    return sourceRef;
+  }
+  if (sourceRef.startsWith("remote:")) {
+    return "remote_source";
+  }
+  throw new Error(`unknown source kind or type for preview: ${sourceRef}`);
 }
 
 function normalizeTrackedResourceRef(value: string | null | undefined): string | null {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -555,6 +555,93 @@ test("builtin remote-backed source details expose resolved remote identity", asy
   }
 });
 
+test("source schema preview resolves a user-defined remote module without persisting a source", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "preview.mjs"),
+      `export default {
+  id: "demo.preview",
+  validateConfig(source) {
+    if (!source.config.token) throw new Error("preview token required");
+  },
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; },
+  describeCapabilities() {
+    return {
+      sourceKind: "remote:demo.preview",
+      configSchema: [{ name: "token", type: "string", required: true, description: "Preview token." }],
+      metadataFields: [{ name: "ticketId", type: "string", description: "Ticket id." }],
+      eventVariantExamples: ["ticket.updated"],
+      payloadExamples: [{ id: "T-1" }]
+    };
+  }
+};`,
+      "utf8",
+    );
+
+    const preview = await service.previewSourceSchema({
+      sourceRef: "remote:demo.preview",
+      config: {
+        profilePath: "preview.mjs",
+        profileConfig: { token: "demo-token" },
+      },
+    });
+    assert.equal(preview.sourceType, "remote_source");
+    assert.equal(preview.hostType, "remote_source");
+    assert.equal(preview.sourceKind, "remote:demo.preview");
+    assert.equal(preview.implementationId, "demo.preview");
+    assert.deepEqual(preview.configFields, [
+      { name: "token", type: "string", required: true, description: "Preview token." },
+    ]);
+    assert.deepEqual(preview.metadataFields, [
+      { name: "ticketId", type: "string", description: "Ticket id." },
+    ]);
+    assert.equal(store.listSources().length, 0);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("source schema preview supports builtin remote-backed aliases without persisting a source", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const preview = await service.previewSourceSchema({
+      sourceRef: "github_repo",
+      config: { owner: "holon-run", repo: "agentinbox" },
+    });
+    assert.equal(preview.sourceType, "github_repo");
+    assert.equal(preview.hostType, "remote_source");
+    assert.equal(preview.sourceKind, "github_repo");
+    assert.equal(preview.implementationId, "builtin.github_repo");
+    assert.ok(preview.subscriptionSchema);
+    assert.deepEqual(preview.subscriptionSchema?.shortcuts, [{
+      name: "pr",
+      description: "Follow one pull request and auto-retire when it closes.",
+      argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+    }]);
+    assert.equal(store.listSources().length, 0);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("remote_source capability hooks override resolved schema fields and advertise shortcut/lifecycle support", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -674,6 +674,77 @@ test("cli source schema resolves source ids to instance schema", () => {
   }
 });
 
+test("cli source schema preview resolves remote module-backed schemas before registration", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-schema-preview-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%937",
+    CODEX_THREAD_ID: "thread-source-schema-preview",
+  };
+
+  try {
+    const profileDir = path.join(homeDir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "preview.mjs"),
+      `export default {
+  id: "demo.preview",
+  validateConfig(source) {
+    if (!source.config.token) throw new Error("preview token required");
+  },
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; },
+  describeCapabilities() {
+    return {
+      sourceKind: "remote:demo.preview",
+      metadataFields: [{ name: "ticketId", type: "string", description: "Ticket id." }]
+    };
+  }
+};`,
+      "utf8",
+    );
+
+    const schema = runCli([
+      "source",
+      "schema",
+      "preview",
+      "remote:demo.preview",
+      "--config-json",
+      "{\"profilePath\":\"preview.mjs\",\"profileConfig\":{\"token\":\"demo-token\"}}",
+    ], env);
+    assert.equal(schema.status, 0, schema.stderr);
+    const payload = JSON.parse(schema.stdout) as {
+      sourceType: string;
+      hostType: string;
+      sourceKind: string;
+      implementationId: string;
+      metadataFields: Array<{ name: string }>;
+    };
+    assert.equal(payload.sourceType, "remote_source");
+    assert.equal(payload.hostType, "remote_source");
+    assert.equal(payload.sourceKind, "remote:demo.preview");
+    assert.equal(payload.implementationId, "demo.preview");
+    assert.deepEqual(payload.metadataFields, [{ name: "ticketId", type: "string", description: "Ticket id." }]);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli inbox read rejects unsupported flags like --ack", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-read-flags-"));
   const env = {
@@ -1048,6 +1119,85 @@ test("control plane subscriptions accept generic shortcut invocation", async () 
       assert.deepEqual(subscription.data.filter, { metadata: { ticketId: "A-9" } });
       assert.equal(subscription.data.trackedResourceRef, "ticket:A-9");
       assert.deepEqual(subscription.data.cleanupPolicy, { mode: "manual" });
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane source schema preview resolves remote modules without persistence", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-schema-preview-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const profileDir = path.join(homeDir, "source-profiles");
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(profileDir, "preview.mjs"),
+    `export default {
+  id: "demo.http.preview",
+  validateConfig(source) {
+    if (!source.config.token) throw new Error("preview token required");
+  },
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; },
+  describeCapabilities() {
+    return {
+      sourceKind: "remote:demo.http.preview",
+      metadataFields: [{ name: "ticketId", type: "string", description: "Ticket id." }]
+    };
+  }
+};`,
+    "utf8",
+  );
+
+  const store = await AgentInboxStore.open(dbPath);
+  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }), { homeDir });
+  const service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const preview = await client.request<{
+        sourceType: string;
+        hostType: string;
+        sourceKind: string;
+        implementationId: string;
+      }>("/sources/schema-preview", {
+        sourceRef: "remote:demo.http.preview",
+        config: {
+          profilePath: "preview.mjs",
+          profileConfig: { token: "demo-token" },
+        },
+      }, "POST");
+      assert.equal(preview.statusCode, 200);
+      assert.equal(preview.data.sourceType, "remote_source");
+      assert.equal(preview.data.hostType, "remote_source");
+      assert.equal(preview.data.sourceKind, "remote:demo.http.preview");
+      assert.equal(preview.data.implementationId, "demo.http.preview");
+      assert.equal(store.listSources().length, 0);
     } finally {
       await started.close();
     }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1208,6 +1208,71 @@ test("control plane source schema preview resolves remote modules without persis
   }
 });
 
+test("control plane source schema preview returns 400 for invalid preview inputs", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-schema-preview-error-"));
+  const socketPath = path.join(os.tmpdir(), `aix-preview-${process.pid}-${Date.now()}.sock`);
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const profileDir = path.join(homeDir, "source-profiles");
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(profileDir, "preview-error.mjs"),
+    `export default {
+  id: "demo.http.preview.error",
+  validateConfig(source) {
+    if (!source.config.token) throw new Error("preview token required");
+  },
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; }
+};`,
+    "utf8",
+  );
+
+  const store = await AgentInboxStore.open(dbPath);
+  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }), { homeDir });
+  const service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const preview = await client.request<{ error: string }>("/sources/schema-preview", {
+        sourceRef: "remote:demo.http.preview.error",
+        config: {
+          profilePath: "preview-error.mjs",
+          profileConfig: {},
+        },
+      }, "POST");
+      assert.equal(preview.statusCode, 400);
+      assert.match(preview.data.error, /preview failed: preview token required/);
+      assert.equal(store.listSources().length, 0);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("control plane shortcut validation errors return 400 instead of 500", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-shortcut-error-"));
   const socketPath = path.join(homeDir, "agentinbox.sock");


### PR DESCRIPTION
Closes #55

## Summary
- add a non-persisting source schema preview path to the service and HTTP API
- add CLI support for `agentinbox source schema preview ...`
- cover user-defined remote modules and builtin remote-backed aliases in tests and docs