### PR TITLE
fix: parse iTerm2 session ids from runtime gate output

### DIFF
--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -178,11 +178,8 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
   private async checkSessionPresence(it2api: string, sessionId: string): Promise<TerminalPresenceStatus> {
     try {
       const result = await this.execAsync(it2api, ["list-sessions"]);
-      const sessions = result.stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter((line) => line.length > 0);
-      return sessions.includes(sessionId) ? "available" : "gone";
+      const sessionIds = parseIterm2SessionIds(result.stdout);
+      return sessionIds.includes(sessionId) ? "available" : "gone";
     } catch {
       return "unknown";
     }
@@ -534,19 +531,22 @@ export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
     try {
       const it2api = resolveIterm2ApiPath();
       const result = await execFileAsync(it2api, ["list-sessions"]);
-      const lines = result.stdout.split(/\r?\n/).map((line: string) => line.trim()).filter((line: string) => line.length > 0);
-
-      // Parse session IDs from iTerm2 output format: "Session \"...\" id=<UUID> ..."
-      const sessionIds = lines
-        .map((line: string) => {
-          const match = line.match(/id=([A-F0-9-]+)/);
-          return match ? match[1] : null;
-        })
-        .filter((id: string | null): id is string => id !== null);
-
+      const sessionIds = parseIterm2SessionIds(result.stdout);
       return sessionIds.includes(itermSessionId) ? "available" : "gone";
     } catch {
       return "unknown";
     }
   }
+}
+
+function parseIterm2SessionIds(stdout: string): string[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const match = line.match(/\bid=([A-F0-9-]+)/i);
+      return match ? match[1] : null;
+    })
+    .filter((id): id is string => id !== null);
 }

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -29,7 +29,7 @@ function makeItermTarget(): TerminalActivationTarget {
     tmuxPaneId: null,
     tty: null,
     termProgram: "iTerm.app",
-    itermSessionId: "SESSION-1",
+    itermSessionId: "4F7A2F18-E5F4-4E27-A391-23953DE1F826",
     createdAt: "2026-04-01T00:00:00.000Z",
     updatedAt: "2026-04-01T00:00:00.000Z",
     lastSeenAt: "2026-04-01T00:00:00.000Z",
@@ -79,7 +79,10 @@ test("CodexRuntimePresenceProbe reports gone for ESRCH", async () => {
 test("Iterm2TerminalStateProbe reports gone when the session is absent", async () => {
   const probe = new Iterm2TerminalStateProbe(async (_file, args) => {
     if (args[0] === "list-sessions") {
-      return { stdout: "OTHER-SESSION\n", stderr: "" };
+      return {
+        stdout: "Session \"codex\" id=F1111111-E5F4-4E27-A391-23953DE1F826 (110 x 30)\n",
+        stderr: "",
+      };
     }
     throw new Error(`unexpected command: ${args.join(" ")}`);
   }, {
@@ -96,7 +99,13 @@ test("Iterm2TerminalStateProbe reports gone when the session is absent", async (
 test("Iterm2TerminalStateProbe matches session ids exactly", async () => {
   const probe = new Iterm2TerminalStateProbe(async (_file, args) => {
     if (args[0] === "list-sessions") {
-      return { stdout: "SESSION-10\n", stderr: "" };
+      return {
+        stdout: [
+          "Session \"codex one\" id=4F7A2F18-E5F4-4E27-A391-23953DE1F820 (110 x 30)",
+          "Session \"codex two\" id=F1111111-E5F4-4E27-A391-23953DE1F826 (110 x 30)",
+        ].join("\n"),
+        stderr: "",
+      };
     }
     throw new Error(`unexpected command: ${args.join(" ")}`);
   }, {
@@ -128,7 +137,10 @@ test("Iterm2TerminalStateProbe reports busy when the buffer tail changes", async
   const buffers = ["first snapshot", "second snapshot"];
   const probe = new Iterm2TerminalStateProbe(async (_file, args) => {
     if (args[0] === "list-sessions") {
-      return { stdout: "SESSION-1\n", stderr: "" };
+      return {
+        stdout: "Session \"codex\" id=4F7A2F18-E5F4-4E27-A391-23953DE1F826 (110 x 30)\n",
+        stderr: "",
+      };
     }
     if (args[0] === "get-prompt") {
       throw new Error("prompt unavailable");
@@ -151,7 +163,10 @@ test("Iterm2TerminalStateProbe reports busy when the buffer tail changes", async
 test("Iterm2TerminalStateProbe reports busy when the stable buffer shows a codex activity marker", async () => {
   const probe = new Iterm2TerminalStateProbe(async (_file, args) => {
     if (args[0] === "list-sessions") {
-      return { stdout: "SESSION-1\n", stderr: "" };
+      return {
+        stdout: "Session \"codex\" id=4F7A2F18-E5F4-4E27-A391-23953DE1F826 (110 x 30)\n",
+        stderr: "",
+      };
     }
     if (args[0] === "get-prompt") {
       throw new Error("prompt unavailable");
@@ -177,7 +192,10 @@ test("Iterm2TerminalStateProbe reports busy when the stable buffer shows a codex
 test("Iterm2TerminalStateProbe reports unknown when the buffer is stable and quiet", async () => {
   const probe = new Iterm2TerminalStateProbe(async (_file, args) => {
     if (args[0] === "list-sessions") {
-      return { stdout: "SESSION-1\n", stderr: "" };
+      return {
+        stdout: "Session \"codex\" id=4F7A2F18-E5F4-4E27-A391-23953DE1F826 (110 x 30)\n",
+        stderr: "",
+      };
     }
     if (args[0] === "get-prompt") {
       throw new Error("prompt unavailable");


### PR DESCRIPTION
## Summary
- parse iTerm2 session ids from real `it2api list-sessions` output in the runtime gate
- reuse the same iTerm2 session-id parser for Codex and Claude Code presence checks
- update runtime-gate tests to cover `Session ... id=<UUID>` lines instead of bare placeholder ids

## Testing
- npm run build
- node --require ts-node/register --test test/runtime_gate.test.ts
