### PR TITLE
fix: use unacked totals in terminal prompts

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -1739,9 +1739,10 @@ export class AgentInboxService {
           });
           return "deferred";
         }
+        const totalUnackedCount = this.store.countInboxItems(inbox.inboxId, false);
         const prompt = renderAgentPrompt({
           inboxId: inbox.inboxId,
-          newItemCount: input.newItemCount,
+          totalUnackedCount,
           summary: input.summary,
         });
         await this.terminalDispatcher.dispatch(target, prompt);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -63,10 +63,11 @@ export function detectTerminalContext(env: NodeJS.ProcessEnv = process.env): Det
 
 export function renderAgentPrompt(input: {
   inboxId: string;
-  newItemCount: number;
+  totalUnackedCount: number;
   summary?: string | null;
 }): string {
-  const base = `AgentInbox: ${input.newItemCount} new items arrived in inbox ${input.inboxId}.`;
+  const itemWord = input.totalUnackedCount === 1 ? "item" : "items";
+  const base = `AgentInbox: ${input.totalUnackedCount} unacked ${itemWord} in inbox ${input.inboxId}.`;
   if (input.summary) {
     return `${base} Summary: ${input.summary}. Please read the inbox, process them, and ack when finished.`;
   }

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2405,6 +2405,72 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
   }
 });
 
+test("terminal activation prompts use the current unacked inbox total", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-unacked",
+      tmuxPaneId: "%52",
+      notifyLeaseMs: 100,
+    });
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-event-unacked-prompt",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-1",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.match(terminalDispatcher.calls[0]!.prompt, /AgentInbox: 1 unacked item in inbox/);
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-2",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    const allItems = service.listInboxItems(registered.agent.agentId, { includeAcked: false });
+    assert.equal(allItems.length, 2);
+
+    const ack = service.ackInboxItemsThrough(registered.agent.agentId, allItems[0]!.itemId);
+    assert.equal(ack.acked, 1);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 2);
+    assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 1 unacked item in inbox/);
+    assert.doesNotMatch(terminalDispatcher.calls[1]!.prompt, /2 new items arrived/);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("terminal target goes offline when dispatch fails and probe confirms disappearance", async () => {
   const terminalDispatcher = new FailingTerminalDispatcher();
   terminalDispatcher.probeResult = false;


### PR DESCRIPTION
## Summary
- use the current inbox unacked total when rendering terminal activation prompts
- change terminal prompt wording from batch-local "new items arrived" to current-state "unacked items in inbox"
- add an ack-gated regression test showing that a later prompt reflects the current remaining unacked total after partial ack

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "webhook and terminal targets share ack-gated notification flow|terminal activation prompts use the current unacked inbox total" test/agentinbox.test.ts
