### PR TITLE
feat: add agent reminder timers

### DIFF
--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -107,6 +107,18 @@ agentinbox inbox ack [--agent-id <agent_id>] --all
 agentinbox inbox compact <agent_id>
 ```
 
+## Timers
+
+```bash
+agentinbox timer add --agent-id <agent_id> --at 2026-04-15T08:00:00+08:00 --message "..."
+agentinbox timer add --agent-id <agent_id> --every 24h --message "..."
+agentinbox timer add --agent-id <agent_id> --cron "0 8 * * *" --timezone Asia/Shanghai --message "..."
+agentinbox timer list [--agent-id <agent_id>]
+agentinbox timer pause <schedule_id>
+agentinbox timer resume <schedule_id>
+agentinbox timer remove <schedule_id>
+```
+
 ## Maintenance
 
 ```bash

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -43,6 +43,27 @@ going forward.
 - `POST /agents/{agentId}/targets`
 - `DELETE /agents/{agentId}/targets/{targetId}`
 
+## Timers
+
+- `GET /timers`
+- `POST /timers`
+- `POST /timers/{scheduleId}/pause`
+- `POST /timers/{scheduleId}/resume`
+- `DELETE /timers/{scheduleId}`
+
+`POST /timers` accepts a narrow reminder body:
+
+```json
+{
+  "agentId": "agent_...",
+  "at": "2026-04-15T08:00:00+08:00",
+  "message": "Analyze the agentinbox project and prepare today's task plan.",
+  "sender": "timer"
+}
+```
+
+Use exactly one of `at`, `every`, or `cron`. `every` is an interval in milliseconds. `timezone` is optional and defaults to the daemon host timezone.
+
 ## Subscriptions
 
 - `GET /subscriptions`

--- a/drizzle/migrations/0005_timers.sql
+++ b/drizzle/migrations/0005_timers.sql
@@ -1,0 +1,22 @@
+create table if not exists timers (
+  schedule_id text primary key not null,
+  agent_id text not null,
+  status text not null,
+  mode text not null,
+  at text,
+  interval_ms integer,
+  cron_expr text,
+  timezone text not null,
+  message text not null,
+  sender text,
+  next_fire_at text,
+  last_fired_at text,
+  created_at text not null,
+  updated_at text not null
+);
+
+create index if not exists idx_timers_agent_next_fire_at
+  on timers(agent_id, next_fire_at);
+
+create index if not exists idx_timers_next_fire_at
+  on timers(next_fire_at);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -24,6 +24,26 @@ export const sourceIdleStates = sqliteTable("source_idle_states", {
   autoPauseAtIdx: index("idx_source_idle_states_auto_pause_at").on(table.autoPauseAt),
 }));
 
