### PR TITLE
feat: expose daemon runtime metadata in status

### DIFF
--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -23,6 +23,10 @@ agentinbox daemon stop
 agentinbox daemon status
 ```
 
+`daemon status` returns machine-readable JSON including the daemon PID,
+transport, and runtime metadata such as the running `version`, `startedAt`,
+`command`, and `nodeVersion` when they can be determined locally.
+
 ## Agent
 
 ```bash

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { execFileSync, spawn } from "node:child_process";
 import { AgentInboxClient } from "./client";
 import { resolveAgentInboxHome, resolveDaemonPaths, type ClientTransport } from "./paths";
-import packageJson from "../package.json";
 
 export interface DaemonCliOptions {
   env?: NodeJS.ProcessEnv;
@@ -34,6 +33,7 @@ export interface DaemonStatusResult {
 }
 
 const START_TIMEOUT_MS = 15_000;
+const PACKAGE_VERSION = readOwnPackageVersion();
 
 export async function ensureDaemonForClient(options: DaemonCliOptions = {}): Promise<ClientTransport> {
   const transport = resolveDaemonClientTransport(options);
@@ -140,7 +140,7 @@ export async function daemonStatus(options: DaemonCliOptions = {}): Promise<Daem
   return {
     running: await canReachHealthz(transport),
     pid,
-    version: pid == null ? null : packageJson.version,
+    version: pid == null ? null : PACKAGE_VERSION,
     startedAt: processInfo?.startedAt ?? null,
     command: processInfo?.command ?? null,
     nodeVersion: processInfo?.nodeVersion ?? null,
@@ -230,6 +230,24 @@ async function canReachHealthz(transport: ClientTransport): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function readOwnPackageVersion(): string | null {
+  const candidatePaths = [
+    path.join(__dirname, "..", "package.json"),
+    path.join(__dirname, "..", "..", "package.json"),
+  ];
+  for (const candidate of candidatePaths) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(candidate, "utf8")) as { version?: unknown };
+      if (typeof parsed.version === "string" && parsed.version.length > 0) {
+        return parsed.version;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
 }
 
 async function waitForHealthz(transport: ClientTransport, timeoutMs: number): Promise<void> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { AgentInboxClient } from "./client";
 import { resolveAgentInboxHome, resolveDaemonPaths, type ClientTransport } from "./paths";
+import packageJson from "../package.json";
 
 export interface DaemonCliOptions {
   env?: NodeJS.ProcessEnv;
@@ -23,6 +24,10 @@ export interface DaemonStartResult {
 export interface DaemonStatusResult {
   running: boolean;
   pid: number | null;
+  version: string | null;
+  startedAt: string | null;
+  command: string | null;
+  nodeVersion: string | null;
   pidPath: string;
   logPath: string;
   transport: ClientTransport;
@@ -121,15 +126,24 @@ export async function daemonStatus(options: DaemonCliOptions = {}): Promise<Daem
     return {
       running: false,
       pid: null,
+      version: null,
+      startedAt: null,
+      command: null,
+      nodeVersion: null,
       pidPath,
       logPath,
       transport,
     };
   }
 
+  const processInfo = pid == null ? null : readProcessMetadata(pid);
   return {
     running: await canReachHealthz(transport),
     pid,
+    version: pid == null ? null : packageJson.version,
+    startedAt: processInfo?.startedAt ?? null,
+    command: processInfo?.command ?? null,
+    nodeVersion: processInfo?.nodeVersion ?? null,
     pidPath,
     logPath,
     transport,
@@ -262,6 +276,52 @@ function readPidFile(pidPath: string): number | null {
   } catch {
     return null;
   }
+}
+
+function readProcessMetadata(pid: number): {
+  startedAt: string | null;
+  command: string | null;
+  nodeVersion: string | null;
+} | null {
+  try {
+    const output = execFileSync("ps", ["-o", "lstart=", "-o", "command=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trimEnd();
+    if (!output) {
+      return null;
+    }
+    const firstNonSpace = output.search(/\S/);
+    if (firstNonSpace < 0) {
+      return null;
+    }
+    const trimmed = output.slice(firstNonSpace);
+    const match = trimmed.match(/^([A-Z][a-z]{2}\s+[A-Z][a-z]{2}\s+\d{1,2}\s+\d\d:\d\d:\d\d\s+\d{4})\s+(.*)$/);
+    if (!match) {
+      return {
+        startedAt: null,
+        command: trimmed,
+        nodeVersion: inferNodeVersionFromCommand(trimmed),
+      };
+    }
+    const [, startedAtRaw, command] = match;
+    const startedAtMs = Date.parse(startedAtRaw);
+    return {
+      startedAt: Number.isNaN(startedAtMs) ? null : new Date(startedAtMs).toISOString(),
+      command: command || null,
+      nodeVersion: inferNodeVersionFromCommand(command),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function inferNodeVersionFromCommand(command: string | null): string | null {
+  if (!command) {
+    return null;
+  }
+  const match = command.match(/node\/(v\d+\.\d+\.\d+)\//);
+  return match ? match[1] : null;
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -213,9 +213,25 @@ test("cli auto-starts the daemon for normal commands and daemon stop shuts it do
       timeout: 25_000,
     });
     assert.equal(daemonState.status, 0, daemonState.stderr);
-    const parsedDaemon = JSON.parse(daemonState.stdout) as { running: boolean; pid: number | null };
+    const parsedDaemon = JSON.parse(daemonState.stdout) as {
+      running: boolean;
+      pid: number | null;
+      version: string | null;
+      startedAt: string | null;
+      command: string | null;
+      nodeVersion: string | null;
+      pidPath: string;
+      logPath: string;
+    };
     assert.equal(parsedDaemon.running, true);
     assert.ok(parsedDaemon.pid && parsedDaemon.pid > 0);
+    assert.equal(parsedDaemon.version, "0.3.0");
+    assert.equal(typeof parsedDaemon.command, "string");
+    assert.ok(parsedDaemon.command && parsedDaemon.command.includes("serve"));
+    assert.equal(typeof parsedDaemon.startedAt, "string");
+    assert.ok(parsedDaemon.startedAt && !Number.isNaN(Date.parse(parsedDaemon.startedAt)));
+    assert.equal(typeof parsedDaemon.pidPath, "string");
+    assert.equal(typeof parsedDaemon.logPath, "string");
 
     const stopped = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "daemon", "stop"], {
       cwd: repoDir,

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -190,6 +190,7 @@ test("daemonStatus removes stale pid files", async () => {
 
 test("cli auto-starts the daemon for normal commands and daemon stop shuts it down", () => {
   const repoDir = path.resolve(__dirname, "..");
+  const packageVersion = JSON.parse(fs.readFileSync(path.join(repoDir, "package.json"), "utf8")) as { version: string };
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-autostart-home-"));
   const env = {
     ...process.env,
@@ -225,7 +226,7 @@ test("cli auto-starts the daemon for normal commands and daemon stop shuts it do
     };
     assert.equal(parsedDaemon.running, true);
     assert.ok(parsedDaemon.pid && parsedDaemon.pid > 0);
-    assert.equal(parsedDaemon.version, "0.3.0");
+    assert.equal(parsedDaemon.version, packageVersion.version);
     assert.equal(typeof parsedDaemon.command, "string");
     assert.ok(parsedDaemon.command && parsedDaemon.command.includes("serve"));
     assert.equal(typeof parsedDaemon.startedAt, "string");


### PR DESCRIPTION
## Summary
- extend `agentinbox daemon status` with daemon runtime metadata including version, startedAt, command, and nodeVersion
- read process metadata locally from the daemon PID when available while preserving machine-readable JSON output
- cover the daemon status JSON shape in the CLI auto-start control-plane test and document the new fields

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "cli auto-starts the daemon for normal commands and daemon stop shuts it down" test/control_plane.test.ts
