### PR TITLE
fix: submit tmux codex notifications with literal CR

### DIFF
--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -109,7 +109,8 @@ export class TerminalDispatcher {
       if (!target.tmuxPaneId) {
         throw new Error(`tmux terminal target ${target.targetId} is missing tmuxPaneId`);
       }
-      await this.execAsync("tmux", ["send-keys", "-t", target.tmuxPaneId, prompt, "Enter"]);
+      await this.execAsync("tmux", ["send-keys", "-t", target.tmuxPaneId, "-l", prompt]);
+      await this.execAsync("tmux", ["send-keys", "-t", target.tmuxPaneId, "-l", "\r"]);
       return;
     }
 

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -98,3 +98,60 @@ test("TerminalDispatcher uses two-step it2api submission for iTerm2 targets", as
     "\r",
   ]);
 });
+
+test("TerminalDispatcher uses literal text plus carriage return for tmux targets", async () => {
+  const calls: Array<{ file: string; args: string[] }> = [];
+  const dispatcher = new TerminalDispatcher(async (file, args) => {
+    calls.push({
+      file,
+      args: [...args],
+    });
+    return {
+      stdout: "sent\n",
+      stderr: "",
+    };
+  });
+
+  const target: TerminalActivationTarget = {
+    targetId: "tgt_tmux_1",
+    agentId: "agent_codex_tmux",
+    kind: "terminal",
+    status: "active",
+    offlineSince: null,
+    consecutiveFailures: 0,
+    lastDeliveredAt: null,
+    lastError: null,
+    mode: "agent_prompt",
+    notifyLeaseMs: 600000,
+    runtimeKind: "codex",
+    runtimeSessionId: "thread-tmux-1",
+    backend: "tmux",
+    tmuxPaneId: "%2",
+    tty: null,
+    termProgram: "tmux",
+    itermSessionId: null,
+    createdAt: "2026-04-07T00:00:00.000Z",
+    updatedAt: "2026-04-07T00:00:00.000Z",
+    lastSeenAt: "2026-04-07T00:00:00.000Z",
+  };
+
+  await dispatcher.dispatch(target, "AgentInbox: hello");
+
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].file, "tmux");
+  assert.deepEqual(calls[0].args, [
+    "send-keys",
+    "-t",
+    "%2",
+    "-l",
+    "AgentInbox: hello",
+  ]);
+  assert.equal(calls[1].file, "tmux");
+  assert.deepEqual(calls[1].args, [
+    "send-keys",
+    "-t",
+    "%2",
+    "-l",
+    "\r",
+  ]);
+});


### PR DESCRIPTION
## Summary
- switch tmux terminal dispatch from `send-keys <prompt> Enter` to literal text injection plus a literal carriage return
- align tmux submit semantics with the working codex pane behavior we re-verified on pane `%2`
- add a dispatcher unit test that locks the tmux argument sequence

## Validation
- verified on the current codex tmux pane `%2` that `tmux send-keys -t %2 -l '...'; tmux send-keys -t %2 -l $'\r'` submits
- `node --require ts-node/register --test test/terminal.test.ts`
- `npm run build`
- `npm test` reaches the late suite tail and then hangs in `node --test` exit; not treated as green
