### PR TITLE
feat: add tmux input-aware terminal gating

### DIFF
--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -216,7 +216,7 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
-    return target.backend === "tmux" && typeof target.tmuxPaneId === "string" && target.tmuxPaneId.length > 0;
+    return target.backend === "tmux" && typeof target.tmuxPaneId === "string" && target.tmuxPaneId.trim().length > 0;
   }
 
   async check(target: TerminalActivationTarget): Promise<{
@@ -229,8 +229,11 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
     }
 
     const paneState = await this.readPaneState(paneId);
-    if (!paneState) {
+    if (paneState === "missing") {
       return { presence: "gone", busy: "unknown" };
+    }
+    if (paneState === "unknown") {
+      return { presence: "unknown", busy: "unknown" };
     }
     if (paneState.dead) {
       return { presence: "gone", busy: "unknown" };
@@ -258,12 +261,12 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
     return { presence: "available", busy: "unknown" };
   }
 
-  private async readPaneState(paneId: string): Promise<{ active: boolean; dead: boolean } | null> {
+  private async readPaneState(paneId: string): Promise<{ active: boolean; dead: boolean } | "missing" | "unknown"> {
     try {
       const result = await this.execAsync("tmux", ["display-message", "-p", "-t", paneId, "#{pane_active} #{pane_dead}"]);
       const [active, dead] = result.stdout.trim().split(/\s+/, 2);
       if (!active || !dead) {
-        return { active: false, dead: false };
+        return "unknown";
       }
       return {
         active: active === "1",
@@ -271,9 +274,9 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
       };
     } catch (error) {
       if (isTmuxMissingPaneError(error)) {
-        return null;
+        return "missing";
       }
-      return { active: false, dead: false };
+      return "unknown";
     }
   }
 

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -7,10 +7,15 @@ import { TerminalActivationTarget } from "./model";
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_ITERM2_SAMPLE_DELAY_MS = 250;
+const DEFAULT_TMUX_SAMPLE_DELAY_MS = 250;
 const ACTIVE_BUFFER_MARKERS = [
   "esc to interrupt",
   "Working (",
   "⠼ ",
+];
+const TYPING_PROMPT_PREFIXES = [
+  "› ",
+  "> ",
 ];
 
 type ExecFileAsyncLike = (
@@ -54,6 +59,7 @@ export class DefaultActivationGate implements ActivationGate {
     private readonly terminalProbes: TerminalStateProbe[] = [
       new Iterm2TerminalStateProbe(),
       new ClaudeCodeTerminalStateProbe(),
+      new TmuxTerminalStateProbe(),
     ],
   ) {}
 
@@ -200,8 +206,106 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
   }
 }
 
+export class TmuxTerminalStateProbe implements TerminalStateProbe {
+  constructor(
+    private readonly execAsync: ExecFileAsyncLike = execFileAsync,
+    private readonly options: {
+      sampleDelayMs?: number;
+      sleep?: (ms: number) => Promise<void>;
+    } = {},
+  ) {}
+
+  supports(target: TerminalActivationTarget): boolean {
+    return target.backend === "tmux" && typeof target.tmuxPaneId === "string" && target.tmuxPaneId.length > 0;
+  }
+
+  async check(target: TerminalActivationTarget): Promise<{
+    presence: TerminalPresenceStatus;
+    busy: TerminalBusyStatus;
+  }> {
+    const paneId = target.tmuxPaneId?.trim();
+    if (!paneId) {
+      return { presence: "unknown", busy: "unknown" };
+    }
+
+    const paneState = await this.readPaneState(paneId);
+    if (!paneState) {
+      return { presence: "gone", busy: "unknown" };
+    }
+    if (paneState.dead) {
+      return { presence: "gone", busy: "unknown" };
+    }
+
+    const first = await this.readBufferTail(paneId);
+    if (!first) {
+      return { presence: "available", busy: "unknown" };
+    }
+    await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? DEFAULT_TMUX_SAMPLE_DELAY_MS);
+    const second = await this.readBufferTail(paneId);
+    if (!second) {
+      return { presence: "available", busy: "unknown" };
+    }
+
+    if (first !== second) {
+      return { presence: "available", busy: "busy" };
+    }
+    if (containsActiveBufferMarker(second)) {
+      return { presence: "available", busy: "busy" };
+    }
+    if (paneState.active && hasVisibleTypingPrompt(second)) {
+      return { presence: "available", busy: "busy" };
+    }
+    return { presence: "available", busy: "unknown" };
+  }
+
+  private async readPaneState(paneId: string): Promise<{ active: boolean; dead: boolean } | null> {
+    try {
+      const result = await this.execAsync("tmux", ["display-message", "-p", "-t", paneId, "#{pane_active} #{pane_dead}"]);
+      const [active, dead] = result.stdout.trim().split(/\s+/, 2);
+      if (!active || !dead) {
+        return { active: false, dead: false };
+      }
+      return {
+        active: active === "1",
+        dead: dead === "1",
+      };
+    } catch (error) {
+      if (isTmuxMissingPaneError(error)) {
+        return null;
+      }
+      return { active: false, dead: false };
+    }
+  }
+
+  private async readBufferTail(paneId: string): Promise<string | null> {
+    try {
+      const result = await this.execAsync("tmux", ["capture-pane", "-p", "-t", paneId, "-S", "-20"]);
+      return normalizeBufferTail(result.stdout);
+    } catch {
+      return null;
+    }
+  }
+}
+
 function containsActiveBufferMarker(bufferTail: string): boolean {
   return ACTIVE_BUFFER_MARKERS.some((marker) => bufferTail.includes(marker));
+}
+
+function hasVisibleTypingPrompt(bufferTail: string): boolean {
+  const lines = bufferTail
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+  const lastLine = lines.at(-1);
+  if (!lastLine) {
+    return false;
+  }
+  for (const prefix of TYPING_PROMPT_PREFIXES) {
+    if (lastLine.startsWith(prefix) && lastLine.slice(prefix.length).trim().length > 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function normalizeBufferTail(buffer: string): string | null {
@@ -233,6 +337,14 @@ function resolveIterm2ApiPath(override?: string): string {
 
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTmuxMissingPaneError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const candidate = `${error.message} ${"stderr" in error ? String((error as { stderr?: unknown }).stderr ?? "") : ""}`;
+  return candidate.includes("can't find pane");
 }
 
 export class ClaudeCodeRuntimePresenceProbe implements RuntimePresenceProbe {

--- a/src/service.ts
+++ b/src/service.ts
@@ -176,6 +176,7 @@ export class AgentInboxService {
       this.timerSyncTimeout = null;
     }
     await this.flushAllPendingNotifications();
+    await this.awaitInFlightNotificationBuffers();
   }
 
   async registerSource(input: RegisterSourceInput): Promise<SubscriptionSource> {
@@ -1565,6 +1566,16 @@ export class AgentInboxService {
     }
   }
 
+  private async awaitInFlightNotificationBuffers(): Promise<void> {
+    while (true) {
+      const activeBuffers = Array.from(this.notificationBuffers.values());
+      if (activeBuffers.every((buffer) => !buffer.inFlight)) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
   private async flushNotificationBuffer(key: string): Promise<void> {
     const buffer = this.notificationBuffers.get(key);
     if (!buffer || buffer.inFlight || buffer.pending.length === 0) {
@@ -1609,9 +1620,11 @@ export class AgentInboxService {
       const hasPendingDuringFlight = buffer.pending.length > 0;
       buffer.inFlight = false;
       if (hasPendingDuringFlight) {
-        buffer.timer = setTimeout(() => {
-          void this.flushNotificationBuffer(key);
-        }, this.activationWindowMs);
+        if (!this.stopping) {
+          buffer.timer = setTimeout(() => {
+            void this.flushNotificationBuffer(key);
+          }, this.activationWindowMs);
+        }
         return;
       }
       this.notificationBuffers.delete(key);

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2333,6 +2333,7 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
     terminalDispatcher,
     activationWindowMs: 20,
     activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
   });
   try {
     const registered = service.registerAgent({
@@ -2410,6 +2411,7 @@ test("terminal target goes offline when dispatch fails and probe confirms disapp
   const { store, service, dir } = await makeService({
     terminalDispatcher,
     activationWindowMs: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
   });
   try {
     const registered = service.registerAgent({

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -238,6 +238,29 @@ test("TmuxTerminalStateProbe reports gone when the pane is absent", async () => 
   });
 });
 
+test("TmuxTerminalStateProbe trims pane ids in supports()", () => {
+  const probe = new TmuxTerminalStateProbe();
+  const target = makeTmuxTarget();
+  target.tmuxPaneId = "   ";
+  assert.equal(probe.supports(target), false);
+});
+
+test("TmuxTerminalStateProbe reports unknown when tmux pane lookup fails for non-missing reasons", async () => {
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      throw new Error("failed to connect to server");
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "unknown",
+    busy: "unknown",
+  });
+});
+
 test("TmuxTerminalStateProbe reports busy when the buffer tail changes", async () => {
   const buffers = ["first snapshot", "second snapshot"];
   const probe = new TmuxTerminalStateProbe(async (_file, args) => {

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -6,6 +6,7 @@ import {
   Iterm2TerminalStateProbe,
   ClaudeCodeRuntimePresenceProbe,
   ClaudeCodeTerminalStateProbe,
+  TmuxTerminalStateProbe,
 } from "../src/runtime_gate";
 import { TerminalActivationTarget } from "../src/model";
 
@@ -29,6 +30,32 @@ function makeItermTarget(): TerminalActivationTarget {
     tty: null,
     termProgram: "iTerm.app",
     itermSessionId: "SESSION-1",
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    lastSeenAt: "2026-04-01T00:00:00.000Z",
+  };
+}
+
+function makeTmuxTarget(): TerminalActivationTarget {
+  return {
+    targetId: "tgt_tmux",
+    agentId: "agent_codex_tmux",
+    kind: "terminal",
+    status: "active",
+    offlineSince: null,
+    consecutiveFailures: 0,
+    lastDeliveredAt: null,
+    lastError: null,
+    mode: "agent_prompt",
+    notifyLeaseMs: 100,
+    runtimeKind: "codex",
+    runtimeSessionId: "thread-tmux-1",
+    runtimePid: 1234,
+    backend: "tmux",
+    tmuxPaneId: "%2",
+    tty: "/dev/ttys001",
+    termProgram: "tmux",
+    itermSessionId: null,
     createdAt: "2026-04-01T00:00:00.000Z",
     updatedAt: "2026-04-01T00:00:00.000Z",
     lastSeenAt: "2026-04-01T00:00:00.000Z",
@@ -190,6 +217,110 @@ test("DefaultActivationGate defers when the terminal probe reports busy", async 
   assert.deepEqual(await gate.evaluate(makeItermTarget()), {
     outcome: "defer",
     reason: "terminal_busy",
+  });
+});
+
+test("TmuxTerminalStateProbe reports gone when the pane is absent", async () => {
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      const error = new Error("can't find pane: %2") as Error & { stderr?: string };
+      error.stderr = "can't find pane: %2";
+      throw error;
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "gone",
+    busy: "unknown",
+  });
+});
+
+test("TmuxTerminalStateProbe reports busy when the buffer tail changes", async () => {
+  const buffers = ["first snapshot", "second snapshot"];
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      return { stdout: "1 0\n", stderr: "" };
+    }
+    if (args[0] === "capture-pane") {
+      return { stdout: `${buffers.shift() ?? "second snapshot"}\n`, stderr: "" };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "available",
+    busy: "busy",
+  });
+});
+
+test("TmuxTerminalStateProbe reports busy when the stable buffer shows a codex activity marker", async () => {
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      return { stdout: "1 0\n", stderr: "" };
+    }
+    if (args[0] === "capture-pane") {
+      return {
+        stdout: "workspace\n• Working (1m 23s • esc to interrupt)\n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "available",
+    busy: "busy",
+  });
+});
+
+test("TmuxTerminalStateProbe reports busy when the active pane shows typed prompt input", async () => {
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      return { stdout: "1 0\n", stderr: "" };
+    }
+    if (args[0] === "capture-pane") {
+      return {
+        stdout: "question text\n\n› abcdefg\n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "available",
+    busy: "busy",
+  });
+});
+
+test("TmuxTerminalStateProbe reports unknown when the pane is stable and prompt is empty", async () => {
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      return { stdout: "1 0\n", stderr: "" };
+    }
+    if (args[0] === "capture-pane") {
+      return {
+        stdout: "workspace\nAll quiet here\n› \n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "available",
+    busy: "unknown",
   });
 });
 


### PR DESCRIPTION
## Summary
- add a `TmuxTerminalStateProbe` to the activation gate pipeline
- detect tmux panes that are gone before dispatching
- defer terminal injection when the tmux pane is visibly active, the buffer is changing, or the rendered prompt line contains in-progress user input
- add unit tests for missing panes, changing buffers, codex activity markers, typed prompt input, and quiet panes

## Context
This is a follow-up to the work landed for #79. PR #84 intentionally left tmux busy detection as `unknown`; this patch fills in that missing tmux-specific input probe using non-destructive `tmux display-message` and `tmux capture-pane` sampling.

## Testing
- `node --require ts-node/register --test test/runtime_gate.test.ts`
- `npm run build`
- `npm test` *(currently still reports existing `out of memory` failures in unrelated `agentinbox.test.ts` paths; the new tmux probe tests pass)*
