### PR TITLE
feat: add direct inbox text ingress

### DIFF
--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -99,6 +99,7 @@ Inbox commands use `agentId`, not `inboxId`.
 agentinbox inbox list
 agentinbox inbox show <agent_id>
 agentinbox inbox read [--agent-id <agent_id>]
+agentinbox inbox send --agent-id <agent_id> --message "..." [--sender <sender>]
 agentinbox inbox watch [--agent-id <agent_id>]
 agentinbox inbox ack [--agent-id <agent_id>] --through <item_id>
 agentinbox inbox ack [--agent-id <agent_id>] --item <item_id>

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -75,9 +75,21 @@ going forward.
 
 - `GET /agents/{agentId}/inbox`
 - `GET /agents/{agentId}/inbox/items`
+- `POST /agents/{agentId}/inbox/items`
 - `GET /agents/{agentId}/inbox/watch`
 - `POST /agents/{agentId}/inbox/ack`
 - `POST /agents/{agentId}/inbox/compact`
+
+`POST /agents/{agentId}/inbox/items` accepts a narrow direct-text ingress body:
+
+```json
+{
+  "message": "Review PR #51 CI failure and push a fix.",
+  "sender": "local-script"
+}
+```
+
+`message` is required. `sender` is optional.
 
 `POST /agents/{agentId}/inbox/ack` accepts exactly one of:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -417,6 +417,24 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "inbox" && normalized[1] === "send") {
+    const args = normalized.slice(2);
+    const allowedFlags = ["--agent-id", "--message", "--sender"];
+    if (positionalArgs(args, ["--agent-id", "--message", "--sender"]).length > 0 || unexpectedFlags(args, allowedFlags).length > 0) {
+      throw new Error("usage: agentinbox inbox send --agent-id ID --message TEXT [--sender SENDER]");
+    }
+    const agentId = takeFlagValue(normalized, "--agent-id");
+    const message = takeFlagValue(normalized, "--message");
+    if (!agentId || !message) {
+      throw new Error("usage: agentinbox inbox send --agent-id ID --message TEXT [--sender SENDER]");
+    }
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/inbox/items`, {
+      message,
+      sender: takeFlagValue(normalized, "--sender") ?? undefined,
+    });
+    return;
+  }
+
   if (command === "inbox" && normalized[1] === "watch") {
     const args = normalized.slice(2);
     if (positionalArgs(args, ["--agent-id", "--after-item", "--heartbeat-ms"]).length > 0) {
@@ -930,6 +948,7 @@ Usage:
   agentinbox inbox list
   agentinbox inbox show <agentId>
   agentinbox inbox read [--agent-id ID] [--after-item ID] [--include-acked]
+  agentinbox inbox send --agent-id ID --message TEXT [--sender SENDER]
   agentinbox inbox watch [--agent-id ID] [--after-item ID] [--include-acked] [--heartbeat-ms N]
   agentinbox inbox ack [--agent-id ID] (--through <itemId> | --item <itemId> | --all)
   agentinbox inbox compact <agentId>

--- a/src/http.ts
+++ b/src/http.ts
@@ -857,6 +857,40 @@ function buildFastifyServer(service: AgentInboxService) {
     };
   });
 
+  app.post("/agents/:agentId/inbox/items", {
+    schema: {
+      tags: ["inbox"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["message"],
+        properties: {
+          message: { type: "string", minLength: 1 },
+          sender: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    const body = request.body as { message: string; sender?: string };
+    return service.addDirectInboxTextMessage(decodeURIComponent(params.agentId), {
+      message: body.message,
+      sender: body.sender ?? null,
+    });
+  });
+
   app.get("/agents/:agentId/inbox/watch", {
     schema: {
       tags: ["inbox"],
@@ -1130,6 +1164,7 @@ function normalizeValidationMessage(message: string): string {
 
 function isBadRequestError(message: string): boolean {
   return (
+    message.startsWith("direct inbox ") ||
     message.startsWith("manual append is not supported") ||
     message.startsWith("sources/events requires") ||
     message.startsWith("source remove requires") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -231,6 +231,17 @@ export interface AddWebhookActivationTargetInput {
   notifyLeaseMs?: number | null;
 }
 
+export interface DirectInboxTextMessageInput {
+  message: string;
+  sender?: string | null;
+}
+
+export interface DirectInboxTextMessageResult {
+  itemId: string;
+  inboxId: string;
+  activated: boolean;
+}
+
 export interface RegisterSubscriptionInput {
   agentId: string;
   sourceId: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -740,7 +740,10 @@ export class AgentInboxService {
       deliveryHandle: null,
       ackedAt: null,
     };
-    this.store.insertInboxItem(item);
+    const inserted = this.store.insertInboxItem(item);
+    if (!inserted) {
+      throw new Error(`failed to persist direct inbox message item: ${item.itemId}`);
+    }
     this.notifyInboxWatchers(agentId, [item]);
 
     const activationItem: ActivationItem = {
@@ -2237,9 +2240,9 @@ function summarizeSourceEvent(sourceType: string, sourceKey: string, eventVarian
 
 function summarizeDirectInboxMessage(sender: string | null): string {
   if (sender) {
-    return `direct message from ${sender}`;
+    return `direct_text_message:${sender}`;
   }
-  return "direct message";
+  return "direct_text_message";
 }
 
 function normalizeDirectInboxMessage(message: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,6 +4,8 @@ import {
   ActivationTarget,
   AddWebhookActivationTargetInput,
   Agent,
+  DirectInboxTextMessageInput,
+  DirectInboxTextMessageResult,
   AppendSourceEventInput,
   AppendSourceEventResult,
   DeliveryAttempt,
@@ -59,6 +61,8 @@ const DEFAULT_OFFLINE_AGENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_GC_INTERVAL_MS = 60 * 1000;
 const DEFAULT_SYNC_INTERVAL_MS = 2_000;
 const DEFAULT_IDLE_SOURCE_GRACE_MS = 5 * 60 * 1000;
+const DIRECT_INBOX_SOURCE_ID = "__agentinbox_direct_text__";
+const DIRECT_INBOX_EVENT_VARIANT = "agentinbox.direct_text_message";
 const WEBHOOK_ACTIVATION_MODES = new Set<WebhookActivationTarget["mode"]>(["activation_only", "activation_with_items"]);
 const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
 interface ActivationPolicy {
@@ -70,7 +74,7 @@ interface BufferedNotification {
   agentId: string;
   targetId: string;
   pending: Array<{
-    subscriptionId: string;
+    subscriptionId: string | null;
     sourceId: string;
     summary: string;
     item: ActivationItem;
@@ -710,6 +714,64 @@ export class AgentInboxService {
     return this.store.listInboxItems(this.ensureInboxForAgent(agentId).inboxId, options);
   }
 
+  async addDirectInboxTextMessage(
+    agentId: string,
+    input: DirectInboxTextMessageInput,
+    env: NodeJS.ProcessEnv = process.env,
+  ): Promise<DirectInboxTextMessageResult> {
+    this.getAgent(agentId);
+    const message = normalizeDirectInboxMessage(input.message);
+    const sender = normalizeDirectInboxSender(input.sender) ?? this.detectDirectInboxSender(env);
+    const inbox = this.ensureInboxForAgent(agentId);
+    const occurredAt = nowIso();
+    const item: InboxItem = {
+      itemId: generateId("item"),
+      sourceId: DIRECT_INBOX_SOURCE_ID,
+      sourceNativeId: generateId("direct"),
+      eventVariant: DIRECT_INBOX_EVENT_VARIANT,
+      inboxId: inbox.inboxId,
+      occurredAt,
+      metadata: {},
+      rawPayload: {
+        type: "direct_text_message",
+        message,
+        sender,
+      },
+      deliveryHandle: null,
+      ackedAt: null,
+    };
+    this.store.insertInboxItem(item);
+    this.notifyInboxWatchers(agentId, [item]);
+
+    const activationItem: ActivationItem = {
+      itemId: item.itemId,
+      sourceId: item.sourceId,
+      sourceNativeId: item.sourceNativeId,
+      eventVariant: item.eventVariant,
+      inboxId: item.inboxId,
+      occurredAt: item.occurredAt,
+      metadata: item.metadata,
+      rawPayload: item.rawPayload,
+      deliveryHandle: item.deliveryHandle,
+    };
+    const targets = this.store.listActivationTargetsForAgent(agentId).filter((target) => target.status === "active");
+    for (const target of targets) {
+      this.enqueueActivationTarget(target, {
+        agentId,
+        subscriptionId: null,
+        sourceId: DIRECT_INBOX_SOURCE_ID,
+        summary: summarizeDirectInboxMessage(sender),
+        item: activationItem,
+      });
+    }
+
+    return {
+      itemId: item.itemId,
+      inboxId: inbox.inboxId,
+      activated: targets.length > 0,
+    };
+  }
+
   watchInbox(
     agentId: string,
     options: WatchInboxOptions,
@@ -1232,7 +1294,7 @@ export class AgentInboxService {
     target: ActivationTarget,
     input: {
       agentId: string;
-      subscriptionId: string;
+      subscriptionId: string | null;
       sourceId: string;
       summary: string;
       item: ActivationItem;
@@ -1332,7 +1394,7 @@ export class AgentInboxService {
           targetId: buffer.targetId,
           newItemCount: entries.length,
           summary: entries[0]?.summary ?? null,
-          subscriptionIds: uniqueSorted(entries.map((entry) => entry.subscriptionId)),
+          subscriptionIds: uniqueSortedNullable(entries.map((entry) => entry.subscriptionId)),
           sourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
           items: entries.map((entry) => entry.item),
         });
@@ -1347,7 +1409,7 @@ export class AgentInboxService {
           leaseExpiresAt: state.leaseExpiresAt,
           pendingNewItemCount: state.pendingNewItemCount + entries.length,
           pendingSummary: state.pendingSummary ?? entries[0]?.summary ?? null,
-          pendingSubscriptionIds: uniqueSorted([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)]),
+          pendingSubscriptionIds: uniqueSortedNullable([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)]),
           pendingSourceIds: uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)]),
           updatedAt: nowIso(),
         });
@@ -1513,7 +1575,7 @@ export class AgentInboxService {
   private upsertDirtyDispatchState(
     agentId: string,
     targetId: string,
-    entries: Array<{ subscriptionId: string; sourceId: string; summary: string }>,
+    entries: Array<{ subscriptionId: string | null; sourceId: string; summary: string }>,
   ): void {
     this.store.upsertActivationDispatchState({
       agentId,
@@ -1522,10 +1584,35 @@ export class AgentInboxService {
       leaseExpiresAt: new Date(Date.now() + DEFAULT_NOTIFY_RETRY_MS).toISOString(),
       pendingNewItemCount: entries.length,
       pendingSummary: entries[0]?.summary ?? null,
-      pendingSubscriptionIds: uniqueSorted(entries.map((entry) => entry.subscriptionId)),
+      pendingSubscriptionIds: uniqueSortedNullable(entries.map((entry) => entry.subscriptionId)),
       pendingSourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
       updatedAt: nowIso(),
     });
+  }
+
+  private detectDirectInboxSender(env: NodeJS.ProcessEnv): string | null {
+    try {
+      const detected = detectTerminalContext(env);
+      const target = findExistingTerminalActivationTarget(this.store, {
+        runtimeKind: detected.runtimeKind,
+        runtimeSessionId: detected.runtimeSessionId ?? null,
+        backend: detected.backend,
+        tmuxPaneId: detected.tmuxPaneId ?? null,
+        tty: detected.tty ?? null,
+        termProgram: detected.termProgram ?? null,
+        itermSessionId: detected.itermSessionId ?? null,
+      });
+      if (target) {
+        return target.agentId;
+      }
+      return detected.runtimeSessionId
+        ?? detected.tmuxPaneId
+        ?? detected.itermSessionId
+        ?? detected.tty
+        ?? null;
+    } catch {
+      return null;
+    }
   }
 
   private markActivationTargetDelivered(targetId: string): void {
@@ -2109,6 +2196,10 @@ function uniqueSorted(values: string[]): string[] {
   return Array.from(new Set(values)).sort();
 }
 
+function uniqueSortedNullable(values: Array<string | null | undefined>): string[] {
+  return uniqueSorted(values.filter((value): value is string => typeof value === "string" && value.length > 0));
+}
+
 function notificationBufferKey(agentId: string, targetId: string): string {
   return `${agentId}::${targetId}`;
 }
@@ -2142,4 +2233,36 @@ function summarizeSourceEvent(sourceType: string, sourceKey: string, eventVarian
     return summaryParts.join(":");
   }
   return `${sourceType}:${sourceKey}:${eventVariant}`;
+}
+
+function summarizeDirectInboxMessage(sender: string | null): string {
+  if (sender) {
+    return `direct message from ${sender}`;
+  }
+  return "direct message";
+}
+
+function normalizeDirectInboxMessage(message: string): string {
+  if (typeof message !== "string") {
+    throw new Error("direct inbox message must be a string");
+  }
+  const trimmed = message.trim();
+  if (trimmed.length === 0) {
+    throw new Error("direct inbox message must not be empty");
+  }
+  return trimmed;
+}
+
+function normalizeDirectInboxSender(sender: string | null | undefined): string | null {
+  if (sender == null) {
+    return null;
+  }
+  if (typeof sender !== "string") {
+    throw new Error("direct inbox sender must be a string");
+  }
+  const trimmed = sender.trim();
+  if (trimmed.length === 0) {
+    throw new Error("direct inbox sender must not be empty");
+  }
+  return trimmed;
 }

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -1993,6 +1993,56 @@ test("inbox read defaults to unacked items and ack through clears a processed ba
   }
 });
 
+test("direct inbox text messages create inbox items and trigger activation", async () => {
+  const dispatcher = new RecordingActivationDispatcher();
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { store, service, dir } = await makeService({
+    dispatcher,
+    terminalDispatcher,
+    activationWindowMs: 10,
+    activationMaxItems: 1,
+  });
+  try {
+    const alpha = await registerTmuxAgent(service, "63");
+    service.addWebhookActivationTarget(alpha.agentId, {
+      url: "http://127.0.0.1:9999/direct",
+      activationMode: "activation_with_items",
+    });
+
+    const delivered = await service.addDirectInboxTextMessage(alpha.agentId, {
+      message: "  Review PR #51 CI failure and push a fix.  ",
+    }, {
+      ...process.env,
+      TMUX_PANE: "%63",
+      CODEX_THREAD_ID: "thread-63",
+      ITERM_SESSION_ID: "",
+      TERM_SESSION_ID: "",
+      TERM_PROGRAM: "",
+    });
+
+    assert.equal(delivered.activated, true);
+    const items = service.listInboxItems(alpha.agentId, { includeAcked: true });
+    assert.equal(items.length, 1);
+    assert.equal(items[0].eventVariant, "agentinbox.direct_text_message");
+    assert.deepEqual(items[0].metadata, {});
+    assert.deepEqual(items[0].rawPayload, {
+      type: "direct_text_message",
+      message: "Review PR #51 CI failure and push a fix.",
+      sender: alpha.agentId,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(dispatcher.calls.length, 1);
+    assert.equal(dispatcher.calls[0].activation.agentId, alpha.agentId);
+    assert.equal(dispatcher.calls[0].activation.newItemCount, 1);
+    assert.equal(dispatcher.calls[0].activation.items?.[0]?.itemId, delivered.itemId);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("compact and gc remove only acked inbox items older than retention", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2036,6 +2036,36 @@ test("direct inbox text messages create inbox items and trigger activation", asy
     assert.equal(dispatcher.calls[0].activation.agentId, alpha.agentId);
     assert.equal(dispatcher.calls[0].activation.newItemCount, 1);
     assert.equal(dispatcher.calls[0].activation.items?.[0]?.itemId, delivered.itemId);
+    assert.match(dispatcher.calls[0].activation.summary, /from direct_text_message:/);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("direct inbox text messages fail cleanly if the inbox item cannot be persisted", async () => {
+  const dispatcher = new RecordingActivationDispatcher();
+  const { store, service, dir } = await makeService({
+    dispatcher,
+    activationWindowMs: 10,
+    activationMaxItems: 1,
+  });
+  try {
+    const alpha = await registerTmuxAgent(service, "64");
+    const originalInsert = store.insertInboxItem.bind(store);
+    store.insertInboxItem = () => false;
+
+    await assert.rejects(
+      service.addDirectInboxTextMessage(alpha.agentId, {
+        message: "This should fail",
+      }),
+      /failed to persist direct inbox message item/,
+    );
+    assert.equal(service.listInboxItems(alpha.agentId, { includeAcked: true }).length, 0);
+    assert.equal(dispatcher.calls.length, 0);
+
+    store.insertInboxItem = originalInsert;
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -767,6 +767,53 @@ test("cli inbox read rejects unsupported flags like --ack", () => {
   }
 });
 
+test("cli inbox send writes a direct text message into the target inbox", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-send-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%963",
+    CODEX_THREAD_ID: "thread-send",
+  };
+
+  try {
+    const register = runCli(["agent", "register"], env);
+    assert.equal(register.status, 0, register.stderr);
+    const registered = JSON.parse(register.stdout) as { agent: { agentId: string } };
+
+    const send = runCli([
+      "inbox",
+      "send",
+      "--agent-id",
+      registered.agent.agentId,
+      "--message",
+      "Review PR #51 CI failure and push a fix.",
+      "--sender",
+      "local-script",
+    ], env);
+    assert.equal(send.status, 0, send.stderr);
+    const delivered = JSON.parse(send.stdout) as { itemId: string; inboxId: string; activated: boolean };
+    assert.equal(delivered.activated, true);
+
+    const read = runCli(["inbox", "read", "--agent-id", registered.agent.agentId, "--include-acked"], env);
+    assert.equal(read.status, 0, read.stderr);
+    const payload = JSON.parse(read.stdout) as { items: Array<{ itemId: string; rawPayload: Record<string, unknown> }> };
+    assert.equal(payload.items.length, 1);
+    assert.equal(payload.items[0].itemId, delivered.itemId);
+    assert.deepEqual(payload.items[0].rawPayload, {
+      type: "direct_text_message",
+      message: "Review PR #51 CI failure and push a fix.",
+      sender: "local-script",
+    });
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli subscription add accepts filter-file and filter-stdin and echoes normalized filter", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-filter-"));
   const env = {
@@ -1653,6 +1700,121 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(invalidCleanupPolicyResponse.statusCode, 400);
       assert.match(invalidCleanupPolicyResponse.data.error, /unsupported cleanup policy mode/);
 
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    webhookServer.close();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane accepts direct inbox text messages and rejects blank payloads", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-direct-http-home-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters, undefined, undefined, {
+    windowMs: 10,
+    maxItems: 1,
+  }, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  let resolveWebhook: ((activation: Activation) => void) | null = null;
+  const webhookReceived = new Promise<Activation>((resolve) => {
+    resolveWebhook = resolve;
+  });
+  const webhookServer = http.createServer(async (req, res) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const payload = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Activation;
+    res.statusCode = 204;
+    res.end(() => {
+      resolveWebhook?.(payload);
+    });
+  });
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      await new Promise<void>((resolve) => {
+        webhookServer.listen(0, "127.0.0.1", () => resolve());
+      });
+      const address = webhookServer.address();
+      assert.ok(address && typeof address === "object");
+      const webhookUrl = `http://127.0.0.1:${address.port}/activate`;
+
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+
+      const agentResponse = await client.request<{ agent: { agentId: string } }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-direct-http",
+        tmuxPaneId: "%164",
+        notifyLeaseMs: 200,
+      });
+      assert.equal(agentResponse.statusCode, 200);
+      const agentId = agentResponse.data.agent.agentId;
+
+      const targetResponse = await client.request<{ targetId: string }>(`/agents/${encodeURIComponent(agentId)}/targets`, {
+        kind: "webhook",
+        url: webhookUrl,
+        activationMode: "activation_with_items",
+      });
+      assert.equal(targetResponse.statusCode, 200);
+
+      const sendResponse = await client.request<{ itemId: string; inboxId: string; activated: boolean }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/items`,
+        {
+          message: "Review PR #51 CI failure and push a fix.",
+          sender: "local-script",
+        },
+      );
+      assert.equal(sendResponse.statusCode, 200);
+      assert.equal(sendResponse.data.activated, true);
+
+      const activation = await waitFor(webhookReceived, 1_000, "timed out waiting for direct inbox activation");
+      assert.equal(activation.agentId, agentId);
+      assert.equal(activation.newItemCount, 1);
+      assert.equal(activation.items?.[0]?.eventVariant, "agentinbox.direct_text_message");
+
+      const inboxResponse = await client.request<{ items: InboxItem[] }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/items?include_acked=true`,
+        undefined,
+        "GET",
+      );
+      assert.equal(inboxResponse.statusCode, 200);
+      assert.equal(inboxResponse.data.items.length, 1);
+      assert.deepEqual(inboxResponse.data.items[0].rawPayload, {
+        type: "direct_text_message",
+        message: "Review PR #51 CI failure and push a fix.",
+        sender: "local-script",
+      });
+
+      const invalidResponse = await client.request<{ error: string }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/items`,
+        { message: "   " },
+      );
+      assert.equal(invalidResponse.statusCode, 400);
+      assert.match(invalidResponse.data.error, /direct inbox message must not be empty/);
     } finally {
       await started.close();
     }


### PR DESCRIPTION
Closes #63

## Summary
- add a narrow direct text ingress path for known agent inboxes
- materialize direct text messages as normal inbox items and trigger normal activation
- expose the feature through HTTP and CLI, with service/control-plane regression coverage