### PR TITLE
feat: Add Claude Code session liveness and busy-state probe (#83)

### DIFF
--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -118,7 +118,14 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
-    return target.backend === "iterm2" && typeof target.itermSessionId === "string" && target.itermSessionId.length > 0;
+    // Only support iTerm2 targets that are NOT Claude Code
+    // Claude Code targets are handled by ClaudeCodeTerminalStateProbe
+    return (
+      target.backend === "iterm2" &&
+      target.runtimeKind !== "claude_code" &&
+      typeof target.itermSessionId === "string" &&
+      target.itermSessionId.length > 0
+    );
   }
 
   async check(target: TerminalActivationTarget): Promise<{
@@ -231,6 +238,7 @@ async function sleep(ms: number): Promise<void> {
 export class ClaudeCodeRuntimePresenceProbe implements RuntimePresenceProbe {
   constructor(
     private readonly killFn: (pid: number, signal: number) => void = (pid, signal) => process.kill(pid, signal),
+    private readonly sessionFileReader?: (pid: number) => Promise<{ sessionId: string; cwd: string } | null>,
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -247,7 +255,7 @@ export class ClaudeCodeRuntimePresenceProbe implements RuntimePresenceProbe {
       this.killFn(target.runtimePid!, 0);
 
       // 2. Verify session file exists and is valid
-      const sessionInfo = await this.findSessionByPid(target.runtimePid!);
+      const sessionInfo = await (this.sessionFileReader ?? this.defaultSessionFileReader)(target.runtimePid!);
       if (!sessionInfo) {
         return "gone"; // Process exists but session file is invalid/missing
       }
@@ -267,10 +275,10 @@ export class ClaudeCodeRuntimePresenceProbe implements RuntimePresenceProbe {
     }
   }
 
-  private async findSessionByPid(pid: number): Promise<{
+  private readonly defaultSessionFileReader = async (pid: number): Promise<{
     sessionId: string;
     cwd: string;
-  } | null> {
+  } | null> => {
     const sessionFile = path.join(os.homedir(), ".claude", "sessions", `${pid}.json`);
     try {
       const content = await fs.promises.readFile(sessionFile, "utf8");
@@ -287,10 +295,16 @@ export class ClaudeCodeRuntimePresenceProbe implements RuntimePresenceProbe {
     } catch {
       return null;
     }
-  }
+  };
 }
 
 export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
+  constructor(
+    private readonly sessionFileReader?: (pid: number) => Promise<{ sessionId: string; cwd: string } | null>,
+    private readonly logFileStatReader?: (path: string) => Promise<{ mtimeMs: number } | null>,
+    private readonly sleepFn: (ms: number) => Promise<void> = sleep,
+  ) {}
+
   supports(target: TerminalActivationTarget): boolean {
     return target.runtimeKind === "claude_code";
   }
@@ -305,9 +319,10 @@ export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
 
     try {
       // 1. Read session file to get cwd
-      const sessionFile = path.join(os.homedir(), ".claude", "sessions", `${target.runtimePid}.json`);
-      const sessionContent = await fs.promises.readFile(sessionFile, "utf8");
-      const sessionData = JSON.parse(sessionContent);
+      const sessionData = await (this.sessionFileReader ?? this.defaultSessionFileReader)(target.runtimePid);
+      if (!sessionData) {
+        return { presence: "gone", busy: "unknown" };
+      }
 
       // 2. Verify session ID matches
       if (sessionData.sessionId !== target.runtimeSessionId) {
@@ -334,10 +349,45 @@ export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
     }
   }
 
+  private readonly defaultSessionFileReader = async (pid: number): Promise<{
+    sessionId: string;
+    cwd: string;
+  } | null> => {
+    const sessionFile = path.join(os.homedir(), ".claude", "sessions", `${pid}.json`);
+    try {
+      const content = await fs.promises.readFile(sessionFile, "utf8");
+      const session = JSON.parse(content);
+
+      if (!session.sessionId || typeof session.sessionId !== "string") {
+        return null;
+      }
+
+      return {
+        sessionId: session.sessionId,
+        cwd: session.cwd,
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  private readonly defaultLogFileStatReader = async (filePath: string): Promise<{ mtimeMs: number } | null> => {
+    try {
+      const stats = await fs.promises.stat(filePath);
+      return { mtimeMs: stats.mtimeMs };
+    } catch {
+      return null;
+    }
+  };
+
   private async checkLogFileActivity(logFile: string): Promise<TerminalBusyStatus> {
     try {
-      const stats = await fs.promises.stat(logFile);
-      const timeSinceLastActivity = Date.now() - stats.mtimeMs;
+      const statResult = await (this.logFileStatReader ?? this.defaultLogFileStatReader)(logFile);
+      if (!statResult) {
+        return "unknown";
+      }
+
+      const timeSinceLastActivity = Date.now() - statResult.mtimeMs;
 
       // Activity within last 5 seconds = busy
       if (timeSinceLastActivity < 5000) {
@@ -345,11 +395,15 @@ export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
       }
 
       // Secondary sampling to confirm (avoid false positives)
-      await sleep(250);
-      const stats2 = await fs.promises.stat(logFile);
-      const timeSinceLastActivity2 = Date.now() - stats2.mtimeMs;
+      await this.sleepFn(250);
+      const statResult2 = await (this.logFileStatReader ?? this.defaultLogFileStatReader)(logFile);
+      if (!statResult2) {
+        return "unknown";
+      }
 
-      if (stats2.mtimeMs > stats.mtimeMs && timeSinceLastActivity2 < 5000) {
+      const timeSinceLastActivity2 = Date.now() - statResult2.mtimeMs;
+
+      if (statResult2.mtimeMs > statResult.mtimeMs && timeSinceLastActivity2 < 5000) {
         return "busy";
       }
 
@@ -365,8 +419,17 @@ export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
     try {
       const it2api = resolveIterm2ApiPath();
       const result = await execFileAsync(it2api, ["list-sessions"]);
-      const sessions = result.stdout.split(/\r?\n/).map((line: string) => line.trim()).filter((line: string) => line.length > 0);
-      return sessions.includes(itermSessionId) ? "available" : "gone";
+      const lines = result.stdout.split(/\r?\n/).map((line: string) => line.trim()).filter((line: string) => line.length > 0);
+
+      // Parse session IDs from iTerm2 output format: "Session \"...\" id=<UUID> ..."
+      const sessionIds = lines
+        .map((line: string) => {
+          const match = line.match(/id=([A-F0-9-]+)/);
+          return match ? match[1] : null;
+        })
+        .filter((id: string | null): id is string => id !== null);
+
+      return sessionIds.includes(itermSessionId) ? "available" : "gone";
     } catch {
       return "unknown";
     }

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -1,6 +1,8 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import { TerminalActivationTarget } from "./model";
 
 const execFileAsync = promisify(execFile);
@@ -47,9 +49,11 @@ export class DefaultActivationGate implements ActivationGate {
   constructor(
     private readonly runtimeProbes: RuntimePresenceProbe[] = [
       new CodexRuntimePresenceProbe(),
+      new ClaudeCodeRuntimePresenceProbe(),
     ],
     private readonly terminalProbes: TerminalStateProbe[] = [
       new Iterm2TerminalStateProbe(),
+      new ClaudeCodeTerminalStateProbe(),
     ],
   ) {}
 
@@ -222,4 +226,149 @@ function resolveIterm2ApiPath(override?: string): string {
 
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class ClaudeCodeRuntimePresenceProbe implements RuntimePresenceProbe {
+  constructor(
+    private readonly killFn: (pid: number, signal: number) => void = (pid, signal) => process.kill(pid, signal),
+  ) {}
+
+  supports(target: TerminalActivationTarget): boolean {
+    return target.runtimeKind === "claude_code" && Number.isInteger(target.runtimePid);
+  }
+
+  async check(target: TerminalActivationTarget): Promise<RuntimePresenceStatus> {
+    if (!Number.isInteger(target.runtimePid)) {
+      return "unknown";
+    }
+
+    try {
+      // 1. Check if process exists
+      this.killFn(target.runtimePid!, 0);
+
+      // 2. Verify session file exists and is valid
+      const sessionInfo = await this.findSessionByPid(target.runtimePid!);
+      if (!sessionInfo) {
+        return "gone"; // Process exists but session file is invalid/missing
+      }
+
+      // 3. Verify session ID matches (prevent PID reuse)
+      if (target.runtimeSessionId && sessionInfo.sessionId !== target.runtimeSessionId) {
+        return "gone";
+      }
+
+      return "alive";
+    } catch (error) {
+      const code = error instanceof Error && "code" in error ? String((error as NodeJS.ErrnoException).code ?? "") : "";
+      if (code === "ESRCH") {
+        return "gone"; // Process doesn't exist
+      }
+      return "unknown";
+    }
+  }
+
+  private async findSessionByPid(pid: number): Promise<{
+    sessionId: string;
+    cwd: string;
+  } | null> {
+    const sessionFile = path.join(os.homedir(), ".claude", "sessions", `${pid}.json`);
+    try {
+      const content = await fs.promises.readFile(sessionFile, "utf8");
+      const session = JSON.parse(content);
+
+      if (!session.sessionId || typeof session.sessionId !== "string") {
+        return null;
+      }
+
+      return {
+        sessionId: session.sessionId,
+        cwd: session.cwd,
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
+  supports(target: TerminalActivationTarget): boolean {
+    return target.runtimeKind === "claude_code";
+  }
+
+  async check(target: TerminalActivationTarget): Promise<{
+    presence: TerminalPresenceStatus;
+    busy: TerminalBusyStatus;
+  }> {
+    if (!target.runtimePid || !target.runtimeSessionId) {
+      return { presence: "unknown", busy: "unknown" };
+    }
+
+    try {
+      // 1. Read session file to get cwd
+      const sessionFile = path.join(os.homedir(), ".claude", "sessions", `${target.runtimePid}.json`);
+      const sessionContent = await fs.promises.readFile(sessionFile, "utf8");
+      const sessionData = JSON.parse(sessionContent);
+
+      // 2. Verify session ID matches
+      if (sessionData.sessionId !== target.runtimeSessionId) {
+        return { presence: "gone", busy: "unknown" };
+      }
+
+      // 3. Construct log file path using Claude Code's encoding rules
+      const sanitizedProjectPath = sessionData.cwd.replace(/[^a-zA-Z0-9]/g, '-');
+      const logFile = path.join(os.homedir(), ".claude", "projects", sanitizedProjectPath, `${target.runtimeSessionId}.jsonl`);
+
+      // 4. Check log file activity
+      const busy = await this.checkLogFileActivity(logFile);
+
+      // 5. Check iTerm2 session presence if available
+      const presence = target.backend === "iterm2" && target.itermSessionId
+        ? await this.checkIterm2Presence(target.itermSessionId)
+        : "available";
+
+      return { presence, busy };
+
+    } catch (error) {
+      console.warn('Claude Code state check failed:', error);
+      return { presence: "unknown", busy: "unknown" };
+    }
+  }
+
+  private async checkLogFileActivity(logFile: string): Promise<TerminalBusyStatus> {
+    try {
+      const stats = await fs.promises.stat(logFile);
+      const timeSinceLastActivity = Date.now() - stats.mtimeMs;
+
+      // Activity within last 5 seconds = busy
+      if (timeSinceLastActivity < 5000) {
+        return "busy";
+      }
+
+      // Secondary sampling to confirm (avoid false positives)
+      await sleep(250);
+      const stats2 = await fs.promises.stat(logFile);
+      const timeSinceLastActivity2 = Date.now() - stats2.mtimeMs;
+
+      if (stats2.mtimeMs > stats.mtimeMs && timeSinceLastActivity2 < 5000) {
+        return "busy";
+      }
+
+      // Activity within last 30 seconds = idle but recently active
+      return timeSinceLastActivity2 < 30000 ? "idle" : "unknown";
+
+    } catch {
+      return "unknown";
+    }
+  }
+
+  private async checkIterm2Presence(itermSessionId: string): Promise<TerminalPresenceStatus> {
+    try {
+      const it2api = resolveIterm2ApiPath();
+      const result = await execFileAsync(it2api, ["list-sessions"]);
+      const sessions = result.stdout.split(/\r?\n/).map((line: string) => line.trim()).filter((line: string) => line.length > 0);
+      return sessions.includes(itermSessionId) ? "available" : "gone";
+    } catch {
+      return "unknown";
+    }
+  }
 }

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -4,6 +4,8 @@ import {
   CodexRuntimePresenceProbe,
   DefaultActivationGate,
   Iterm2TerminalStateProbe,
+  ClaudeCodeRuntimePresenceProbe,
+  ClaudeCodeTerminalStateProbe,
 } from "../src/runtime_gate";
 import { TerminalActivationTarget } from "../src/model";
 
@@ -188,5 +190,73 @@ test("DefaultActivationGate defers when the terminal probe reports busy", async 
   assert.deepEqual(await gate.evaluate(makeItermTarget()), {
     outcome: "defer",
     reason: "terminal_busy",
+  });
+});
+
+// Claude Code Runtime Presence Probe Tests
+function makeClaudeCodeTarget(): TerminalActivationTarget {
+  return {
+    targetId: "tgt_claude",
+    agentId: "agent_claude_demo",
+    kind: "terminal",
+    status: "active",
+    offlineSince: null,
+    consecutiveFailures: 0,
+    lastDeliveredAt: null,
+    lastError: null,
+    mode: "agent_prompt",
+    notifyLeaseMs: 100,
+    runtimeKind: "claude_code",
+    runtimeSessionId: "f6037b9e-b970-475f-b339-5c5b286aceac",
+    runtimePid: 48663,
+    backend: "iterm2",
+    tmuxPaneId: null,
+    tty: null,
+    termProgram: "iTerm.app",
+    itermSessionId: "E551BC86-9787-4C74-B297-F0A3EC3C9F46",
+    createdAt: "2026-04-15T00:00:00.000Z",
+    updatedAt: "2026-04-15T00:00:00.000Z",
+    lastSeenAt: "2026-04-15T00:00:00.000Z",
+  };
+}
+
+test("ClaudeCodeRuntimePresenceProbe supports claude_code runtime with PID", () => {
+  const probe = new ClaudeCodeRuntimePresenceProbe();
+  assert.equal(probe.supports(makeClaudeCodeTarget()), true);
+});
+
+test("ClaudeCodeRuntimePresenceProbe does not support targets without PID", () => {
+  const probe = new ClaudeCodeRuntimePresenceProbe();
+  const target = makeClaudeCodeTarget();
+  target.runtimePid = null;
+  assert.equal(probe.supports(target), false);
+});
+
+test("ClaudeCodeRuntimePresenceProbe reports alive for live process with valid session", async () => {
+  const probe = new ClaudeCodeRuntimePresenceProbe(() => {});
+  assert.equal(await probe.check(makeClaudeCodeTarget()), "alive");
+});
+
+test("ClaudeCodeRuntimePresenceProbe reports gone for ESRCH", async () => {
+  const probe = new ClaudeCodeRuntimePresenceProbe(() => {
+    const error = new Error("missing") as NodeJS.ErrnoException;
+    error.code = "ESRCH";
+    throw error;
+  });
+  assert.equal(await probe.check(makeClaudeCodeTarget()), "gone");
+});
+
+test("ClaudeCodeTerminalStateProbe supports claude_code runtime", () => {
+  const probe = new ClaudeCodeTerminalStateProbe();
+  assert.equal(probe.supports(makeClaudeCodeTarget()), true);
+});
+
+test("ClaudeCodeTerminalStateProbe returns unknown for missing PID/sessionId", async () => {
+  const probe = new ClaudeCodeTerminalStateProbe();
+  const target = makeClaudeCodeTarget();
+  target.runtimePid = null;
+  assert.deepEqual(await probe.check(target), {
+    presence: "unknown",
+    busy: "unknown",
   });
 });

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -233,7 +233,11 @@ test("ClaudeCodeRuntimePresenceProbe does not support targets without PID", () =
 });
 
 test("ClaudeCodeRuntimePresenceProbe reports alive for live process with valid session", async () => {
-  const probe = new ClaudeCodeRuntimePresenceProbe(() => {});
+  const mockSessionReader = async () => ({
+    sessionId: "f6037b9e-b970-475f-b339-5c5b286aceac",
+    cwd: "/Users/jolestar/opensource/src/github.com/holon-run/agentinbox",
+  });
+  const probe = new ClaudeCodeRuntimePresenceProbe(() => {}, mockSessionReader);
   assert.equal(await probe.check(makeClaudeCodeTarget()), "alive");
 });
 
@@ -259,4 +263,59 @@ test("ClaudeCodeTerminalStateProbe returns unknown for missing PID/sessionId", a
     presence: "unknown",
     busy: "unknown",
   });
+});
+
+test("ClaudeCodeRuntimePresenceProbe reports gone when session reader returns null", async () => {
+  const mockSessionReader = async () => null;
+  const probe = new ClaudeCodeRuntimePresenceProbe(() => {}, mockSessionReader);
+  assert.equal(await probe.check(makeClaudeCodeTarget()), "gone");
+});
+
+test("ClaudeCodeRuntimePresenceProbe reports gone when session ID mismatches", async () => {
+  const mockSessionReader = async () => ({
+    sessionId: "different-session-id",
+    cwd: "/Users/jolestar/opensource/src/github.com/holon-run/agentinbox",
+  });
+  const probe = new ClaudeCodeRuntimePresenceProbe(() => {}, mockSessionReader);
+  assert.equal(await probe.check(makeClaudeCodeTarget()), "gone");
+});
+
+test("ClaudeCodeTerminalStateProbe detects busy state from recent log activity", async () => {
+  const now = Date.now();
+  const mockSessionReader = async () => ({
+    sessionId: "f6037b9e-b970-475f-b339-5c5b286aceac",
+    cwd: "/Users/jolestar/opensource/src/github.com/holon-run/agentinbox",
+  });
+  const mockStatReader = async () => ({ mtimeMs: now - 1000 }); // 1 second ago
+  const mockSleep = async () => {};
+  const probe = new ClaudeCodeTerminalStateProbe(mockSessionReader, mockStatReader, mockSleep);
+
+  const result = await probe.check(makeClaudeCodeTarget());
+  assert.equal(result.busy, "busy");
+});
+
+test("ClaudeCodeTerminalStateProbe reports idle for older log activity", async () => {
+  const now = Date.now();
+  const mockSessionReader = async () => ({
+    sessionId: "f6037b9e-b970-475f-b339-5c5b286aceac",
+    cwd: "/Users/jolestar/opensource/src/github.com/holon-run/agentinbox",
+  });
+  const mockStatReader = async () => ({ mtimeMs: now - 10000 }); // 10 seconds ago
+  const mockSleep = async () => {};
+  const probe = new ClaudeCodeTerminalStateProbe(mockSessionReader, mockStatReader, mockSleep);
+
+  const result = await probe.check(makeClaudeCodeTarget());
+  assert.equal(result.busy, "idle");
+});
+
+test("Iterm2TerminalStateProbe does not support claude_code runtime", () => {
+  const probe = new Iterm2TerminalStateProbe();
+  const claudeTarget = makeClaudeCodeTarget();
+  assert.equal(probe.supports(claudeTarget), false);
+});
+
+test("Iterm2TerminalStateProbe supports non-claude iTerm2 targets", () => {
+  const probe = new Iterm2TerminalStateProbe();
+  const codexTarget = makeItermTarget(); // This has runtimeKind: "codex"
+  assert.equal(probe.supports(codexTarget), true);
 });


### PR DESCRIPTION
## Summary

Implements Claude Code session probing for issue #83, building on the runtime gating abstraction from issue #79.

## What this PR does

- **ClaudeCodeRuntimePresenceProbe**: Detects Claude Code session liveness
  - Uses `process.kill(pid, 0)` for process existence check
  - Validates session file at `~/.claude/sessions/{pid}.json`
  - Prevents PID reuse false positives via session ID matching

- **ClaudeCodeTerminalStateProbe**: Detects Claude Code busy state
  - Monitors session log file activity at `~/.claude/projects/{sanitized-cwd}/{sessionId}.jsonl`
  - Uses Claude Code's actual path encoding: `cwd.replace(/[^a-zA-Z0-9]/g, '-')`
  - Implements secondary sampling (250ms delay) to avoid false positives
  - Falls back to iTerm2 presence check when available

- **Integration**: Registers both probes in `DefaultActivationGate`

## Implementation details

Based on analysis of Claude Code source code at:
- `src/utils/sessionStorage.ts`: Session file structure
- `src/utils/sessionStoragePortable.ts`: Path encoding via `sanitizePath()`

### Path construction
```typescript
// Session file
~/.claude/sessions/{pid}.json

// Log file (using Claude Code's encoding)
const sanitizedProjectPath = cwd.replace(/[^a-zA-Z0-9]/g, '-');
~/.claude/projects/${sanitizedProjectPath}/${sessionId}.jsonl
```

### Busy detection logic
- `< 5s` since last log write = busy
- Secondary sampling confirmation to avoid race conditions
- `< 30s` since last activity = idle (recently finished)
- Otherwise = unknown

## Test plan

- [x] TypeScript compilation passes
- [x] Unit tests for probe support conditions
- [x] Unit tests for alive/gone/unknown status reporting
- [x] Unit tests for error handling (ESRCH, missing files)
- [ ] Manual testing with active Claude Code session
- [ ] Verify busy state detection during tool execution

## Acceptance criteria (from #83)

- [x] AgentInbox can distinguish a terminated Claude Code session from a merely open terminal window
- [x] AgentInbox can return `busy` when Claude Code is actively engaged
- [x] Unsupported/weak-signal environments degrade to `unknown` without breaking existing delivery
- [x] Implementation plugs into the same dispatch gating model as #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)