### PR TITLE
docs: document inbox send and timer commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ agentinbox inbox send --agent-id <agent_id> --message "CI failed on main" --send
 Schedule reminder messages with timers:
 
 ```bash
-agentinbox timer add --agent-id <agent_id> --at 2026-04-15T08:00:00+08:00 --message "Check the morning build"
+agentinbox timer add --agent-id <agent_id> --at <RFC3339_TIMESTAMP> --message "Check the morning build"
 agentinbox timer add --agent-id <agent_id> --every 24h --message "Review today's open PRs"
 agentinbox timer add --agent-id <agent_id> --cron "0 8 * * *" --timezone Asia/Shanghai --message "Daily triage"
 agentinbox timer list

--- a/README.md
+++ b/README.md
@@ -146,6 +146,26 @@ agentinbox inbox read
 agentinbox inbox read --agent-id <agent_id>
 ```
 
+Send a direct text message into an agent inbox:
+
+```bash
+agentinbox inbox send --agent-id <agent_id> --message "Please review PR #87"
+agentinbox inbox send --agent-id <agent_id> --message "CI failed on main" --sender operator
+```
+
+Schedule reminder messages with timers:
+
+```bash
+agentinbox timer add --agent-id <agent_id> --at 2026-04-15T08:00:00+08:00 --message "Check the morning build"
+agentinbox timer add --agent-id <agent_id> --every 24h --message "Review today's open PRs"
+agentinbox timer add --agent-id <agent_id> --cron "0 8 * * *" --timezone Asia/Shanghai --message "Daily triage"
+agentinbox timer list
+agentinbox timer list --agent-id <agent_id>
+agentinbox timer pause <schedule_id>
+agentinbox timer resume <schedule_id>
+agentinbox timer remove <schedule_id>
+```
+
 Update an existing source in place:
 
 ```bash

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -142,11 +142,34 @@ Read and ack the inbox:
 ```bash
 agentinbox inbox read
 agentinbox inbox read --agent-id <agentId>
+agentinbox inbox send --agent-id <agentId> --message "Please review PR #87"
+agentinbox inbox send --agent-id <agentId> --message "CI failed on main" --sender operator
 agentinbox inbox watch
 agentinbox inbox watch --agent-id <agentId>
 agentinbox inbox ack --all
 agentinbox inbox ack --agent-id <agentId> --all
 ```
+
+Use `inbox send` as the default local operator path for direct text ingress when
+you want to place a human-written or agent-written message into an inbox
+without creating a source event or calling the HTTP control plane directly.
+
+Manage timers:
+
+```bash
+agentinbox timer add --agent-id <agentId> --at 2026-04-15T08:00:00+08:00 --message "Check the morning build"
+agentinbox timer add --agent-id <agentId> --every 24h --message "Review today's open PRs"
+agentinbox timer add --agent-id <agentId> --cron "0 8 * * *" --timezone Asia/Shanghai --message "Daily triage"
+agentinbox timer list
+agentinbox timer list --agent-id <agentId>
+agentinbox timer pause <scheduleId>
+agentinbox timer resume <scheduleId>
+agentinbox timer remove <scheduleId>
+```
+
+Use timers when the need is time-based rather than source-based. Prefer them
+over local event workarounds for reminders, recurring check-ins, and scheduled
+follow-ups.
 
 Manage activation targets:
 

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -157,7 +157,7 @@ without creating a source event or calling the HTTP control plane directly.
 Manage timers:
 
 ```bash
-agentinbox timer add --agent-id <agentId> --at 2026-04-15T08:00:00+08:00 --message "Check the morning build"
+agentinbox timer add --agent-id <agentId> --at <RFC3339_TIMESTAMP> --message "Check the morning build"
 agentinbox timer add --agent-id <agentId> --every 24h --message "Review today's open PRs"
 agentinbox timer add --agent-id <agentId> --cron "0 8 * * *" --timezone Asia/Shanghai --message "Daily triage"
 agentinbox timer list


### PR DESCRIPTION
Closes #94.

## Summary
- add `agentinbox inbox send` examples to the README quick start
- add timer command examples to the README quick start
- update the bundled `agentinbox` skill so agents see `inbox send` and timer commands without needing the full CLI reference
- explicitly steer agents toward `inbox send` for direct text ingress and timers for time-based reminders

## Validation
- verified `README.md` now includes clear `inbox send` examples and a timer section
- verified `skills/agentinbox/SKILL.md` now includes `inbox send`, timer commands, and selection guidance
