### PR TITLE
docs: recommend ack --through for inbox batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,13 @@ cat filter.json | agentinbox subscription add <source_id> --filter-stdin
 agentinbox source event <source_id> --native-id demo-1 --event local.demo
 agentinbox inbox read
 agentinbox inbox read --agent-id <agent_id>
+agentinbox inbox ack --agent-id <agent_id> --through <last_item_id>
 ```
+
+When acking a reviewed batch, prefer `--through <last_item_id>` over `--all`.
+That preserves the boundary of the items you actually inspected. Use
+`ack --all` only when you have intentionally verified that every current
+unacked item should be cleared.
 
 Update an existing source in place:
 

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -142,11 +142,23 @@ Read and ack the inbox:
 ```bash
 agentinbox inbox read
 agentinbox inbox read --agent-id <agentId>
+agentinbox inbox ack --agent-id <agentId> --through <lastItemId>
 agentinbox inbox watch
 agentinbox inbox watch --agent-id <agentId>
 agentinbox inbox ack --all
 agentinbox inbox ack --agent-id <agentId> --all
 ```
+
+Default to a batch-bounded ack flow:
+
+1. read the inbox items you intend to process
+2. identify the last item you actually reviewed in that batch
+3. ack with `--through <lastItemId>`
+
+Use `ack --all` only when you have explicitly verified that every current
+unacked item should be cleared and there is no need to preserve the reviewed
+batch boundary. Otherwise it can clear items that arrived after the read step
+or older pending items you did not intend to acknowledge yet.
 
 Manage activation targets:
 


### PR DESCRIPTION
Closes #95.

## Summary
- add a safer read-then-ack example to the README quick start using `inbox ack --through <last_item_id>`
- update the bundled `agentinbox` skill to recommend `ack --through` as the default batch-bounded ack path
- warn explicitly that `ack --all` should only be used when intentionally clearing every current unacked item

## Validation
- verified `README.md` now shows a batch-bounded `read` + `ack --through` flow
- verified `skills/agentinbox/SKILL.md` now recommends `ack --through` by default and warns about `ack --all`