+export const timers = sqliteTable("timers", {
+  scheduleId: text("schedule_id").primaryKey(),
+  agentId: text("agent_id").notNull(),
+  status: text("status").notNull(),
+  mode: text("mode").notNull(),
+  at: text("at"),
+  intervalMs: integer("interval_ms"),
+  cronExpr: text("cron_expr"),
+  timezone: text("timezone").notNull(),
+  message: text("message").notNull(),
+  sender: text("sender"),
+  nextFireAt: text("next_fire_at"),
+  lastFiredAt: text("last_fired_at"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+}, (table) => ({
+  agentNextFireIdx: index("idx_timers_agent_next_fire_at").on(table.agentId, table.nextFireAt),
+  nextFireIdx: index("idx_timers_next_fire_at").on(table.nextFireAt),
+}));
+
 export const agents = sqliteTable("agents", {
   agentId: text("agent_id").primaryKey(),
   status: text("status").notNull(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -384,6 +384,67 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "timer" && normalized[1] === "add") {
+    const args = normalized.slice(2);
+    const allowedFlags = ["--agent-id", "--at", "--every", "--cron", "--timezone", "--message", "--sender"];
+    if (positionalArgs(args, ["--agent-id", "--at", "--every", "--cron", "--timezone", "--message", "--sender"]).length > 0 || unexpectedFlags(args, allowedFlags).length > 0) {
+      throw new Error("usage: agentinbox timer add --agent-id ID (--at ISO8601 | --every DURATION | --cron EXPR) --message TEXT [--timezone TZ] [--sender SENDER]");
+    }
+    const agentId = takeFlagValue(normalized, "--agent-id");
+    const message = takeFlagValue(normalized, "--message");
+    const at = takeFlagValue(normalized, "--at");
+    const every = takeFlagValue(normalized, "--every");
+    const cron = takeFlagValue(normalized, "--cron");
+    if (!agentId || !message || [at, every, cron].filter(Boolean).length !== 1) {
+      throw new Error("usage: agentinbox timer add --agent-id ID (--at ISO8601 | --every DURATION | --cron EXPR) --message TEXT [--timezone TZ] [--sender SENDER]");
+    }
+    await printRemote(client, "/timers", {
+      agentId,
+      at: at ?? undefined,
+      every: every ? parseDurationMs(every) : undefined,
+      cron: cron ?? undefined,
+      timezone: takeFlagValue(normalized, "--timezone") ?? undefined,
+      message,
+      sender: takeFlagValue(normalized, "--sender") ?? undefined,
+    });
+    return;
+  }
+
+  if (command === "timer" && normalized[1] === "list") {
+    const query = buildQuery({
+      agent_id: takeFlagValue(normalized, "--agent-id"),
+    });
+    await printRemote(client, `/timers${query}`, undefined, "GET");
+    return;
+  }
+
+  if (command === "timer" && normalized[1] === "pause") {
+    const scheduleId = normalized[2];
+    if (!scheduleId) {
+      throw new Error("usage: agentinbox timer pause <scheduleId>");
+    }
+    await printRemote(client, `/timers/${encodeURIComponent(scheduleId)}/pause`, {});
+    return;
+  }
+
+  if (command === "timer" && normalized[1] === "resume") {
+    const scheduleId = normalized[2];
+    if (!scheduleId) {
+      throw new Error("usage: agentinbox timer resume <scheduleId>");
+    }
+    await printRemote(client, `/timers/${encodeURIComponent(scheduleId)}/resume`, {});
+    return;
+  }
+
+  if (command === "timer" && normalized[1] === "remove") {
+    const scheduleId = normalized[2];
+    if (!scheduleId) {
+      throw new Error("usage: agentinbox timer remove <scheduleId>");
+    }
+    await printRemote(client, `/timers/${encodeURIComponent(scheduleId)}`, undefined, "DELETE");
+    return;
+  }
+
   if (command === "inbox" && normalized[1] === "list") {
     await printRemote(client, "/agents", undefined, "GET");
     return;
@@ -758,6 +819,31 @@ function parseOptionalNumber(value: string | undefined): number | undefined {
   return parsed;
 }
 
+function parseDurationMs(value: string): number {
+  if (/^\d+$/.test(value)) {
+    return Number(value);
+  }
+  const match = /^(\d+)(ms|s|m|h|d)$/.exec(value);
+  if (!match) {
+    throw new Error(`invalid duration: ${value}`);
+  }
+  const amount = Number(match[1]);
+  switch (match[2]) {
+    case "ms":
+      return amount;
+    case "s":
+      return amount * 1_000;
+    case "m":
+      return amount * 60_000;
+    case "h":
+      return amount * 60 * 60_000;
+    case "d":
+      return amount * 24 * 60 * 60_000;
+    default:
+      throw new Error(`invalid duration: ${value}`);
+  }
+}
+
 function normalizeHelpArgs(args: string[]): string[] {
   if (args[0] !== "help") {
     return args;
@@ -884,6 +970,7 @@ Commands:
   daemon
   source
   agent
+  timer
   subscription
   inbox
   gc
@@ -930,6 +1017,15 @@ Usage:
   agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N]
   agentinbox agent target list <agentId>
   agentinbox agent target remove <agentId> <targetId>
+`,
+    timer: `agentinbox timer
+
+Usage:
+  agentinbox timer add --agent-id ID (--at ISO8601 | --every DURATION | --cron EXPR) --message TEXT [--timezone TZ] [--sender SENDER]
+  agentinbox timer list [--agent-id ID]
+  agentinbox timer pause <scheduleId>
+  agentinbox timer resume <scheduleId>
+  agentinbox timer remove <scheduleId>
 `,
     subscription: `agentinbox subscription
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -599,6 +599,128 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.removeActivationTarget(decodeURIComponent(params.agentId), decodeURIComponent(params.targetId));
   });
 
+  app.get("/timers", {
+    schema: {
+      tags: ["timers"],
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          agent_id: { type: "string" },
+        },
+      },
+      response: {
+        200: {
+          type: "object",
+          required: ["timers"],
+          properties: {
+            timers: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async (request) => {
+    const query = request.query as { agent_id?: string };
+    return { timers: service.listTimers(query.agent_id) };
+  });
+
+  app.post("/timers", {
+    schema: {
+      tags: ["timers"],
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["agentId", "message"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+          at: { type: "string", minLength: 1 },
+          every: { type: "integer", minimum: 60000 },
+          cron: { type: "string", minLength: 1 },
+          timezone: { type: "string", minLength: 1 },
+          message: { type: "string", minLength: 1 },
+          sender: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const body = request.body as Record<string, unknown>;
+    return service.registerTimer({
+      agentId: String(body.agentId),
+      at: optionalString(body.at) ?? null,
+      every: typeof body.every === "number" ? body.every : null,
+      cron: optionalString(body.cron) ?? null,
+      timezone: optionalString(body.timezone) ?? null,
+      message: String(body.message),
+      sender: optionalString(body.sender) ?? null,
+    });
+  });
+
+  app.post("/timers/:scheduleId/pause", {
+    schema: {
+      tags: ["timers"],
+      params: {
+        type: "object",
+        required: ["scheduleId"],
+        properties: {
+          scheduleId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { scheduleId: string };
+    return service.pauseTimer(decodeURIComponent(params.scheduleId));
+  });
+
+  app.post("/timers/:scheduleId/resume", {
+    schema: {
+      tags: ["timers"],
+      params: {
+        type: "object",
+        required: ["scheduleId"],
+        properties: {
+          scheduleId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { scheduleId: string };
+    return service.resumeTimer(decodeURIComponent(params.scheduleId));
+  });
+
+  app.delete("/timers/:scheduleId", {
+    schema: {
+      tags: ["timers"],
+      params: {
+        type: "object",
+        required: ["scheduleId"],
+        properties: {
+          scheduleId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { scheduleId: string };
+    return service.removeTimer(decodeURIComponent(params.scheduleId));
+  });
+
   app.get("/subscriptions", {
     schema: {
       tags: ["subscriptions"],
@@ -1165,6 +1287,9 @@ function normalizeValidationMessage(message: string): string {
 function isBadRequestError(message: string): boolean {
   return (
     message.startsWith("direct inbox ") ||
+    message.startsWith("timers require ") ||
+    message.startsWith("timer ") ||
+    message.startsWith("invalid timezone: ") ||
     message.startsWith("manual append is not supported") ||
     message.startsWith("sources/events requires") ||
     message.startsWith("source remove requires") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -242,6 +242,41 @@ export interface DirectInboxTextMessageResult {
   activated: boolean;
 }
 
+export type TimerMode = "at" | "every" | "cron";
+export type TimerStatus = "active" | "paused";
+
+export interface AgentTimer {
+  scheduleId: string;
+  agentId: string;
+  status: TimerStatus;
+  mode: TimerMode;
+  at?: string | null;
+  intervalMs?: number | null;
+  cronExpr?: string | null;
+  timezone: string;
+  message: string;
+  sender?: string | null;
+  nextFireAt?: string | null;
+  lastFiredAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RegisterTimerInput {
+  agentId: string;
+  at?: string | null;
+  every?: number | null;
+  cron?: string | null;
+  timezone?: string | null;
+  message: string;
+  sender?: string | null;
+}
+
+export interface UpdateTimerStatusResult {
+  updated: boolean;
+  timer: AgentTimer;
+}
+
 export interface RegisterSubscriptionInput {
   agentId: string;
   sourceId: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,6 +4,7 @@ import {
   ActivationTarget,
   AddWebhookActivationTargetInput,
   Agent,
+  AgentTimer,
   DirectInboxTextMessageInput,
   DirectInboxTextMessageResult,
   AppendSourceEventInput,
@@ -19,6 +20,7 @@ import {
   RegisterAgentResult,
   RegisterSourceInput,
   RegisterSubscriptionInput,
+  RegisterTimerInput,
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
   SourceSchema,
@@ -30,6 +32,7 @@ import {
   SubscriptionPollResult,
   SubscriptionSource,
   TerminalActivationTarget,
+  UpdateTimerStatusResult,
   UpdateSourceInput,
   WatchInboxOptions,
   WebhookActivationTarget,
@@ -63,6 +66,10 @@ const DEFAULT_SYNC_INTERVAL_MS = 2_000;
 const DEFAULT_IDLE_SOURCE_GRACE_MS = 5 * 60 * 1000;
 const DIRECT_INBOX_SOURCE_ID = "__agentinbox_direct_text__";
 const DIRECT_INBOX_EVENT_VARIANT = "agentinbox.direct_text_message";
+const TIMER_INBOX_SOURCE_ID = "__agentinbox_timer__";
+const TIMER_INBOX_EVENT_VARIANT = "agentinbox.timer_fired";
+const DEFAULT_TIMER_SENDER = "timer";
+const MIN_TIMER_INTERVAL_MS = 60 * 1000;
 const WEBHOOK_ACTIVATION_MODES = new Set<WebhookActivationTarget["mode"]>(["activation_only", "activation_with_items"]);
 const SUBSCRIPTION_START_POLICIES = new Set<Subscription["startPolicy"]>(["latest", "earliest", "at_offset", "at_time"]);
 interface ActivationPolicy {
@@ -104,6 +111,7 @@ export class AgentInboxService {
   private readonly notificationBuffers = new Map<string, BufferedNotification>();
   private readonly inboxWatchers = new Map<string, Set<InboxWatcher>>();
   private syncInterval: NodeJS.Timeout | null = null;
+  private timerSyncTimeout: NodeJS.Timeout | null = null;
   private stopping = false;
   private lastAckedInboxGcAt = 0;
   private lastLifecycleCleanupAt = 0;
@@ -139,10 +147,12 @@ export class AgentInboxService {
       void this.runAckedInboxGcIfDue();
       void this.syncLifecycleGc();
     }, DEFAULT_SYNC_INTERVAL_MS);
+    this.refreshTimersOnStart();
     await this.syncAllSubscriptions();
     await this.syncActivationDispatchStates();
     await this.runAckedInboxGcIfDue(true);
     await this.syncLifecycleGc();
+    await this.syncTimers();
   }
 
   async stop(): Promise<void> {
@@ -156,6 +166,10 @@ export class AgentInboxService {
     if (this.syncInterval) {
       clearInterval(this.syncInterval);
       this.syncInterval = null;
+    }
+    if (this.timerSyncTimeout) {
+      clearTimeout(this.timerSyncTimeout);
+      this.timerSyncTimeout = null;
     }
     await this.flushAllPendingNotifications();
   }
@@ -476,7 +490,110 @@ export class AgentInboxService {
       }
     });
     this.inboxWatchers.delete(agentId);
+    this.rescheduleTimerSync();
     return { removed: true };
+  }
+
+  registerTimer(input: RegisterTimerInput): AgentTimer {
+    this.getAgent(input.agentId);
+    const normalized = normalizeTimerInput(input);
+    const timezone = normalized.timezone ?? detectHostTimezone();
+    assertValidTimeZone(timezone);
+    const now = nowIso();
+    const nextFireAt = computeNextTimerFire({
+      mode: normalized.mode,
+      at: normalized.at ?? null,
+      intervalMs: normalized.every ?? null,
+      cronExpr: normalized.cron ?? null,
+      timezone,
+      fromIso: now,
+      lastFiredAt: null,
+      restartRecovery: false,
+    });
+    const timer: AgentTimer = {
+      scheduleId: generateId("sched"),
+      agentId: input.agentId,
+      status: "active",
+      mode: normalized.mode,
+      at: normalized.at ?? null,
+      intervalMs: normalized.every ?? null,
+      cronExpr: normalized.cron ?? null,
+      timezone,
+      message: normalizeDirectInboxMessage(input.message),
+      sender: normalizeDirectInboxSender(input.sender) ?? DEFAULT_TIMER_SENDER,
+      nextFireAt,
+      lastFiredAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.store.insertTimer(timer);
+    this.rescheduleTimerSync();
+    return timer;
+  }
+
+  listTimers(agentId?: string): AgentTimer[] {
+    if (agentId) {
+      this.getAgent(agentId);
+      return this.store.listTimersForAgent(agentId);
+    }
+    return this.store.listTimers();
+  }
+
+  getTimer(scheduleId: string): AgentTimer {
+    const timer = this.store.getTimer(scheduleId);
+    if (!timer) {
+      throw new Error(`unknown timer: ${scheduleId}`);
+    }
+    return timer;
+  }
+
+  pauseTimer(scheduleId: string): UpdateTimerStatusResult {
+    const timer = this.getTimer(scheduleId);
+    const updated = this.store.updateTimer(scheduleId, {
+      status: "paused",
+      nextFireAt: null,
+      updatedAt: nowIso(),
+    });
+    this.rescheduleTimerSync();
+    return {
+      updated: timer.status !== "paused",
+      timer: updated,
+    };
+  }
+
+  resumeTimer(scheduleId: string): UpdateTimerStatusResult {
+    const timer = this.getTimer(scheduleId);
+    if (timer.mode === "at" && timer.lastFiredAt) {
+      throw new Error(`timer ${scheduleId} already fired`);
+    }
+    const now = nowIso();
+    const nextFireAt = computeNextTimerFire({
+      mode: timer.mode,
+      at: timer.at ?? null,
+      intervalMs: timer.intervalMs ?? null,
+      cronExpr: timer.cronExpr ?? null,
+      timezone: timer.timezone,
+      fromIso: now,
+      lastFiredAt: timer.lastFiredAt ?? null,
+      restartRecovery: false,
+    });
+    const updated = this.store.updateTimer(scheduleId, {
+      status: "active",
+      nextFireAt,
+      updatedAt: now,
+    });
+    this.rescheduleTimerSync();
+    return {
+      updated: timer.status !== "active",
+      timer: updated,
+    };
+  }
+
+  removeTimer(scheduleId: string): { removed: boolean; scheduleId: string } {
+    this.getTimer(scheduleId);
+    this.store.deleteTimer(scheduleId);
+    this.rescheduleTimerSync();
+    return { removed: true, scheduleId };
   }
 
   addWebhookActivationTarget(agentId: string, input: AddWebhookActivationTargetInput): WebhookActivationTarget {
@@ -722,21 +839,74 @@ export class AgentInboxService {
     this.getAgent(agentId);
     const message = normalizeDirectInboxMessage(input.message);
     const sender = normalizeDirectInboxSender(input.sender) ?? this.detectDirectInboxSender(env);
-    const inbox = this.ensureInboxForAgent(agentId);
-    const occurredAt = nowIso();
-    const item: InboxItem = {
-      itemId: generateId("item"),
+    return this.materializeAgentInboxItem(agentId, {
       sourceId: DIRECT_INBOX_SOURCE_ID,
       sourceNativeId: generateId("direct"),
       eventVariant: DIRECT_INBOX_EVENT_VARIANT,
-      inboxId: inbox.inboxId,
-      occurredAt,
-      metadata: {},
+      summary: summarizeDirectInboxMessage(sender),
       rawPayload: {
         type: "direct_text_message",
         message,
         sender,
       },
+    });
+  }
+
+  private async fireTimer(timer: AgentTimer, now: string): Promise<void> {
+    await this.materializeAgentInboxItem(timer.agentId, {
+      sourceId: TIMER_INBOX_SOURCE_ID,
+      sourceNativeId: `${timer.scheduleId}:${now}`,
+      eventVariant: TIMER_INBOX_EVENT_VARIANT,
+      summary: summarizeTimerMessage(timer.scheduleId),
+      rawPayload: {
+        type: "timer_fired",
+        scheduleId: timer.scheduleId,
+        message: timer.message,
+        sender: timer.sender ?? DEFAULT_TIMER_SENDER,
+      },
+      occurredAt: now,
+    });
+
+    const nextFireAt = computeNextTimerFire({
+      mode: timer.mode,
+      at: timer.at ?? null,
+      intervalMs: timer.intervalMs ?? null,
+      cronExpr: timer.cronExpr ?? null,
+      timezone: timer.timezone,
+      fromIso: now,
+      lastFiredAt: now,
+      restartRecovery: false,
+    });
+    this.store.updateTimer(timer.scheduleId, {
+      status: nextFireAt ? "active" : "paused",
+      nextFireAt,
+      lastFiredAt: now,
+      updatedAt: now,
+    });
+  }
+
+  private materializeAgentInboxItem(
+    agentId: string,
+    input: {
+      sourceId: string;
+      sourceNativeId: string;
+      eventVariant: string;
+      summary: string;
+      rawPayload: Record<string, unknown>;
+      occurredAt?: string;
+    },
+  ): DirectInboxTextMessageResult {
+    const inbox = this.ensureInboxForAgent(agentId);
+    const occurredAt = input.occurredAt ?? nowIso();
+    const item: InboxItem = {
+      itemId: generateId("item"),
+      sourceId: input.sourceId,
+      sourceNativeId: input.sourceNativeId,
+      eventVariant: input.eventVariant,
+      inboxId: inbox.inboxId,
+      occurredAt,
+      metadata: {},
+      rawPayload: input.rawPayload,
       deliveryHandle: null,
       ackedAt: null,
     };
@@ -762,8 +932,8 @@ export class AgentInboxService {
       this.enqueueActivationTarget(target, {
         agentId,
         subscriptionId: null,
-        sourceId: DIRECT_INBOX_SOURCE_ID,
-        summary: summarizeDirectInboxMessage(sender),
+        sourceId: input.sourceId,
+        summary: input.summary,
         item: activationItem,
       });
     }
@@ -1800,6 +1970,9 @@ export class AgentInboxService {
     if (agents.length > 0) {
       this.store.save();
     }
+    if (agents.length > 0) {
+      this.rescheduleTimerSync();
+    }
     return { removedAgents: agents.length };
   }
 
@@ -1856,6 +2029,66 @@ export class AgentInboxService {
     } catch (error) {
       console.warn("offline agent gc failed:", error);
     }
+  }
+
+  private async syncTimers(): Promise<void> {
+    const now = nowIso();
+    const due = this.store.listDueTimers(now);
+    for (const timer of due) {
+      try {
+        await this.fireTimer(timer, now);
+      } catch (error) {
+        console.warn(`timer fire failed for ${timer.scheduleId}:`, error);
+      }
+    }
+    this.rescheduleTimerSync();
+  }
+
+  private refreshTimersOnStart(): void {
+    const now = nowIso();
+    for (const timer of this.store.listTimers()) {
+      if (timer.status !== "active") {
+        continue;
+      }
+      const nextFireAt = computeNextTimerFire({
+        mode: timer.mode,
+        at: timer.at ?? null,
+        intervalMs: timer.intervalMs ?? null,
+        cronExpr: timer.cronExpr ?? null,
+        timezone: timer.timezone,
+        fromIso: now,
+        lastFiredAt: timer.lastFiredAt ?? null,
+        restartRecovery: true,
+      });
+      this.store.updateTimer(timer.scheduleId, {
+        nextFireAt,
+        status: nextFireAt ? "active" : "paused",
+        updatedAt: now,
+      });
+    }
+  }
+
+  private rescheduleTimerSync(): void {
+    if (this.timerSyncTimeout) {
+      clearTimeout(this.timerSyncTimeout);
+      this.timerSyncTimeout = null;
+    }
+    if (this.stopping) {
+      return;
+    }
+    const nearest = this.store.getNearestActiveTimer();
+    if (!nearest?.nextFireAt) {
+      return;
+    }
+    const dueAt = Date.parse(nearest.nextFireAt);
+    if (Number.isNaN(dueAt)) {
+      return;
+    }
+    const delay = Math.max(0, dueAt - Date.now());
+    this.timerSyncTimeout = setTimeout(() => {
+      this.timerSyncTimeout = null;
+      void this.syncTimers();
+    }, delay);
   }
 
   private refreshSourceIdleState(sourceId: string): void {
@@ -2245,6 +2478,10 @@ function summarizeDirectInboxMessage(sender: string | null): string {
   return "direct_text_message";
 }
 
+function summarizeTimerMessage(scheduleId: string): string {
+  return `timer:${scheduleId}`;
+}
+
 function normalizeDirectInboxMessage(message: string): string {
   if (typeof message !== "string") {
     throw new Error("direct inbox message must be a string");
@@ -2268,4 +2505,242 @@ function normalizeDirectInboxSender(sender: string | null | undefined): string |
     throw new Error("direct inbox sender must not be empty");
   }
   return trimmed;
+}
+
+function normalizeTimerInput(input: RegisterTimerInput): {
+  mode: "at" | "every" | "cron";
+  at?: string | null;
+  every?: number | null;
+  cron?: string | null;
+  timezone?: string | null;
+} {
+  const modes = [input.at != null, input.every != null, input.cron != null].filter(Boolean).length;
+  if (modes !== 1) {
+    throw new Error("timers require exactly one of at, every, or cron");
+  }
+  if (input.at != null) {
+    const at = normalizeIsoTimestamp(input.at, "timer at");
+    return { mode: "at", at, timezone: input.timezone ?? null };
+  }
+  if (input.every != null) {
+    if (!Number.isInteger(input.every) || input.every < MIN_TIMER_INTERVAL_MS) {
+      throw new Error("timer every interval must be an integer number of milliseconds and at least 60000");
+    }
+    return { mode: "every", every: input.every, timezone: input.timezone ?? null };
+  }
+  const cron = normalizeCronExpression(input.cron!);
+  return { mode: "cron", cron, timezone: input.timezone ?? null };
+}
+
+function normalizeIsoTimestamp(value: string, label: string): string {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${label} must be a valid ISO8601 timestamp`);
+  }
+  return new Date(parsed).toISOString();
+}
+
+function normalizeCronExpression(value: string): string {
+  if (typeof value !== "string") {
+    throw new Error("timer cron must be a string");
+  }
+  const trimmed = value.trim().replace(/\s+/g, " ");
+  const fields = trimmed.split(" ");
+  if (fields.length !== 5) {
+    throw new Error("timer cron must use standard 5-field syntax");
+  }
+  for (const field of fields) {
+    if (/[LW#@]/.test(field)) {
+      throw new Error("timer cron does not support extensions like L, W, #, or @reboot");
+    }
+  }
+  parseCronExpression(trimmed);
+  return trimmed;
+}
+
+function detectHostTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+function assertValidTimeZone(timezone: string): void {
+  try {
+    Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
+  } catch {
+    throw new Error(`invalid timezone: ${timezone}`);
+  }
+}
+
+function computeNextTimerFire(input: {
+  mode: "at" | "every" | "cron";
+  at: string | null;
+  intervalMs: number | null;
+  cronExpr: string | null;
+  timezone: string;
+  fromIso: string;
+  lastFiredAt: string | null;
+  restartRecovery: boolean;
+}): string | null {
+  const fromMs = Date.parse(input.fromIso);
+  if (Number.isNaN(fromMs)) {
+    return null;
+  }
+  if (input.mode === "at") {
+    if (!input.at) {
+      return null;
+    }
+    const atMs = Date.parse(input.at);
+    if (Number.isNaN(atMs)) {
+      return null;
+    }
+    if (input.lastFiredAt) {
+      return null;
+    }
+    if (atMs <= fromMs) {
+      return input.restartRecovery ? input.at : input.at;
+    }
+    return input.at;
+  }
+  if (input.mode === "every") {
+    if (!input.intervalMs) {
+      return null;
+    }
+    if (!input.lastFiredAt) {
+      return new Date(fromMs + input.intervalMs).toISOString();
+    }
+    const lastFiredMs = Date.parse(input.lastFiredAt);
+    if (Number.isNaN(lastFiredMs)) {
+      return new Date(fromMs + input.intervalMs).toISOString();
+    }
+    const base = input.restartRecovery ? fromMs : Math.max(fromMs, lastFiredMs);
+    return new Date(base + input.intervalMs).toISOString();
+  }
+  if (!input.cronExpr) {
+    return null;
+  }
+  return nextCronOccurrence(input.cronExpr, input.timezone, new Date(fromMs));
+}
+
+type ParsedCronField = {
+  any: boolean;
+  values: Set<number>;
+};
+
+type ParsedCron = {
+  minute: ParsedCronField;
+  hour: ParsedCronField;
+  dayOfMonth: ParsedCronField;
+  month: ParsedCronField;
+  dayOfWeek: ParsedCronField;
+};
+
+function parseCronExpression(expr: string): ParsedCron {
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = expr.split(" ");
+  return {
+    minute: parseCronField(minute, 0, 59),
+    hour: parseCronField(hour, 0, 23),
+    dayOfMonth: parseCronField(dayOfMonth, 1, 31),
+    month: parseCronField(month, 1, 12),
+    dayOfWeek: parseCronField(dayOfWeek, 0, 6, true),
+  };
+}
+
+function parseCronField(field: string, min: number, max: number, normalizeSunday = false): ParsedCronField {
+  if (field === "*") {
+    return { any: true, values: new Set() };
+  }
+  const values = new Set<number>();
+  for (const part of field.split(",")) {
+    const [rangePart, stepPart] = part.split("/");
+    const step = stepPart ? Number(stepPart) : 1;
+    if (!Number.isInteger(step) || step <= 0) {
+      throw new Error(`invalid cron field: ${field}`);
+    }
+    const [startRaw, endRaw] = rangePart === "*" ? [String(min), String(max)] : rangePart.split("-");
+    const start = Number(startRaw);
+    const end = endRaw != null ? Number(endRaw) : start;
+    if (!Number.isInteger(start) || !Number.isInteger(end) || start < min || end > max || start > end) {
+      throw new Error(`invalid cron field: ${field}`);
+    }
+    for (let value = start; value <= end; value += step) {
+      values.add(normalizeSunday && value === 7 ? 0 : value);
+    }
+  }
+  return { any: false, values };
+}
+
+function nextCronOccurrence(expr: string, timezone: string, after: Date): string | null {
+  const parsed = parseCronExpression(expr);
+  const candidate = new Date(after.getTime());
+  candidate.setUTCSeconds(0, 0);
+  candidate.setUTCMinutes(candidate.getUTCMinutes() + 1);
+  for (let index = 0; index < 366 * 24 * 60; index += 1) {
+    const zoned = zonedDateParts(candidate, timezone);
+    if (matchesCron(parsed, zoned)) {
+      return candidate.toISOString();
+    }
+    candidate.setUTCMinutes(candidate.getUTCMinutes() + 1);
+  }
+  return null;
+}
+
+function matchesCron(parsed: ParsedCron, parts: ReturnType<typeof zonedDateParts>): boolean {
+  const monthMatches = parsed.month.any || parsed.month.values.has(parts.month);
+  const hourMatches = parsed.hour.any || parsed.hour.values.has(parts.hour);
+  const minuteMatches = parsed.minute.any || parsed.minute.values.has(parts.minute);
+  if (!monthMatches || !hourMatches || !minuteMatches) {
+    return false;
+  }
+  const dayOfMonthMatches = parsed.dayOfMonth.any || parsed.dayOfMonth.values.has(parts.day);
+  const dayOfWeekMatches = parsed.dayOfWeek.any || parsed.dayOfWeek.values.has(parts.dayOfWeek);
+  if (!parsed.dayOfMonth.any && !parsed.dayOfWeek.any) {
+    return dayOfMonthMatches || dayOfWeekMatches;
+  }
+  return dayOfMonthMatches && dayOfWeekMatches;
+}
+
+function zonedDateParts(date: Date, timezone: string): {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  dayOfWeek: number;
+} {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    weekday: "short",
+  });
+  const entries = Object.fromEntries(
+    formatter.formatToParts(date)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  ) as Record<string, string>;
+  return {
+    year: Number(entries.year),
+    month: Number(entries.month),
+    day: Number(entries.day),
+    hour: Number(entries.hour),
+    minute: Number(entries.minute),
+    dayOfWeek: weekdayToNumber(entries.weekday),
+  };
+}
+
+function weekdayToNumber(value: string): number {
+  switch (value) {
+    case "Sun": return 0;
+    case "Mon": return 1;
+    case "Tue": return 2;
+    case "Wed": return 3;
+    case "Thu": return 4;
+    case "Fri": return 5;
+    case "Sat": return 6;
+    default:
+      throw new Error(`unsupported weekday: ${value}`);
+  }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -2769,7 +2769,7 @@ function zonedDateParts(date: Date, timezone: string): {
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
-    hour12: false,
+    hourCycle: "h23",
     weekday: "short",
   });
   const entries = Object.fromEntries(
@@ -2777,11 +2777,14 @@ function zonedDateParts(date: Date, timezone: string): {
       .filter((part) => part.type !== "literal")
       .map((part) => [part.type, part.value]),
   ) as Record<string, string>;
+  const hour = Number(entries.hour);
   return {
     year: Number(entries.year),
     month: Number(entries.month),
     day: Number(entries.day),
-    hour: Number(entries.hour),
+    // Some ICU builds format midnight as 24:00 even for exact timestamps.
+    // Normalize that representation so cron matching stays cross-platform.
+    hour: hour === 24 ? 0 : hour,
     minute: Number(entries.minute),
     dayOfWeek: weekdayToNumber(entries.weekday),
   };

--- a/src/service.ts
+++ b/src/service.ts
@@ -513,7 +513,7 @@ export class AgentInboxService {
     const timer: AgentTimer = {
       scheduleId: generateId("sched"),
       agentId: input.agentId,
-      status: "active",
+      status: nextFireAt ? "active" : "paused",
       mode: normalized.mode,
       at: normalized.at ?? null,
       intervalMs: normalized.every ?? null,
@@ -577,14 +577,15 @@ export class AgentInboxService {
       lastFiredAt: timer.lastFiredAt ?? null,
       restartRecovery: false,
     });
+    const status: AgentTimer["status"] = nextFireAt ? "active" : "paused";
     const updated = this.store.updateTimer(scheduleId, {
-      status: "active",
+      status,
       nextFireAt,
       updatedAt: now,
     });
     this.rescheduleTimerSync();
     return {
-      updated: timer.status !== "active",
+      updated: timer.status !== status,
       timer: updated,
     };
   }
@@ -853,9 +854,10 @@ export class AgentInboxService {
   }
 
   private async fireTimer(timer: AgentTimer, now: string): Promise<void> {
-    await this.materializeAgentInboxItem(timer.agentId, {
+    const scheduledFireAt = timer.nextFireAt ?? now;
+    this.materializeAgentInboxItem(timer.agentId, {
       sourceId: TIMER_INBOX_SOURCE_ID,
-      sourceNativeId: `${timer.scheduleId}:${now}`,
+      sourceNativeId: `${timer.scheduleId}:${scheduledFireAt}`,
       eventVariant: TIMER_INBOX_EVENT_VARIANT,
       summary: summarizeTimerMessage(timer.scheduleId),
       rawPayload: {
@@ -864,7 +866,8 @@ export class AgentInboxService {
         message: timer.message,
         sender: timer.sender ?? DEFAULT_TIMER_SENDER,
       },
-      occurredAt: now,
+      occurredAt: scheduledFireAt,
+      allowDuplicate: true,
     });
 
     const nextFireAt = computeNextTimerFire({
@@ -873,8 +876,8 @@ export class AgentInboxService {
       intervalMs: timer.intervalMs ?? null,
       cronExpr: timer.cronExpr ?? null,
       timezone: timer.timezone,
-      fromIso: now,
-      lastFiredAt: now,
+      fromIso: scheduledFireAt,
+      lastFiredAt: scheduledFireAt,
       restartRecovery: false,
     });
     this.store.updateTimer(timer.scheduleId, {
@@ -894,6 +897,7 @@ export class AgentInboxService {
       summary: string;
       rawPayload: Record<string, unknown>;
       occurredAt?: string;
+      allowDuplicate?: boolean;
     },
   ): DirectInboxTextMessageResult {
     const inbox = this.ensureInboxForAgent(agentId);
@@ -911,8 +915,15 @@ export class AgentInboxService {
       ackedAt: null,
     };
     const inserted = this.store.insertInboxItem(item);
-    if (!inserted) {
+    if (!inserted && !input.allowDuplicate) {
       throw new Error(`failed to persist direct inbox message item: ${item.itemId}`);
+    }
+    if (!inserted) {
+      return {
+        itemId: item.itemId,
+        inboxId: inbox.inboxId,
+        activated: false,
+      };
     }
     this.notifyInboxWatchers(agentId, [item]);
 
@@ -2640,7 +2651,7 @@ function parseCronExpression(expr: string): ParsedCron {
     hour: parseCronField(hour, 0, 23),
     dayOfMonth: parseCronField(dayOfMonth, 1, 31),
     month: parseCronField(month, 1, 12),
-    dayOfWeek: parseCronField(dayOfWeek, 0, 6, true),
+    dayOfWeek: parseCronField(dayOfWeek, 0, 7, true),
   };
 }
 
@@ -2670,15 +2681,51 @@ function parseCronField(field: string, min: number, max: number, normalizeSunday
 
 function nextCronOccurrence(expr: string, timezone: string, after: Date): string | null {
   const parsed = parseCronExpression(expr);
-  const candidate = new Date(after.getTime());
+  let candidate = addMinutes(after, 1);
   candidate.setUTCSeconds(0, 0);
-  candidate.setUTCMinutes(candidate.getUTCMinutes() + 1);
-  for (let index = 0; index < 366 * 24 * 60; index += 1) {
+
+  for (let guard = 0; guard < 10_000; guard += 1) {
     const zoned = zonedDateParts(candidate, timezone);
+
+    const nextMonth = nextAllowedValue(parsed.month, zoned.month, 1, 12);
+    if (nextMonth == null) {
+      candidate = utcDateForZoned(timezone, zoned.year + 1, firstAllowedValue(parsed.month, 1, 12), 1, 0, 0);
+      continue;
+    }
+    if (nextMonth !== zoned.month) {
+      candidate = utcDateForZoned(timezone, zoned.year, nextMonth, 1, 0, 0);
+      continue;
+    }
+
+    if (!matchesCronDay(parsed, zoned)) {
+      candidate = utcDateForZoned(timezone, zoned.year, zoned.month, zoned.day + 1, 0, 0);
+      continue;
+    }
+
+    const nextHour = nextAllowedValue(parsed.hour, zoned.hour, 0, 23);
+    if (nextHour == null) {
+      candidate = utcDateForZoned(timezone, zoned.year, zoned.month, zoned.day + 1, firstAllowedValue(parsed.hour, 0, 23), 0);
+      continue;
+    }
+    if (nextHour !== zoned.hour) {
+      candidate = utcDateForZoned(timezone, zoned.year, zoned.month, zoned.day, nextHour, 0);
+      continue;
+    }
+
+    const nextMinute = nextAllowedValue(parsed.minute, zoned.minute, 0, 59);
+    if (nextMinute == null) {
+      candidate = utcDateForZoned(timezone, zoned.year, zoned.month, zoned.day, zoned.hour + 1, firstAllowedValue(parsed.minute, 0, 59));
+      continue;
+    }
+    if (nextMinute !== zoned.minute) {
+      candidate = utcDateForZoned(timezone, zoned.year, zoned.month, zoned.day, zoned.hour, nextMinute);
+      continue;
+    }
+
     if (matchesCron(parsed, zoned)) {
       return candidate.toISOString();
     }
-    candidate.setUTCMinutes(candidate.getUTCMinutes() + 1);
+    candidate = addMinutes(candidate, 1);
   }
   return null;
 }
@@ -2690,6 +2737,15 @@ function matchesCron(parsed: ParsedCron, parts: ReturnType<typeof zonedDateParts
   if (!monthMatches || !hourMatches || !minuteMatches) {
     return false;
   }
+  const dayOfMonthMatches = parsed.dayOfMonth.any || parsed.dayOfMonth.values.has(parts.day);
+  const dayOfWeekMatches = parsed.dayOfWeek.any || parsed.dayOfWeek.values.has(parts.dayOfWeek);
+  if (!parsed.dayOfMonth.any && !parsed.dayOfWeek.any) {
+    return dayOfMonthMatches || dayOfWeekMatches;
+  }
+  return dayOfMonthMatches && dayOfWeekMatches;
+}
+
+function matchesCronDay(parsed: ParsedCron, parts: ReturnType<typeof zonedDateParts>): boolean {
   const dayOfMonthMatches = parsed.dayOfMonth.any || parsed.dayOfMonth.values.has(parts.day);
   const dayOfWeekMatches = parsed.dayOfWeek.any || parsed.dayOfWeek.values.has(parts.dayOfWeek);
   if (!parsed.dayOfMonth.any && !parsed.dayOfWeek.any) {
@@ -2729,6 +2785,43 @@ function zonedDateParts(date: Date, timezone: string): {
     minute: Number(entries.minute),
     dayOfWeek: weekdayToNumber(entries.weekday),
   };
+}
+
+function nextAllowedValue(field: ParsedCronField, current: number, min: number, max: number): number | null {
+  if (field.any) {
+    return current;
+  }
+  for (let value = current; value <= max; value += 1) {
+    if (field.values.has(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstAllowedValue(field: ParsedCronField, min: number, max: number): number {
+  if (field.any) {
+    return min;
+  }
+  for (let value = min; value <= max; value += 1) {
+    if (field.values.has(value)) {
+      return value;
+    }
+  }
+  return min;
+}
+
+function addMinutes(date: Date, minutes: number): Date {
+  return new Date(date.getTime() + minutes * 60_000);
+}
+
+function utcDateForZoned(timezone: string, year: number, month: number, day: number, hour: number, minute: number): Date {
+  const approxUtc = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
+  const approx = new Date(approxUtc);
+  const zoned = zonedDateParts(approx, timezone);
+  const targetNaiveUtc = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
+  const zonedNaiveUtc = Date.UTC(zoned.year, zoned.month - 1, zoned.day, zoned.hour, zoned.minute, 0, 0);
+  return new Date(approxUtc - (zonedNaiveUtc - targetNaiveUtc));
 }
 
 function weekdayToNumber(value: string): number {

--- a/src/store.ts
+++ b/src/store.ts
@@ -20,6 +20,7 @@ import {
   Inbox,
   InboxItem,
   ListInboxItemsOptions,
+  AgentTimer,
   RegisterAgentInput,
   SourceIdleState,
   Subscription,
@@ -830,6 +831,7 @@ export class AgentInboxStore {
         "delete from source_idle_states where source_id in (select distinct source_id from subscriptions where agent_id = ?)",
         [agentId],
       );
+      this.db.run("delete from timers where agent_id = ?", [agentId]);
       this.db.run("delete from subscriptions where agent_id = ?", [agentId]);
       this.db.run("delete from activation_dispatch_states where agent_id = ?", [agentId]);
       this.db.run("delete from activation_targets where agent_id = ?", [agentId]);
@@ -861,6 +863,105 @@ export class AgentInboxStore {
       [cutoffIso],
     );
     return rows.map((row) => this.mapAgent(row));
+  }
+
+  insertTimer(timer: AgentTimer): void {
+    this.db.run(
+      `
+      insert into timers (
+        schedule_id, agent_id, status, mode, at, interval_ms, cron_expr, timezone,
+        message, sender, next_fire_at, last_fired_at, created_at, updated_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      [
+        timer.scheduleId,
+        timer.agentId,
+        timer.status,
+        timer.mode,
+        timer.at ?? null,
+        timer.intervalMs ?? null,
+        timer.cronExpr ?? null,
+        timer.timezone,
+        timer.message,
+        timer.sender ?? null,
+        timer.nextFireAt ?? null,
+        timer.lastFiredAt ?? null,
+        timer.createdAt,
+        timer.updatedAt,
+      ],
+    );
+    this.persist();
+  }
+
+  getTimer(scheduleId: string): AgentTimer | null {
+    const row = this.getOne("select * from timers where schedule_id = ?", [scheduleId]);
+    return row ? this.mapTimer(row) : null;
+  }
+
+  listTimers(): AgentTimer[] {
+    const rows = this.getAll("select * from timers order by created_at asc");
+    return rows.map((row) => this.mapTimer(row));
+  }
+
+  listTimersForAgent(agentId: string): AgentTimer[] {
+    const rows = this.getAll("select * from timers where agent_id = ? order by created_at asc", [agentId]);
+    return rows.map((row) => this.mapTimer(row));
+  }
+
+  listDueTimers(cutoffIso: string): AgentTimer[] {
+    const rows = this.getAll(
+      "select * from timers where status = 'active' and next_fire_at is not null and next_fire_at <= ? order by next_fire_at asc, schedule_id asc",
+      [cutoffIso],
+    );
+    return rows.map((row) => this.mapTimer(row));
+  }
+
+  getNearestActiveTimer(): AgentTimer | null {
+    const row = this.getOne(
+      "select * from timers where status = 'active' and next_fire_at is not null order by next_fire_at asc, schedule_id asc limit 1",
+    );
+    return row ? this.mapTimer(row) : null;
+  }
+
+  updateTimer(scheduleId: string, input: Partial<Omit<AgentTimer, "scheduleId" | "agentId" | "createdAt">>): AgentTimer {
+    const current = this.getTimer(scheduleId);
+    if (!current) {
+      throw new Error(`unknown timer: ${scheduleId}`);
+    }
+    this.db.run(
+      `
+      update timers
+      set status = ?, mode = ?, at = ?, interval_ms = ?, cron_expr = ?, timezone = ?,
+          message = ?, sender = ?, next_fire_at = ?, last_fired_at = ?, updated_at = ?
+      where schedule_id = ?
+    `,
+      [
+        input.status ?? current.status,
+        input.mode ?? current.mode,
+        input.at !== undefined ? input.at ?? null : current.at ?? null,
+        input.intervalMs !== undefined ? input.intervalMs ?? null : current.intervalMs ?? null,
+        input.cronExpr !== undefined ? input.cronExpr ?? null : current.cronExpr ?? null,
+        input.timezone ?? current.timezone,
+        input.message ?? current.message,
+        input.sender !== undefined ? input.sender ?? null : current.sender ?? null,
+        input.nextFireAt !== undefined ? input.nextFireAt ?? null : current.nextFireAt ?? null,
+        input.lastFiredAt !== undefined ? input.lastFiredAt ?? null : current.lastFiredAt ?? null,
+        input.updatedAt ?? current.updatedAt,
+        scheduleId,
+      ],
+    );
+    this.persist();
+    return this.getTimer(scheduleId)!;
+  }
+
+  deleteTimer(scheduleId: string): AgentTimer | null {
+    const current = this.getTimer(scheduleId);
+    if (!current) {
+      return null;
+    }
+    this.db.run("delete from timers where schedule_id = ?", [scheduleId]);
+    this.persist();
+    return current;
   }
 
   getActivationDispatchState(agentId: string, targetId: string): ActivationDispatchState | null {
@@ -1532,6 +1633,25 @@ export class AgentInboxStore {
       pendingSummary: row.pending_summary ? String(row.pending_summary) : null,
       pendingSubscriptionIds: parseJson<string[]>(row.pending_subscription_ids_json as string),
       pendingSourceIds: parseJson<string[]>(row.pending_source_ids_json as string),
+      updatedAt: String(row.updated_at),
+    };
+  }
+
+  private mapTimer(row: Record<string, unknown>): AgentTimer {
+    return {
+      scheduleId: String(row.schedule_id),
+      agentId: String(row.agent_id),
+      status: String(row.status) as AgentTimer["status"],
+      mode: String(row.mode) as AgentTimer["mode"],
+      at: row.at ? String(row.at) : null,
+      intervalMs: row.interval_ms == null ? null : Number(row.interval_ms),
+      cronExpr: row.cron_expr ? String(row.cron_expr) : null,
+      timezone: String(row.timezone),
+      message: String(row.message),
+      sender: row.sender ? String(row.sender) : null,
+      nextFireAt: row.next_fire_at ? String(row.next_fire_at) : null,
+      lastFiredAt: row.last_fired_at ? String(row.last_fired_at) : null,
+      createdAt: String(row.created_at),
       updatedAt: String(row.updated_at),
     };
   }

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2179,6 +2179,73 @@ test("agent removal and offline GC delete agent timers", async () => {
   }
 });
 
+test("cron timers accept sunday as 7 and leap-day schedules remain active", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "timer-cron");
+
+    const sunday = service.registerTimer({
+      agentId: alpha.agentId,
+      cron: "0 8 * * 7",
+      timezone: "UTC",
+      message: "Sunday reminder",
+    });
+    assert.equal(sunday.status, "active");
+    assert.ok(sunday.nextFireAt);
+
+    const leap = service.registerTimer({
+      agentId: alpha.agentId,
+      cron: "0 0 29 2 *",
+      timezone: "UTC",
+      message: "Leap reminder",
+    });
+    assert.equal(leap.status, "active");
+    assert.ok(leap.nextFireAt);
+    assert.match(leap.nextFireAt ?? "", /^2028-02-29T00:00:00\.000Z$/);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("timer firing is idempotent per scheduled occurrence", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "timer-idempotent");
+    const timer = service.registerTimer({
+      agentId: alpha.agentId,
+      every: 60_000,
+      message: "Stand up reminder",
+    });
+    store.updateTimer(timer.scheduleId, {
+      nextFireAt: "2020-01-01T00:00:00.000Z",
+      updatedAt: nowIso(),
+    });
+
+    await (service as unknown as { fireTimer(timer: { scheduleId: string; nextFireAt?: string | null; message: string; sender?: string | null; mode: "every"; intervalMs?: number | null; cronExpr?: string | null; at?: string | null; timezone: string }, now: string): Promise<void> }).fireTimer(
+      service.getTimer(timer.scheduleId) as never,
+      "2020-01-01T00:00:00.000Z",
+    );
+    store.updateTimer(timer.scheduleId, {
+      nextFireAt: "2020-01-01T00:00:00.000Z",
+      updatedAt: nowIso(),
+    });
+    await (service as unknown as { fireTimer(timer: { scheduleId: string; nextFireAt?: string | null; message: string; sender?: string | null; mode: "every"; intervalMs?: number | null; cronExpr?: string | null; at?: string | null; timezone: string }, now: string): Promise<void> }).fireTimer(
+      service.getTimer(timer.scheduleId) as never,
+      "2020-01-01T00:00:01.000Z",
+    );
+
+    const items = service.listInboxItems(alpha.agentId, { includeAcked: true });
+    assert.equal(items.length, 1);
+    assert.equal(items[0].sourceNativeId, `${timer.scheduleId}:2020-01-01T00:00:00.000Z`);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("compact and gc remove only acked inbox items older than retention", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -162,7 +162,7 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 5);
+    assert.equal(state.appliedCount, 6);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 0);
@@ -179,7 +179,7 @@ test("store upgrades a legacy v12 database with backup and forward migration", a
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 5);
+    assert.equal(state.appliedCount, 6);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 1);
@@ -2066,6 +2066,112 @@ test("direct inbox text messages fail cleanly if the inbox item cannot be persis
     assert.equal(dispatcher.calls.length, 0);
 
     store.insertInboxItem = originalInsert;
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("at timers fire once into the inbox and then pause", async () => {
+  const dispatcher = new RecordingActivationDispatcher();
+  const { store, service, dir } = await makeService({
+    dispatcher,
+    activationWindowMs: 10,
+    activationMaxItems: 1,
+  });
+  try {
+    const alpha = await registerTmuxAgent(service, "timer-at");
+    service.addWebhookActivationTarget(alpha.agentId, {
+      url: "http://127.0.0.1:9999/timer-at",
+      activationMode: "activation_with_items",
+    });
+
+    const timer = service.registerTimer({
+      agentId: alpha.agentId,
+      at: "2020-01-01T00:00:00.000Z",
+      message: "Prepare today's plan.",
+    });
+    await (service as unknown as { syncTimers(): Promise<void> }).syncTimers();
+
+    const fired = service.listInboxItems(alpha.agentId, { includeAcked: true });
+    assert.equal(fired.length, 1);
+    assert.deepEqual(fired[0].rawPayload, {
+      type: "timer_fired",
+      scheduleId: timer.scheduleId,
+      message: "Prepare today's plan.",
+      sender: "timer",
+    });
+    assert.equal(service.getTimer(timer.scheduleId).status, "paused");
+    assert.equal(service.getTimer(timer.scheduleId).nextFireAt, null);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("every timers advance nextFireAt after firing", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "timer-every");
+    const timer = service.registerTimer({
+      agentId: alpha.agentId,
+      every: 60_000,
+      message: "Stand up reminder",
+    });
+    store.updateTimer(timer.scheduleId, {
+      nextFireAt: "2020-01-01T00:00:00.000Z",
+      updatedAt: nowIso(),
+    });
+
+    await (service as unknown as { syncTimers(): Promise<void> }).syncTimers();
+
+    const updated = service.getTimer(timer.scheduleId);
+    assert.equal(updated.status, "active");
+    assert.ok(updated.lastFiredAt);
+    assert.ok(updated.nextFireAt);
+    assert.notEqual(updated.nextFireAt, "2020-01-01T00:00:00.000Z");
+    assert.equal(service.listInboxItems(alpha.agentId, { includeAcked: true }).length, 1);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("agent removal and offline GC delete agent timers", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const first = await registerTmuxAgent(service, "timer-remove");
+    const second = await registerTmuxAgent(service, "timer-gc");
+
+    const firstTimer = service.registerTimer({
+      agentId: first.agentId,
+      every: 60_000,
+      message: "First timer",
+    });
+    const secondTimer = service.registerTimer({
+      agentId: second.agentId,
+      cron: "0 8 * * *",
+      timezone: "Asia/Shanghai",
+      message: "Second timer",
+    });
+
+    service.removeAgent(first.agentId);
+    assert.equal(store.getTimer(firstTimer.scheduleId), null);
+    assert.ok(store.getTimer(secondTimer.scheduleId));
+
+    store.updateAgent(second.agentId, {
+      status: "offline",
+      offlineSince: "2020-01-01T00:00:00.000Z",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-timer-gc",
+      updatedAt: nowIso(),
+      lastSeenAt: "2020-01-01T00:00:00.000Z",
+    });
+    service.gc();
+    assert.equal(store.getTimer(secondTimer.scheduleId), null);
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -814,6 +814,50 @@ test("cli inbox send writes a direct text message into the target inbox", () => 
   }
 });
 
+test("cli timer add and list manage agent-bound reminder timers", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-timer-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%962",
+    CODEX_THREAD_ID: "thread-timer-cli",
+  };
+
+  try {
+    const register = runCli(["agent", "register"], env);
+    assert.equal(register.status, 0, register.stderr);
+    const registered = JSON.parse(register.stdout) as { agent: { agentId: string } };
+
+    const add = runCli([
+      "timer",
+      "add",
+      "--agent-id",
+      registered.agent.agentId,
+      "--every",
+      "60m",
+      "--message",
+      "Daily review reminder",
+    ], env);
+    assert.equal(add.status, 0, add.stderr);
+    const timer = JSON.parse(add.stdout) as { scheduleId: string; mode: string; intervalMs: number };
+    assert.equal(timer.mode, "every");
+    assert.equal(timer.intervalMs, 3_600_000);
+
+    const listed = runCli(["timer", "list", "--agent-id", registered.agent.agentId], env);
+    assert.equal(listed.status, 0, listed.stderr);
+    const payload = JSON.parse(listed.stdout) as { timers: Array<{ scheduleId: string; agentId: string }> };
+    assert.equal(payload.timers.length, 1);
+    assert.equal(payload.timers[0].scheduleId, timer.scheduleId);
+    assert.equal(payload.timers[0].agentId, registered.agent.agentId);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli subscription add accepts filter-file and filter-stdin and echoes normalized filter", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-filter-"));
   const env = {
@@ -1821,6 +1865,104 @@ test("control plane accepts direct inbox text messages and rejects blank payload
   } finally {
     await adapters.stop();
     webhookServer.close();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane exposes timer lifecycle endpoints and timer firing writes inbox items", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-timer-http-home-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters, undefined, undefined, {
+    windowMs: 10,
+    maxItems: 1,
+  }, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+
+      const agentResponse = await client.request<{ agent: { agentId: string } }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-timer-http",
+        tmuxPaneId: "%165",
+        notifyLeaseMs: 200,
+      });
+      assert.equal(agentResponse.statusCode, 200);
+      const agentId = agentResponse.data.agent.agentId;
+
+      const addResponse = await client.request<{ scheduleId: string; mode: string; status: string }>(
+        "/timers",
+        {
+          agentId,
+          at: "2020-01-01T00:00:00.000Z",
+          message: "Prepare today's task plan.",
+        },
+      );
+      assert.equal(addResponse.statusCode, 200);
+      assert.equal(addResponse.data.mode, "at");
+      const scheduleId = addResponse.data.scheduleId;
+
+      const listResponse = await client.request<{ timers: Array<{ scheduleId: string }> }>(
+        `/timers?agent_id=${encodeURIComponent(agentId)}`,
+        undefined,
+        "GET",
+      );
+      assert.equal(listResponse.statusCode, 200);
+      assert.equal(listResponse.data.timers.length, 1);
+
+      await (service as unknown as { syncTimers(): Promise<void> }).syncTimers();
+      const inboxResponse = await client.request<{ items: InboxItem[] }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/items?include_acked=true`,
+        undefined,
+        "GET",
+      );
+      assert.equal(inboxResponse.statusCode, 200);
+      assert.equal(inboxResponse.data.items.length, 1);
+      assert.deepEqual(inboxResponse.data.items[0].rawPayload, {
+        type: "timer_fired",
+        scheduleId,
+        message: "Prepare today's task plan.",
+        sender: "timer",
+      });
+
+      const resumeResponse = await client.request<{ error: string }>(
+        `/timers/${encodeURIComponent(scheduleId)}/resume`,
+        {},
+      );
+      assert.equal(resumeResponse.statusCode, 400);
+
+      const removeResponse = await client.request<{ removed: boolean; scheduleId: string }>(
+        `/timers/${encodeURIComponent(scheduleId)}`,
+        undefined,
+        "DELETE",
+      );
+      assert.equal(removeResponse.statusCode, 200);
+      assert.equal(removeResponse.data.removed, true);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
     await service.stop();
     store.close();
     fs.rmSync(homeDir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #62

## Summary
- add agent-bound reminder timers with at/every/cron modes and persisted next-fire scheduling
- fire timers as normal inbox items plus normal activation using the direct inbox ingress path
- expose timer CRUD through HTTP and CLI, and clean timers up when their agent is removed or GCd