### PR TITLE
feat: auto-pause idle sources

### DIFF
--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -62,6 +62,10 @@ remote-backed kinds can be previewed directly, for example `github_repo`.
 User-defined remote modules can be previewed with either `remote_source` or
 `remote:<moduleId>` plus `--config-json '{"profilePath":"...","profileConfig":{}}'`.
 
+Managed remote sources now auto-pause after a grace period once their last
+subscription is removed. `source show <sourceId>` includes `idleState` when a
+source is idle or was auto-paused for idleness.
+
 ## Subscriptions
 
 ```bash

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -115,3 +115,6 @@ going forward.
   deleting its binding or stream state. Resume re-enters the normal ensure
   path. `POST /sources/{sourceId}/poll` does not implicitly resume a paused
   source.
+- `GET /sources/{sourceId}` may include `idleState` for managed remote sources
+  that are waiting for auto-pause or were auto-paused after their last
+  subscription was removed.

--- a/drizzle/migrations/0004_source_idle_states.sql
+++ b/drizzle/migrations/0004_source_idle_states.sql
@@ -1,0 +1,10 @@
+create table if not exists source_idle_states (
+  source_id text primary key not null,
+  idle_since text not null,
+  auto_pause_at text not null,
+  auto_paused_at text,
+  updated_at text not null
+);
+
+create index if not exists idx_source_idle_states_auto_pause_at
+  on source_idle_states(auto_pause_at);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -14,6 +14,16 @@ export const sources = sqliteTable("sources", {
   sourceTypeKey: uniqueIndex("idx_sources_type_key").on(table.sourceType, table.sourceKey),
 }));
 
+export const sourceIdleStates = sqliteTable("source_idle_states", {
+  sourceId: text("source_id").primaryKey(),
+  idleSince: text("idle_since").notNull(),
+  autoPauseAt: text("auto_pause_at").notNull(),
+  autoPausedAt: text("auto_paused_at"),
+  updatedAt: text("updated_at").notNull(),
+}, (table) => ({
+  autoPauseAtIdx: index("idx_source_idle_states_auto_pause_at").on(table.autoPauseAt),
+}));
+
 export const agents = sqliteTable("agents", {
   agentId: text("agent_id").primaryKey(),
   status: text("status").notNull(),

--- a/src/model.ts
+++ b/src/model.ts
@@ -30,6 +30,14 @@ export interface SubscriptionSource {
   updatedAt: string;
 }
 
+export interface SourceIdleState {
+  sourceId: string;
+  idleSince: string;
+  autoPauseAt: string;
+  autoPausedAt?: string | null;
+  updatedAt: string;
+}
+
 export interface SubscriptionFilter {
   metadata?: Record<string, unknown>;
   payload?: Record<string, unknown>;

--- a/src/service.ts
+++ b/src/service.ts
@@ -58,6 +58,7 @@ const DEFAULT_ACKED_RETENTION_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_OFFLINE_AGENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_GC_INTERVAL_MS = 60 * 1000;
 const DEFAULT_SYNC_INTERVAL_MS = 2_000;
+const DEFAULT_IDLE_SOURCE_GRACE_MS = 5 * 60 * 1000;
 const WEBHOOK_ACTIVATION_MODES = new Set<WebhookActivationTarget["mode"]>(["activation_only", "activation_with_items"]);
 const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
 interface ActivationPolicy {
@@ -214,6 +215,7 @@ export class AgentInboxService {
       schema: resolvedSchema,
       stream: this.store.getStreamBySourceId(sourceId),
       subscriptions: this.store.listSubscriptionsForSource(sourceId),
+      idleState: this.store.getSourceIdleState(sourceId),
     };
   }
 
@@ -341,6 +343,7 @@ export class AgentInboxService {
     if (this.store.getSource(sourceId)?.status !== "paused") {
       this.store.updateSourceRuntime(sourceId, { status: "paused" });
     }
+    this.store.deleteSourceIdleState(sourceId);
     return {
       paused: true,
       source: this.getSource(sourceId),
@@ -356,6 +359,7 @@ export class AgentInboxService {
     if (this.store.getSource(sourceId)?.status === "paused") {
       this.store.updateSourceRuntime(sourceId, { status: "active" });
     }
+    this.store.deleteSourceIdleState(sourceId);
     return {
       resumed: true,
       source: this.getSource(sourceId),
@@ -452,7 +456,13 @@ export class AgentInboxService {
 
   removeAgent(agentId: string): { removed: boolean } {
     this.getAgent(agentId);
+    const affectedSourceIds = Array.from(
+      new Set(this.store.listSubscriptionsForAgent(agentId).map((subscription) => subscription.sourceId)),
+    );
     this.store.deleteAgent(agentId);
+    for (const sourceId of affectedSourceIds) {
+      this.refreshSourceIdleState(sourceId);
+    }
     this.notificationBuffers.forEach((buffer, key) => {
       if (key.startsWith(`${agentId}:`)) {
         if (buffer.timer) {
@@ -543,6 +553,12 @@ export class AgentInboxService {
     if (!source) {
       throw new Error(`unknown source: ${input.sourceId}`);
     }
+    const idleState = this.store.getSourceIdleState(source.sourceId);
+    if (idleState?.autoPausedAt) {
+      await this.resumeSource(source.sourceId);
+    } else if (idleState) {
+      this.store.deleteSourceIdleState(source.sourceId);
+    }
     await validateSubscriptionFilter(input.filter ?? {});
     const cleanupPolicy = normalizeCleanupPolicy(input.cleanupPolicy ?? null);
     const subscription: Subscription = {
@@ -569,6 +585,7 @@ export class AgentInboxService {
       startOffset: subscription.startOffset ?? null,
       startTime: subscription.startTime ?? null,
     });
+    this.store.deleteSourceIdleState(source.sourceId);
     return subscription;
   }
 
@@ -577,6 +594,7 @@ export class AgentInboxService {
     await this.backend.deleteConsumer({ subscriptionId });
     this.store.deleteSubscription(subscriptionId);
     this.clearSubscriptionRuntimeState(subscription);
+    this.refreshSourceIdleState(subscription.sourceId);
     return { removed: true, subscriptionId };
   }
 
@@ -1621,10 +1639,54 @@ export class AgentInboxService {
     return { removedSubscriptions: removed.size };
   }
 
+  private async runIdleSourceCleanupPass(nowMs: number): Promise<void> {
+    const now = new Date(nowMs).toISOString();
+    const due = this.store.listSourceIdleStatesDue(now);
+    for (const idleState of due) {
+      const source = this.store.getSource(idleState.sourceId);
+      if (!source) {
+        this.store.deleteSourceIdleState(idleState.sourceId);
+        continue;
+      }
+      if (this.store.listSubscriptionsForSource(source.sourceId).length > 0) {
+        this.store.deleteSourceIdleState(source.sourceId);
+        continue;
+      }
+      const sourceAdapter = this.adapters.sourceAdapterFor(source.sourceType);
+      if (!sourceAdapter.pauseSource) {
+        this.store.deleteSourceIdleState(source.sourceId);
+        continue;
+      }
+      if (source.status === "paused") {
+        if (!idleState.autoPausedAt) {
+          this.store.upsertSourceIdleState({
+            ...idleState,
+            autoPausedAt: now,
+            updatedAt: now,
+          });
+        }
+        continue;
+      }
+      await this.adapters.pauseSource(source);
+      if (this.store.getSource(source.sourceId)?.status !== "paused") {
+        this.store.updateSourceRuntime(source.sourceId, { status: "paused" });
+      }
+      this.store.upsertSourceIdleState({
+        ...idleState,
+        autoPausedAt: now,
+        updatedAt: now,
+      });
+    }
+  }
+
   private gcOfflineAgents(now = Date.now()): { removedAgents: number } {
     const cutoffIso = new Date(now - DEFAULT_OFFLINE_AGENT_TTL_MS).toISOString();
     const agents = this.store.listOfflineAgentsOlderThan(cutoffIso);
+    const affectedSourceIds = new Set<string>();
     for (const agent of agents) {
+      for (const subscription of this.store.listSubscriptionsForAgent(agent.agentId)) {
+        affectedSourceIds.add(subscription.sourceId);
+      }
       this.store.deleteAgent(agent.agentId, { persist: false });
       this.notificationBuffers.forEach((buffer, key) => {
         if (key.startsWith(`${agent.agentId}:`)) {
@@ -1635,6 +1697,9 @@ export class AgentInboxService {
         }
       });
       this.inboxWatchers.delete(agent.agentId);
+    }
+    for (const sourceId of affectedSourceIds) {
+      this.refreshSourceIdleState(sourceId);
     }
     if (agents.length > 0) {
       this.store.save();
@@ -1677,6 +1742,7 @@ export class AgentInboxService {
     if (now - this.lastLifecycleCleanupAt >= DEFAULT_GC_INTERVAL_MS) {
       try {
         this.runLifecycleCleanupPass(now);
+        await this.runIdleSourceCleanupPass(now);
       } catch (error) {
         console.warn("subscription lifecycle gc failed:", error);
       }
@@ -1691,6 +1757,32 @@ export class AgentInboxService {
     } catch (error) {
       console.warn("offline agent gc failed:", error);
     }
+  }
+
+  private refreshSourceIdleState(sourceId: string): void {
+    const source = this.store.getSource(sourceId);
+    if (!source) {
+      this.store.deleteSourceIdleState(sourceId);
+      return;
+    }
+    const sourceAdapter = this.adapters.sourceAdapterFor(source.sourceType);
+    if (!sourceAdapter.pauseSource) {
+      this.store.deleteSourceIdleState(sourceId);
+      return;
+    }
+    const remainingSubscriptions = this.store.listSubscriptionsForSource(sourceId).length;
+    if (remainingSubscriptions > 0) {
+      this.store.deleteSourceIdleState(sourceId);
+      return;
+    }
+    const now = nowIso();
+    this.store.upsertSourceIdleState({
+      sourceId,
+      idleSince: now,
+      autoPauseAt: new Date(Date.parse(now) + DEFAULT_IDLE_SOURCE_GRACE_MS).toISOString(),
+      autoPausedAt: null,
+      updatedAt: now,
+    });
   }
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -553,14 +553,14 @@ export class AgentInboxService {
     if (!source) {
       throw new Error(`unknown source: ${input.sourceId}`);
     }
+    await validateSubscriptionFilter(input.filter ?? {});
+    const cleanupPolicy = normalizeCleanupPolicy(input.cleanupPolicy ?? null);
     const idleState = this.store.getSourceIdleState(source.sourceId);
     if (idleState?.autoPausedAt) {
       await this.resumeSource(source.sourceId);
     } else if (idleState) {
       this.store.deleteSourceIdleState(source.sourceId);
     }
-    await validateSubscriptionFilter(input.filter ?? {});
-    const cleanupPolicy = normalizeCleanupPolicy(input.cleanupPolicy ?? null);
     const subscription: Subscription = {
       subscriptionId: generateId("sub"),
       agentId: input.agentId,
@@ -1597,9 +1597,10 @@ export class AgentInboxService {
     });
   }
 
-  private runLifecycleCleanupPass(nowMs: number): { removedSubscriptions: number } {
+  private runLifecycleCleanupPass(nowMs: number): { removedSubscriptions: number; affectedSourceIds: string[] } {
     this.lastLifecycleCleanupAt = nowMs;
     const removed = new Set<string>();
+    const affectedSourceIds = new Set<string>();
 
     for (const subscription of this.store.listSubscriptions()) {
       if (removed.has(subscription.subscriptionId)) {
@@ -1615,6 +1616,7 @@ export class AgentInboxService {
       }
       if (this.store.deleteSubscription(subscription.subscriptionId)) {
         removed.add(subscription.subscriptionId);
+        affectedSourceIds.add(subscription.sourceId);
         this.clearSubscriptionRuntimeState(subscription);
       }
     }
@@ -1632,11 +1634,15 @@ export class AgentInboxService {
       }
       if (this.store.deleteSubscription(retirement.subscriptionId)) {
         removed.add(retirement.subscriptionId);
+        affectedSourceIds.add(subscription.sourceId);
         this.clearSubscriptionRuntimeState(subscription);
       }
     }
 
-    return { removedSubscriptions: removed.size };
+    return {
+      removedSubscriptions: removed.size,
+      affectedSourceIds: [...affectedSourceIds],
+    };
   }
 
   private async runIdleSourceCleanupPass(nowMs: number): Promise<void> {
@@ -1741,7 +1747,10 @@ export class AgentInboxService {
     const now = Date.now();
     if (now - this.lastLifecycleCleanupAt >= DEFAULT_GC_INTERVAL_MS) {
       try {
-        this.runLifecycleCleanupPass(now);
+        const lifecycle = this.runLifecycleCleanupPass(now);
+        for (const sourceId of lifecycle.affectedSourceIds) {
+          this.refreshSourceIdleState(sourceId);
+        }
         await this.runIdleSourceCleanupPass(now);
       } catch (error) {
         console.warn("subscription lifecycle gc failed:", error);
@@ -1767,6 +1776,10 @@ export class AgentInboxService {
     }
     const sourceAdapter = this.adapters.sourceAdapterFor(source.sourceType);
     if (!sourceAdapter.pauseSource) {
+      this.store.deleteSourceIdleState(sourceId);
+      return;
+    }
+    if (source.status === "paused") {
       this.store.deleteSourceIdleState(sourceId);
       return;
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -21,6 +21,7 @@ import {
   InboxItem,
   ListInboxItemsOptions,
   RegisterAgentInput,
+  SourceIdleState,
   Subscription,
   SubscriptionLifecycleRetirement,
   SubscriptionFilter,
@@ -277,6 +278,48 @@ export class AgentInboxStore {
     return rows.map((row) => this.mapSource(row));
   }
 
+  getSourceIdleState(sourceId: string): SourceIdleState | null {
+    const row = this.getOne("select * from source_idle_states where source_id = ?", [sourceId]);
+    return row ? this.mapSourceIdleState(row) : null;
+  }
+
+  listSourceIdleStatesDue(cutoffIso: string): SourceIdleState[] {
+    const rows = this.getAll(
+      "select * from source_idle_states where auto_pause_at <= ? order by auto_pause_at asc",
+      [cutoffIso],
+    );
+    return rows.map((row) => this.mapSourceIdleState(row));
+  }
+
+  upsertSourceIdleState(idleState: SourceIdleState): SourceIdleState {
+    this.db.run(
+      `
+      insert into source_idle_states (
+        source_id, idle_since, auto_pause_at, auto_paused_at, updated_at
+      ) values (?, ?, ?, ?, ?)
+      on conflict(source_id) do update set
+        idle_since = excluded.idle_since,
+        auto_pause_at = excluded.auto_pause_at,
+        auto_paused_at = excluded.auto_paused_at,
+        updated_at = excluded.updated_at
+    `,
+      [
+        idleState.sourceId,
+        idleState.idleSince,
+        idleState.autoPauseAt,
+        idleState.autoPausedAt ?? null,
+        idleState.updatedAt,
+      ],
+    );
+    this.persist();
+    return this.getSourceIdleState(idleState.sourceId)!;
+  }
+
+  deleteSourceIdleState(sourceId: string): void {
+    this.db.run("delete from source_idle_states where source_id = ?", [sourceId]);
+    this.persist();
+  }
+
   updateSourceDefinition(
     sourceId: string,
     input: { configRef?: string | null; config?: Record<string, unknown> },
@@ -346,6 +389,7 @@ export class AgentInboxStore {
         this.db.run("delete from stream_events where stream_id = ?", [stream.streamId]);
         this.db.run("delete from streams where stream_id = ?", [stream.streamId]);
       }
+      this.db.run("delete from source_idle_states where source_id = ?", [sourceId]);
       this.db.run("delete from sources where source_id = ?", [sourceId]);
     });
     this.persist();
@@ -780,6 +824,10 @@ export class AgentInboxStore {
       }
       this.db.run(
         "delete from subscription_lifecycle_retirements where subscription_id in (select subscription_id from subscriptions where agent_id = ?)",
+        [agentId],
+      );
+      this.db.run(
+        "delete from source_idle_states where source_id in (select distinct source_id from subscriptions where agent_id = ?)",
         [agentId],
       );
       this.db.run("delete from subscriptions where agent_id = ?", [agentId]);
@@ -1297,6 +1345,7 @@ export class AgentInboxStore {
       offlineAgents: this.count("agents where status = 'offline'"),
       subscriptions: this.count("subscriptions"),
       subscriptionLifecycleRetirements: this.count("subscription_lifecycle_retirements"),
+      sourceIdleStates: this.count("source_idle_states"),
       inboxes: this.count("inboxes"),
       activationTargets: this.count("activation_targets"),
       offlineActivationTargets: this.count("activation_targets where status = 'offline'"),
@@ -1362,6 +1411,16 @@ export class AgentInboxStore {
       status: row.status as SubscriptionSource["status"],
       checkpoint: row.checkpoint ? String(row.checkpoint) : null,
       createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
+    };
+  }
+
+  private mapSourceIdleState(row: Record<string, unknown>): SourceIdleState {
+    return {
+      sourceId: String(row.source_id),
+      idleSince: String(row.idle_since),
+      autoPauseAt: String(row.auto_pause_at),
+      autoPausedAt: row.auto_paused_at ? String(row.auto_paused_at) : null,
       updatedAt: String(row.updated_at),
     };
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -285,7 +285,7 @@ export class AgentInboxStore {
 
   listSourceIdleStatesDue(cutoffIso: string): SourceIdleState[] {
     const rows = this.getAll(
-      "select * from source_idle_states where auto_pause_at <= ? order by auto_pause_at asc",
+      "select * from source_idle_states where auto_pause_at <= ? and auto_paused_at is null order by auto_pause_at asc",
       [cutoffIso],
     );
     return rows.map((row) => this.mapSourceIdleState(row));

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -162,7 +162,7 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 4);
+    assert.equal(state.appliedCount, 5);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 0);
@@ -179,7 +179,7 @@ test("store upgrades a legacy v12 database with backup and forward migration", a
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 4);
+    assert.equal(state.appliedCount, 5);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 1);
@@ -1061,6 +1061,85 @@ test("updateSource preserves source identity and existing subscriptions", async 
     });
     assert.equal(clearedRef.updated, true);
     assert.equal(clearedRef.source?.configRef, null);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("source details expose idle auto-pause state for operators", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { store, service, dir } = await makeService({
+    dispatcher: undefined,
+    terminalDispatcher: undefined,
+  });
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "idle-details.mjs"),
+      `export default {
+  id: "demo.idle.details",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "idle-details-demo",
+      config: {
+        profilePath: "idle-details.mjs",
+        profileConfig: {},
+      },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "idle-details-thread",
+      tmuxPaneId: "%971",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.removeSubscription(subscription.subscriptionId);
+    const idleState = store.getSourceIdleState(source.sourceId);
+    store.upsertSourceIdleState({
+      ...idleState!,
+      autoPauseAt: "2020-01-01T00:00:00.000Z",
+      updatedAt: nowIso(),
+    });
+    await (service as unknown as { runIdleSourceCleanupPass(nowMs: number): Promise<void> }).runIdleSourceCleanupPass(Date.now());
+
+    const details = await service.getSourceDetails(source.sourceId) as {
+      source: { status: string };
+      idleState: {
+        sourceId: string;
+        idleSince: string;
+        autoPauseAt: string;
+        autoPausedAt: string | null;
+      };
+    };
+    assert.equal(details.source.status, "paused");
+    assert.equal(details.idleState.sourceId, source.sourceId);
+    assert.ok(details.idleState.idleSince);
+    assert.ok(details.idleState.autoPauseAt);
+    assert.ok(details.idleState.autoPausedAt);
   } finally {
     await service.stop();
     store.close();

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -1069,7 +1069,6 @@ test("updateSource preserves source identity and existing subscriptions", async 
 });
 
 test("source details expose idle auto-pause state for operators", async () => {
-  const fake = new FakeRemoteSourceClient();
   const { store, service, dir } = await makeService({
     dispatcher: undefined,
     terminalDispatcher: undefined,
@@ -1140,6 +1139,230 @@ test("source details expose idle auto-pause state for operators", async () => {
     assert.ok(details.idleState.idleSince);
     assert.ok(details.idleState.autoPauseAt);
     assert.ok(details.idleState.autoPausedAt);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("idle source due query skips sources that were already auto-paused", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    store.upsertSourceIdleState({
+      sourceId: "src_due",
+      idleSince: "2026-01-01T00:00:00.000Z",
+      autoPauseAt: "2026-01-01T00:05:00.000Z",
+      autoPausedAt: null,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    store.upsertSourceIdleState({
+      sourceId: "src_paused",
+      idleSince: "2026-01-01T00:00:00.000Z",
+      autoPauseAt: "2026-01-01T00:05:00.000Z",
+      autoPausedAt: "2026-01-01T00:06:00.000Z",
+      updatedAt: "2026-01-01T00:06:00.000Z",
+    });
+
+    const due = store.listSourceIdleStatesDue("2026-01-01T00:10:00.000Z");
+    assert.deepEqual(
+      due.map((state) => state.sourceId),
+      ["src_due"],
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("invalid subscription input does not resume an auto-paused source", async () => {
+  const { store, service, dir } = await makeService({
+    dispatcher: undefined,
+    terminalDispatcher: undefined,
+  });
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "idle-invalid-filter.mjs"),
+      `export default {
+  id: "demo.idle.invalid.filter",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "idle-invalid-filter-demo",
+      config: {
+        profilePath: "idle-invalid-filter.mjs",
+        profileConfig: {},
+      },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "idle-invalid-filter-thread",
+      tmuxPaneId: "%972",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+    await service.removeSubscription(subscription.subscriptionId);
+    store.upsertSourceIdleState({
+      ...store.getSourceIdleState(source.sourceId)!,
+      autoPausedAt: "2026-01-01T00:06:00.000Z",
+      updatedAt: "2026-01-01T00:06:00.000Z",
+    });
+    store.updateSourceRuntime(source.sourceId, { status: "paused" });
+
+    await assert.rejects(
+      service.registerSubscription({
+        agentId: agent.agent.agentId,
+        sourceId: source.sourceId,
+        filter: { expr: "metadata[" },
+      }),
+      /Unexpected|Token|parse|bracket/i,
+    );
+    assert.equal(service.getSource(source.sourceId).status, "paused");
+    assert.ok(store.getSourceIdleState(source.sourceId)?.autoPausedAt);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("lifecycle gc refreshes idle state when it removes the last subscription", async () => {
+  const { store, service, dir } = await makeService({
+    dispatcher: undefined,
+    terminalDispatcher: undefined,
+  });
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "idle-lifecycle.mjs"),
+      `export default {
+  id: "demo.idle.lifecycle",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "idle-lifecycle-demo",
+      config: {
+        profilePath: "idle-lifecycle.mjs",
+        profileConfig: {},
+      },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "idle-lifecycle-thread",
+      tmuxPaneId: "%973",
+    });
+    await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      cleanupPolicy: { mode: "at", at: "2020-01-01T00:00:00.000Z" },
+      startPolicy: "earliest",
+    });
+
+    await (service as unknown as { syncLifecycleGc(): Promise<void> }).syncLifecycleGc();
+
+    assert.equal(service.listSubscriptions({ sourceId: source.sourceId }).length, 0);
+    const idleState = store.getSourceIdleState(source.sourceId);
+    assert.ok(idleState);
+    assert.equal(idleState?.sourceId, source.sourceId);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("manual pause does not create idle auto-pause state after the last subscription is removed", async () => {
+  const { store, service, dir } = await makeService({
+    dispatcher: undefined,
+    terminalDispatcher: undefined,
+  });
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "idle-manual-pause.mjs"),
+      `export default {
+  id: "demo.idle.manual.pause",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; }
+};`,
+      "utf8",
+    );
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "idle-manual-pause-demo",
+      config: {
+        profilePath: "idle-manual-pause.mjs",
+        profileConfig: {},
+      },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "idle-manual-pause-thread",
+      tmuxPaneId: "%974",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.pauseSource(source.sourceId);
+    await service.removeSubscription(subscription.subscriptionId);
+
+    assert.equal(service.getSource(source.sourceId).status, "paused");
+    assert.equal(store.getSourceIdleState(source.sourceId), null);
   } finally {
     await service.stop();
     store.close();

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -10,6 +10,7 @@ import { UxcRemoteSourceClient } from "../src/sources/remote";
 import { ManagedSourceSpec } from "../src/sources/remote_profiles";
 import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
+import { nowIso } from "../src/util";
 
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   private readonly streams = new Map<string, Array<{ offset: number; raw_payload: unknown }>>();
@@ -821,6 +822,90 @@ test("updateSource re-ensures active remote sources but does not resume paused o
     );
     assert.equal(service.getSource(source.sourceId).status, "paused");
     assert.equal(fake.ensuredSources.length, ensureCountBeforePausedUpdate);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("idle remote sources auto-pause after the last subscription is removed and resume on new subscription", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "demo-idle.mjs"),
+      `export default {
+  id: "demo.idle",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    if (!raw.id) return null;
+    return { sourceNativeId: "demo:" + raw.id, eventVariant: "demo.event", metadata: {}, rawPayload: raw };
+  }
+};`,
+      "utf8",
+    );
+
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "idle-key",
+      config: {
+        profilePath: "demo-idle.mjs",
+        profileConfig: {},
+      },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "idle-thread",
+      tmuxPaneId: "%970",
+    });
+    const first = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.removeSubscription(first.subscriptionId);
+
+    const idleState = store.getSourceIdleState(source.sourceId);
+    assert.ok(idleState);
+    assert.equal(idleState?.autoPausedAt, null);
+    store.upsertSourceIdleState({
+      ...idleState!,
+      autoPauseAt: "2020-01-01T00:00:00.000Z",
+      updatedAt: nowIso(),
+    });
+
+    await (service as unknown as { runIdleSourceCleanupPass(nowMs: number): Promise<void> }).runIdleSourceCleanupPass(Date.now());
+    assert.equal(service.getSource(source.sourceId).status, "paused");
+    assert.equal(fake.stoppedSources.length, 1);
+    assert.ok(store.getSourceIdleState(source.sourceId)?.autoPausedAt);
+
+    const ensureCountBeforeResume = fake.ensuredSources.length;
+    const second = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    assert.equal(service.getSource(source.sourceId).status, "active");
+    assert.equal(store.getSourceIdleState(source.sourceId), null);
+    assert.equal(fake.ensuredSources.length, ensureCountBeforeResume + 1);
+    assert.ok(store.getSubscription(second.subscriptionId));
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
Closes #75

## Summary
- track idle state after the last subscription is removed from a pausable source
- auto-pause idle managed sources after a bounded grace period and auto-resume when subscriptions return
- expose idle auto-pause state in source details and document the operator-facing behavior