### PR TITLE
feat: harden codex terminal gating

### DIFF
--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -70,14 +70,14 @@ export class DefaultActivationGate implements ActivationGate {
   }> {
     const runtimeProbe = this.runtimeProbes.find((probe) => probe.supports(target));
     const runtimePresence = runtimeProbe ? await runtimeProbe.check(target) : "unknown";
+    if (runtimePresence === "gone") {
+      return { outcome: "offline", reason: "runtime_gone" };
+    }
     const terminalProbe = this.terminalProbes.find((probe) => probe.supports(target));
     const terminalState = terminalProbe
       ? await terminalProbe.check(target)
       : { presence: "unknown" as const, busy: "unknown" as const };
 
-    if (runtimePresence === "gone") {
-      return { outcome: "offline", reason: "runtime_gone" };
-    }
     if (terminalState.presence === "gone") {
       return { outcome: "offline", reason: "terminal_gone" };
     }
@@ -94,7 +94,7 @@ export class DefaultActivationGate implements ActivationGate {
 export class CodexRuntimePresenceProbe implements RuntimePresenceProbe {
   constructor(
     private readonly killFn: (pid: number, signal: number) => void = (pid, signal) => process.kill(pid, signal),
-    private readonly sessionFileReader?: (sessionId: string) => Promise<{ sessionId: string; filePath: string; cwd?: string | null } | null>,
+    private readonly sessionFileReader?: (sessionId: string) => Promise<CodexSessionLookupResult>,
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -111,6 +111,9 @@ export class CodexRuntimePresenceProbe implements RuntimePresenceProbe {
         return "unknown";
       }
       const sessionInfo = await (this.sessionFileReader ?? defaultCodexSessionFileReader)(target.runtimeSessionId);
+      if (sessionInfo === "unknown") {
+        return "unknown";
+      }
       if (!sessionInfo || sessionInfo.sessionId !== target.runtimeSessionId) {
         return "gone";
       }
@@ -129,7 +132,7 @@ export class CodexTerminalStateProbe implements TerminalStateProbe {
   constructor(
     private readonly iTermProbe: TerminalStateProbe = new Iterm2TerminalStateProbe(),
     private readonly tmuxProbe: TerminalStateProbe = new TmuxTerminalStateProbe(),
-    private readonly sessionFileReader?: (sessionId: string) => Promise<{ sessionId: string; filePath: string; cwd?: string | null } | null>,
+    private readonly sessionFileReader?: (sessionId: string) => Promise<CodexSessionLookupResult>,
     private readonly statReader?: (filePath: string) => Promise<{ mtimeMs: number } | null>,
     private readonly nowFn: () => number = () => Date.now(),
   ) {}
@@ -147,7 +150,7 @@ export class CodexTerminalStateProbe implements TerminalStateProbe {
       return terminalState;
     }
     const sessionInfo = await (this.sessionFileReader ?? defaultCodexSessionFileReader)(target.runtimeSessionId);
-    if (!sessionInfo || sessionInfo.sessionId !== target.runtimeSessionId) {
+    if (sessionInfo === "unknown" || !sessionInfo || sessionInfo.sessionId !== target.runtimeSessionId) {
       return terminalState;
     }
     const stat = await (this.statReader ?? defaultFileStatReader)(sessionInfo.filePath);
@@ -419,20 +422,27 @@ async function defaultFileStatReader(filePath: string): Promise<{ mtimeMs: numbe
   }
 }
 
-async function defaultCodexSessionFileReader(sessionId: string): Promise<{
+type CodexSessionInfo = {
   sessionId: string;
   filePath: string;
   cwd?: string | null;
-} | null> {
+};
+
+type CodexSessionLookupResult = CodexSessionInfo | null | "unknown";
+
+async function defaultCodexSessionFileReader(sessionId: string): Promise<CodexSessionLookupResult> {
   const sessionsRoot = path.join(os.homedir(), ".codex", "sessions");
-  const filePath = await findCodexSessionFile(sessionsRoot, sessionId);
+  const filePath = await findCodexSessionFile(sessionsRoot, sessionId).catch(() => "unknown" as const);
+  if (filePath === "unknown") {
+    return "unknown";
+  }
   if (!filePath) {
     return null;
   }
   try {
     const firstLine = await readFirstLine(filePath);
     if (!firstLine) {
-      return null;
+      return "unknown";
     }
     const record = JSON.parse(firstLine) as {
       type?: string;
@@ -440,7 +450,7 @@ async function defaultCodexSessionFileReader(sessionId: string): Promise<{
     };
     const parsedSessionId = typeof record.payload?.id === "string" ? record.payload.id : null;
     if (record.type !== "session_meta" || parsedSessionId !== sessionId) {
-      return null;
+      return "unknown";
     }
     return {
       sessionId: parsedSessionId,
@@ -448,7 +458,7 @@ async function defaultCodexSessionFileReader(sessionId: string): Promise<{
       cwd: typeof record.payload?.cwd === "string" ? record.payload.cwd : null,
     };
   } catch {
-    return null;
+    return "unknown";
   }
 }
 

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -57,6 +57,7 @@ export class DefaultActivationGate implements ActivationGate {
       new ClaudeCodeRuntimePresenceProbe(),
     ],
     private readonly terminalProbes: TerminalStateProbe[] = [
+      new CodexTerminalStateProbe(),
       new Iterm2TerminalStateProbe(),
       new ClaudeCodeTerminalStateProbe(),
       new TmuxTerminalStateProbe(),
@@ -83,6 +84,9 @@ export class DefaultActivationGate implements ActivationGate {
     if (terminalState.busy === "busy") {
       return { outcome: "defer", reason: "terminal_busy" };
     }
+    if (target.runtimeKind === "codex" && terminalState.busy === "idle") {
+      return { outcome: "defer", reason: "terminal_recently_active" };
+    }
     return { outcome: "inject", reason: "gate_unknown_or_idle" };
   }
 }
@@ -90,6 +94,7 @@ export class DefaultActivationGate implements ActivationGate {
 export class CodexRuntimePresenceProbe implements RuntimePresenceProbe {
   constructor(
     private readonly killFn: (pid: number, signal: number) => void = (pid, signal) => process.kill(pid, signal),
+    private readonly sessionFileReader?: (sessionId: string) => Promise<{ sessionId: string; filePath: string; cwd?: string | null } | null>,
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -102,6 +107,13 @@ export class CodexRuntimePresenceProbe implements RuntimePresenceProbe {
     }
     try {
       this.killFn(target.runtimePid!, 0);
+      if (!target.runtimeSessionId) {
+        return "unknown";
+      }
+      const sessionInfo = await (this.sessionFileReader ?? defaultCodexSessionFileReader)(target.runtimeSessionId);
+      if (!sessionInfo || sessionInfo.sessionId !== target.runtimeSessionId) {
+        return "gone";
+      }
       return "alive";
     } catch (error) {
       const code = error instanceof Error && "code" in error ? String((error as NodeJS.ErrnoException).code ?? "") : "";
@@ -110,6 +122,62 @@ export class CodexRuntimePresenceProbe implements RuntimePresenceProbe {
       }
       return "unknown";
     }
+  }
+}
+
+export class CodexTerminalStateProbe implements TerminalStateProbe {
+  constructor(
+    private readonly iTermProbe: TerminalStateProbe = new Iterm2TerminalStateProbe(),
+    private readonly tmuxProbe: TerminalStateProbe = new TmuxTerminalStateProbe(),
+    private readonly sessionFileReader?: (sessionId: string) => Promise<{ sessionId: string; filePath: string; cwd?: string | null } | null>,
+    private readonly statReader?: (filePath: string) => Promise<{ mtimeMs: number } | null>,
+    private readonly nowFn: () => number = () => Date.now(),
+  ) {}
+
+  supports(target: TerminalActivationTarget): boolean {
+    return target.runtimeKind === "codex";
+  }
+
+  async check(target: TerminalActivationTarget): Promise<{
+    presence: TerminalPresenceStatus;
+    busy: TerminalBusyStatus;
+  }> {
+    const terminalState = await this.readTerminalState(target);
+    if (!target.runtimeSessionId) {
+      return terminalState;
+    }
+    const sessionInfo = await (this.sessionFileReader ?? defaultCodexSessionFileReader)(target.runtimeSessionId);
+    if (!sessionInfo || sessionInfo.sessionId !== target.runtimeSessionId) {
+      return terminalState;
+    }
+    const stat = await (this.statReader ?? defaultFileStatReader)(sessionInfo.filePath);
+    if (!stat) {
+      return terminalState;
+    }
+    if (terminalState.busy === "busy" || terminalState.presence === "gone") {
+      return terminalState;
+    }
+    const ageMs = this.nowFn() - stat.mtimeMs;
+    if (ageMs < 5000) {
+      return { presence: terminalState.presence, busy: "busy" };
+    }
+    if (ageMs < 30000) {
+      return { presence: terminalState.presence, busy: "idle" };
+    }
+    return terminalState;
+  }
+
+  private async readTerminalState(target: TerminalActivationTarget): Promise<{
+    presence: TerminalPresenceStatus;
+    busy: TerminalBusyStatus;
+  }> {
+    if (this.iTermProbe.supports(target)) {
+      return this.iTermProbe.check(target);
+    }
+    if (this.tmuxProbe.supports(target)) {
+      return this.tmuxProbe.check(target);
+    }
+    return { presence: "unknown", busy: "unknown" };
   }
 }
 
@@ -170,6 +238,9 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
       return { presence: "available", busy: "busy" };
     }
     if (containsActiveBufferMarker(second)) {
+      return { presence: "available", busy: "busy" };
+    }
+    if (hasVisibleTypingPrompt(second)) {
       return { presence: "available", busy: "busy" };
     }
     return { presence: "available", busy: "unknown" };
@@ -337,6 +408,106 @@ function resolveIterm2ApiPath(override?: string): string {
 
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function defaultFileStatReader(filePath: string): Promise<{ mtimeMs: number } | null> {
+  try {
+    const stats = await fs.promises.stat(filePath);
+    return { mtimeMs: stats.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+async function defaultCodexSessionFileReader(sessionId: string): Promise<{
+  sessionId: string;
+  filePath: string;
+  cwd?: string | null;
+} | null> {
+  const sessionsRoot = path.join(os.homedir(), ".codex", "sessions");
+  const filePath = await findCodexSessionFile(sessionsRoot, sessionId);
+  if (!filePath) {
+    return null;
+  }
+  try {
+    const firstLine = await readFirstLine(filePath);
+    if (!firstLine) {
+      return null;
+    }
+    const record = JSON.parse(firstLine) as {
+      type?: string;
+      payload?: { id?: unknown; cwd?: unknown };
+    };
+    const parsedSessionId = typeof record.payload?.id === "string" ? record.payload.id : null;
+    if (record.type !== "session_meta" || parsedSessionId !== sessionId) {
+      return null;
+    }
+    return {
+      sessionId: parsedSessionId,
+      filePath,
+      cwd: typeof record.payload?.cwd === "string" ? record.payload.cwd : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function findCodexSessionFile(root: string, sessionId: string): Promise<string | null> {
+  let years: fs.Dirent[];
+  try {
+    years = await fs.promises.readdir(root, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const year of years) {
+    if (!year.isDirectory()) {
+      continue;
+    }
+    const yearPath = path.join(root, year.name);
+    const match = await walkCodexSessionLevel(yearPath, sessionId, 2);
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+}
+
+async function walkCodexSessionLevel(dir: string, sessionId: string, depth: number): Promise<string | null> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isFile() && entry.name.endsWith(`${sessionId}.jsonl`)) {
+      return entryPath;
+    }
+    if (entry.isDirectory() && depth > 0) {
+      const match = await walkCodexSessionLevel(entryPath, sessionId, depth - 1);
+      if (match) {
+        return match;
+      }
+    }
+  }
+  return null;
+}
+
+async function readFirstLine(filePath: string): Promise<string | null> {
+  const handle = await fs.promises.open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(4096);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead <= 0) {
+      return null;
+    }
+    const chunk = buffer.toString("utf8", 0, bytesRead);
+    const newline = chunk.indexOf("\n");
+    return (newline >= 0 ? chunk.slice(0, newline) : chunk).trim() || null;
+  } finally {
+    await handle.close();
+  }
 }
 
 function isTmuxMissingPaneError(error: unknown): boolean {

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -504,17 +504,31 @@ async function walkCodexSessionLevel(dir: string, sessionId: string, depth: numb
   return null;
 }
 
-async function readFirstLine(filePath: string): Promise<string | null> {
+export async function readFirstLine(filePath: string): Promise<string | null> {
   const handle = await fs.promises.open(filePath, "r");
   try {
-    const buffer = Buffer.alloc(4096);
-    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
-    if (bytesRead <= 0) {
-      return null;
+    const chunkSize = 4096;
+    const chunks: string[] = [];
+    let position = 0;
+
+    while (true) {
+      const buffer = Buffer.alloc(chunkSize);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+      if (bytesRead <= 0) {
+        break;
+      }
+      const chunk = buffer.toString("utf8", 0, bytesRead);
+      const newline = chunk.indexOf("\n");
+      if (newline >= 0) {
+        chunks.push(chunk.slice(0, newline));
+        break;
+      }
+      chunks.push(chunk);
+      position += bytesRead;
     }
-    const chunk = buffer.toString("utf8", 0, bytesRead);
-    const newline = chunk.indexOf("\n");
-    return (newline >= 0 ? chunk.slice(0, newline) : chunk).trim() || null;
+
+    const firstLine = chunks.join("").trim();
+    return firstLine.length > 0 ? firstLine : null;
   } finally {
     await handle.close();
   }

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -97,6 +97,11 @@ test("CodexRuntimePresenceProbe reports unknown when runtimeSessionId is missing
   assert.equal(await probe.check(target), "unknown");
 });
 
+test("CodexRuntimePresenceProbe reports unknown when the session file cannot be read conclusively", async () => {
+  const probe = new CodexRuntimePresenceProbe(() => {}, async () => "unknown");
+  assert.equal(await probe.check(makeItermTarget()), "unknown");
+});
+
 test("Iterm2TerminalStateProbe reports gone when the session is absent", async () => {
   const probe = new Iterm2TerminalStateProbe(async (_file, args) => {
     if (args[0] === "list-sessions") {
@@ -318,6 +323,33 @@ test("DefaultActivationGate defers when Codex looks recently active but not conc
     outcome: "defer",
     reason: "terminal_recently_active",
   });
+});
+
+test("DefaultActivationGate short-circuits terminal probes when runtime is already gone", async () => {
+  let terminalChecked = false;
+  const gate = new DefaultActivationGate(
+    [new CodexRuntimePresenceProbe(() => {
+      const error = new Error("missing") as NodeJS.ErrnoException;
+      error.code = "ESRCH";
+      throw error;
+    })],
+    [{
+      supports: () => true,
+      async check() {
+        terminalChecked = true;
+        return {
+          presence: "available" as const,
+          busy: "busy" as const,
+        };
+      },
+    }],
+  );
+
+  assert.deepEqual(await gate.evaluate(makeItermTarget()), {
+    outcome: "offline",
+    reason: "runtime_gone",
+  });
+  assert.equal(terminalChecked, false);
 });
 
 test("CodexTerminalStateProbe reports busy when the Codex session file was updated recently", async () => {

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -7,9 +7,13 @@ import {
   Iterm2TerminalStateProbe,
   ClaudeCodeRuntimePresenceProbe,
   ClaudeCodeTerminalStateProbe,
+  readFirstLine,
   TmuxTerminalStateProbe,
 } from "../src/runtime_gate";
 import { TerminalActivationTarget } from "../src/model";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 function makeItermTarget(): TerminalActivationTarget {
   return {
@@ -100,6 +104,26 @@ test("CodexRuntimePresenceProbe reports unknown when runtimeSessionId is missing
 test("CodexRuntimePresenceProbe reports unknown when the session file cannot be read conclusively", async () => {
   const probe = new CodexRuntimePresenceProbe(() => {}, async () => "unknown");
   assert.equal(await probe.check(makeItermTarget()), "unknown");
+});
+
+test("readFirstLine reads a full first line even when it exceeds 4096 bytes", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agentinbox-runtime-gate-"));
+  const filePath = path.join(dir, "large-first-line.jsonl");
+  const largeJsonLine = JSON.stringify({
+    type: "session_meta",
+    payload: {
+      id: "thread-1",
+      cwd: "/tmp/demo",
+      instructions: "x".repeat(16_384),
+    },
+  });
+
+  try {
+    await fs.writeFile(filePath, `${largeJsonLine}\n{"type":"next"}\n`, "utf8");
+    assert.equal(await readFirstLine(filePath), largeJsonLine);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("Iterm2TerminalStateProbe reports gone when the session is absent", async () => {

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   CodexRuntimePresenceProbe,
+  CodexTerminalStateProbe,
   DefaultActivationGate,
   Iterm2TerminalStateProbe,
   ClaudeCodeRuntimePresenceProbe,
@@ -63,7 +64,13 @@ function makeTmuxTarget(): TerminalActivationTarget {
 }
 
 test("CodexRuntimePresenceProbe reports alive for a live pid", async () => {
-  const probe = new CodexRuntimePresenceProbe(() => {});
+  const probe = new CodexRuntimePresenceProbe(
+    () => {},
+    async () => ({
+      sessionId: "thread-1",
+      filePath: "/tmp/codex-thread-1.jsonl",
+    }),
+  );
   assert.equal(await probe.check(makeItermTarget()), "alive");
 });
 
@@ -74,6 +81,20 @@ test("CodexRuntimePresenceProbe reports gone for ESRCH", async () => {
     throw error;
   });
   assert.equal(await probe.check(makeItermTarget()), "gone");
+});
+
+test("CodexRuntimePresenceProbe reports gone when the session file is missing", async () => {
+  const probe = new CodexRuntimePresenceProbe(() => {}, async () => null);
+  assert.equal(await probe.check(makeItermTarget()), "gone");
+});
+
+test("CodexRuntimePresenceProbe reports unknown when runtimeSessionId is missing", async () => {
+  const probe = new CodexRuntimePresenceProbe(() => {}, async () => {
+    throw new Error("should not read session file without runtimeSessionId");
+  });
+  const target = makeItermTarget();
+  target.runtimeSessionId = null;
+  assert.equal(await probe.check(target), "unknown");
 });
 
 test("Iterm2TerminalStateProbe reports gone when the session is absent", async () => {
@@ -218,9 +239,44 @@ test("Iterm2TerminalStateProbe reports unknown when the buffer is stable and qui
   });
 });
 
+test("Iterm2TerminalStateProbe reports busy when the stable buffer shows visible typed input", async () => {
+  const probe = new Iterm2TerminalStateProbe(async (_file, args) => {
+    if (args[0] === "list-sessions") {
+      return {
+        stdout: "Session \"codex\" id=4F7A2F18-E5F4-4E27-A391-23953DE1F826 (110 x 30)\n",
+        stderr: "",
+      };
+    }
+    if (args[0] === "get-prompt") {
+      throw new Error("prompt unavailable");
+    }
+    if (args[0] === "get-buffer") {
+      return {
+        stdout: "workspace\n> agentinbox inbox read --agent-id demo\n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    iterm2ApiPath: "/tmp/fake-it2api",
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeItermTarget()), {
+    presence: "available",
+    busy: "busy",
+  });
+});
+
 test("DefaultActivationGate defers when the terminal probe reports busy", async () => {
   const gate = new DefaultActivationGate(
-    [new CodexRuntimePresenceProbe(() => {})],
+    [new CodexRuntimePresenceProbe(
+      () => {},
+      async () => ({
+        sessionId: "thread-1",
+        filePath: "/tmp/codex-thread-1.jsonl",
+      }),
+    )],
     [{
       supports: () => true,
       async check() {
@@ -235,6 +291,94 @@ test("DefaultActivationGate defers when the terminal probe reports busy", async 
   assert.deepEqual(await gate.evaluate(makeItermTarget()), {
     outcome: "defer",
     reason: "terminal_busy",
+  });
+});
+
+test("DefaultActivationGate defers when Codex looks recently active but not conclusively idle", async () => {
+  const gate = new DefaultActivationGate(
+    [new CodexRuntimePresenceProbe(
+      () => {},
+      async () => ({
+        sessionId: "thread-1",
+        filePath: "/tmp/codex-thread-1.jsonl",
+      }),
+    )],
+    [{
+      supports: () => true,
+      async check() {
+        return {
+          presence: "available" as const,
+          busy: "idle" as const,
+        };
+      },
+    }],
+  );
+
+  assert.deepEqual(await gate.evaluate(makeItermTarget()), {
+    outcome: "defer",
+    reason: "terminal_recently_active",
+  });
+});
+
+test("CodexTerminalStateProbe reports busy when the Codex session file was updated recently", async () => {
+  const probe = new CodexTerminalStateProbe(
+    {
+      supports: () => true,
+      async check() {
+        return {
+          presence: "available" as const,
+          busy: "unknown" as const,
+        };
+      },
+    },
+    {
+      supports: () => false,
+      async check() {
+        throw new Error("tmux probe should not be used");
+      },
+    },
+    async () => ({
+      sessionId: "thread-1",
+      filePath: "/tmp/codex-thread-1.jsonl",
+    }),
+    async () => ({ mtimeMs: 199_000 }),
+    () => 200_000,
+  );
+
+  assert.deepEqual(await probe.check(makeItermTarget()), {
+    presence: "available",
+    busy: "busy",
+  });
+});
+
+test("CodexTerminalStateProbe reports idle when the Codex session was only recently active", async () => {
+  const probe = new CodexTerminalStateProbe(
+    {
+      supports: () => true,
+      async check() {
+        return {
+          presence: "available" as const,
+          busy: "unknown" as const,
+        };
+      },
+    },
+    {
+      supports: () => false,
+      async check() {
+        throw new Error("tmux probe should not be used");
+      },
+    },
+    async () => ({
+      sessionId: "thread-1",
+      filePath: "/tmp/codex-thread-1.jsonl",
+    }),
+    async () => ({ mtimeMs: 190_000 }),
+    () => 200_000,
+  );
+
+  assert.deepEqual(await probe.check(makeItermTarget()), {
+    presence: "available",
+    busy: "idle",
   });
 });
 


### PR DESCRIPTION
## Summary
- verify Codex terminal liveness with `~/.codex/sessions` instead of PID-only checks
- defer Codex terminal activations when the session file shows recent activity, even if terminal sampling is inconclusive
- detect visible typed input in iTerm2 buffer sampling and cover the new Codex gate semantics with runtime-gate tests

## Testing
- npm run build
- node --require ts-node/register --test test/runtime_gate.test.ts
