### PR TITLE
feat: add agent and target resume recovery

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -243,6 +243,15 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "agent" && normalized[1] === "resume") {
+    const agentId = normalized[2];
+    if (!agentId) {
+      throw new Error("usage: agentinbox agent resume <agentId>");
+    }
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/resume`, {});
+    return;
+  }
+
   if (command === "agent" && normalized[1] === "target" && normalized[2] === "add" && normalized[3] === "webhook") {
     const agentId = normalized[4];
     const url = takeFlagValue(normalized, "--url");
@@ -273,6 +282,15 @@ async function main(): Promise<void> {
       throw new Error("usage: agentinbox agent target remove <agentId> <targetId>");
     }
     await printRemote(client, `/agents/${encodeURIComponent(agentId)}/targets/${encodeURIComponent(targetId)}`, undefined, "DELETE");
+    return;
+  }
+
+  if (command === "agent" && normalized[1] === "target" && normalized[2] === "resume") {
+    const [agentId, targetId] = normalized.slice(3, 5);
+    if (!agentId || !targetId) {
+      throw new Error("usage: agentinbox agent target resume <agentId> <targetId>");
+    }
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/targets/${encodeURIComponent(targetId)}/resume`, {});
     return;
   }
 
@@ -1016,9 +1034,11 @@ Usage:
   agentinbox agent current
   agentinbox agent show <agentId>
   agentinbox agent remove <agentId>
+  agentinbox agent resume <agentId>
   agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N]
   agentinbox agent target list <agentId>
   agentinbox agent target remove <agentId> <targetId>
+  agentinbox agent target resume <agentId> <targetId>
 `,
     timer: `agentinbox timer
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -516,6 +516,25 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.removeAgent(decodeURIComponent(params.agentId));
   });
 
+  app.post("/agents/:agentId/resume", {
+    schema: {
+      tags: ["agents"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    return service.resumeAgent(decodeURIComponent(params.agentId));
+  });
+
   app.get("/agents/:agentId/targets", {
     schema: {
       tags: ["agents"],
@@ -599,6 +618,26 @@ function buildFastifyServer(service: AgentInboxService) {
   }, async (request) => {
     const params = request.params as { agentId: string; targetId: string };
     return service.removeActivationTarget(decodeURIComponent(params.agentId), decodeURIComponent(params.targetId));
+  });
+
+  app.post("/agents/:agentId/targets/:targetId/resume", {
+    schema: {
+      tags: ["agents"],
+      params: {
+        type: "object",
+        required: ["agentId", "targetId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+          targetId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string; targetId: string };
+    return service.resumeActivationTarget(decodeURIComponent(params.agentId), decodeURIComponent(params.targetId));
   });
 
   app.get("/timers", {

--- a/src/service.ts
+++ b/src/service.ts
@@ -51,7 +51,12 @@ import { generateId, nowIso } from "./util";
 import { getSourceSchema } from "./source_schema";
 import { withResolvedIdentity } from "./source_resolution";
 import { matchSubscriptionFilter, validateSubscriptionFilter } from "./filter";
-import { assignedAgentIdFromContext, detectTerminalContext, renderAgentPrompt, TerminalDispatcher } from "./terminal";
+import {
+  assignedAgentIdFromContext,
+  detectTerminalContext,
+  renderAgentPrompt,
+  TerminalDispatcher,
+} from "./terminal";
 import { LifecycleSignal } from "./sources/remote_profiles";
 import { ActivationGate, DefaultActivationGate } from "./runtime_gate";
 
@@ -101,6 +106,27 @@ export interface InboxWatchSession {
   initialItems: InboxItem[];
   start(): void;
   close(): void;
+}
+
+type ResumeTargetReason =
+  | "already_active"
+  | "terminal_available"
+  | "terminal_busy"
+  | "terminal_gone"
+  | "probe_unknown"
+  | "webhook_resumed";
+
+export interface ResumeActivationTargetResult {
+  targetId: string;
+  resumed: boolean;
+  status: ActivationTarget["status"];
+  reason: ResumeTargetReason;
+}
+
+export interface ResumeAgentResult {
+  resumed: boolean;
+  agent: Agent;
+  targets: ResumeActivationTargetResult[];
 }
 
 export class AgentInboxService {
@@ -653,6 +679,59 @@ export class AgentInboxService {
     this.store.deleteActivationTarget(agentId, targetId);
     this.reconcileAgentStatus(agentId);
     return { removed: true };
+  }
+
+  async resumeAgent(agentId: string): Promise<ResumeAgentResult> {
+    this.getAgent(agentId);
+    const targets = this.store.listActivationTargetsForAgent(agentId);
+    const results: ResumeActivationTargetResult[] = [];
+    for (const target of targets) {
+      results.push(await this.resumeActivationTarget(agentId, target.targetId));
+    }
+    this.reconcileAgentStatus(agentId);
+    return {
+      resumed: results.some((result) => result.resumed),
+      agent: this.getAgent(agentId),
+      targets: results,
+    };
+  }
+
+  async resumeActivationTarget(agentId: string, targetId: string): Promise<ResumeActivationTargetResult> {
+    const target = this.getActivationTarget(targetId);
+    if (target.agentId !== agentId) {
+      throw new Error(`activation target ${targetId} does not belong to agent ${agentId}`);
+    }
+    if (target.status === "active") {
+      return {
+        targetId: target.targetId,
+        resumed: false,
+        status: target.status,
+        reason: "already_active",
+      };
+    }
+
+    let result: ResumeActivationTargetResult;
+    if (target.kind === "terminal") {
+      result = await this.resumeTerminalActivationTarget(target);
+    } else {
+      const now = nowIso();
+      this.store.updateActivationTargetRuntime(target.targetId, {
+        status: "active",
+        offlineSince: null,
+        consecutiveFailures: 0,
+        lastError: null,
+        updatedAt: now,
+        lastSeenAt: now,
+      });
+      result = {
+        targetId: target.targetId,
+        resumed: true,
+        status: "active",
+        reason: "webhook_resumed",
+      };
+    }
+    this.reconcileAgentStatus(agentId);
+    return result;
   }
 
   async registerSubscription(input: RegisterSubscriptionInput): Promise<Subscription> {
@@ -1907,6 +1986,47 @@ export class AgentInboxService {
       updatedAt: now,
       lastSeenAt: agent.lastSeenAt,
     });
+  }
+
+  private async resumeTerminalActivationTarget(target: TerminalActivationTarget): Promise<ResumeActivationTargetResult> {
+    const probeStatus = await this.terminalDispatcher.probeStatus(target);
+    const now = nowIso();
+    if (probeStatus === "available") {
+      this.store.updateActivationTargetRuntime(target.targetId, {
+        status: "active",
+        offlineSince: null,
+        consecutiveFailures: 0,
+        lastError: null,
+        updatedAt: now,
+        lastSeenAt: now,
+      });
+      return {
+        targetId: target.targetId,
+        resumed: true,
+        status: "active",
+        reason: "terminal_available",
+      };
+    }
+    if (probeStatus === "gone") {
+      this.store.updateActivationTargetRuntime(target.targetId, {
+        status: "offline",
+        offlineSince: target.offlineSince ?? now,
+        updatedAt: now,
+        lastError: target.lastError ?? "terminal gone",
+      });
+      return {
+        targetId: target.targetId,
+        resumed: false,
+        status: "offline",
+        reason: "terminal_gone",
+      };
+    }
+    return {
+      targetId: target.targetId,
+      resumed: false,
+      status: "offline",
+      reason: "probe_unknown",
+    };
   }
 
   private runLifecycleCleanupPass(nowMs: number): { removedSubscriptions: number; affectedSourceIds: string[] } {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,6 +15,8 @@ type ExecFileAsyncLike = (
   },
 ) => Promise<{ stdout: string; stderr: string }>;
 
+export type TerminalProbeStatus = "available" | "gone" | "unknown";
+
 export interface DetectedTerminalContext {
   runtimeKind: RuntimeKind;
   runtimeSessionId?: string | null;
@@ -123,28 +125,43 @@ export class TerminalDispatcher {
   }
 
   async probe(target: TerminalActivationTarget): Promise<boolean> {
+    return (await this.probeStatus(target)) === "available";
+  }
+
+  async probeStatus(target: TerminalActivationTarget): Promise<TerminalProbeStatus> {
     try {
       if (target.backend === "tmux") {
         if (!target.tmuxPaneId) {
-          return false;
+          return "unknown";
         }
         const result = await this.execAsync("tmux", ["display-message", "-p", "-t", target.tmuxPaneId, "#{pane_id}"]);
-        return result.stdout.trim() === target.tmuxPaneId;
+        return result.stdout.trim() === target.tmuxPaneId ? "available" : "gone";
       }
       if (target.backend === "iterm2") {
         const sessionId = normalizeOptionalString(target.itermSessionId);
         if (!sessionId) {
-          return false;
+          return "unknown";
         }
         const it2api = resolveIterm2ApiPath(this.options.iterm2ApiPath);
         const result = await this.execAsync(it2api, ["list-sessions"]);
-        return result.stdout.includes(sessionId);
+        return result.stdout.includes(sessionId) ? "available" : "gone";
       }
-    } catch {
-      return false;
+    } catch (error) {
+      if (target.backend === "tmux" && isTmuxMissingPaneError(error)) {
+        return "gone";
+      }
+      return "unknown";
     }
+    return "unknown";
+  }
+}
+
+function isTmuxMissingPaneError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
     return false;
   }
+  const candidate = `${error.message} ${"stderr" in error ? String((error as { stderr?: unknown }).stderr ?? "") : ""}`;
+  return candidate.includes("can't find pane");
 }
 
 function detectTty(env: NodeJS.ProcessEnv): string | null {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -11,7 +11,7 @@ import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { ActivationGate } from "../src/runtime_gate";
 import { UxcRemoteSourceClient } from "../src/sources/remote";
 import { AgentInboxStore } from "../src/store";
-import { TerminalDispatcher } from "../src/terminal";
+import { TerminalDispatcher, TerminalProbeStatus } from "../src/terminal";
 import { nowIso } from "../src/util";
 
 class RecordingActivationDispatcher extends ActivationDispatcher {
@@ -25,6 +25,7 @@ class RecordingActivationDispatcher extends ActivationDispatcher {
 class RecordingTerminalDispatcher extends TerminalDispatcher {
   public readonly calls: Array<{ target: TerminalActivationTarget; prompt: string }> = [];
   public probeResult = true;
+  public probeStatusResult: TerminalProbeStatus = "available";
 
   override async dispatch(target: TerminalActivationTarget, prompt: string): Promise<void> {
     this.calls.push({ target, prompt });
@@ -32,6 +33,10 @@ class RecordingTerminalDispatcher extends TerminalDispatcher {
 
   override async probe(_target: TerminalActivationTarget): Promise<boolean> {
     return this.probeResult;
+  }
+
+  override async probeStatus(_target: TerminalActivationTarget): Promise<TerminalProbeStatus> {
+    return this.probeStatusResult;
   }
 }
 
@@ -2551,6 +2556,210 @@ test("offline terminal gate marks the target offline before dispatch", async () 
     assert.equal(target?.status, "offline");
     assert.match(target?.lastError ?? "", /runtime gate: runtime_gone/);
     assert.equal(store.listActivationDispatchStatesForAgent(registered.agent.agentId).length, 0);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resumeActivationTarget restores an offline terminal target when the terminal is available", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  terminalDispatcher.probeStatusResult = "available";
+  const { store, service, dir } = await makeService({ terminalDispatcher });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-resume-ok",
+      tmuxPaneId: "%901",
+      notifyLeaseMs: 100,
+    });
+    const target = service.listActivationTargets(registered.agent.agentId)[0];
+    assert.equal(target?.kind, "terminal");
+    const offlineAt = "2026-04-01T00:00:00.000Z";
+    store.updateActivationTargetRuntime(target!.targetId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      consecutiveFailures: 2,
+      lastError: "probe bug",
+      updatedAt: offlineAt,
+    });
+    store.updateAgent(registered.agent.agentId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      runtimeKind: registered.agent.runtimeKind,
+      runtimeSessionId: registered.agent.runtimeSessionId,
+      updatedAt: offlineAt,
+      lastSeenAt: offlineAt,
+    });
+
+    const resumed = await service.resumeActivationTarget(registered.agent.agentId, target!.targetId);
+
+    assert.deepEqual(resumed, {
+      targetId: target!.targetId,
+      resumed: true,
+      status: "active",
+      reason: "terminal_available",
+    });
+    assert.equal(service.getActivationTarget(target!.targetId).status, "active");
+    assert.equal(service.getActivationTarget(target!.targetId).offlineSince, null);
+    assert.equal(service.getAgent(registered.agent.agentId).status, "active");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resumeActivationTarget keeps an offline terminal target offline when the terminal is gone", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  terminalDispatcher.probeStatusResult = "gone";
+  const { store, service, dir } = await makeService({ terminalDispatcher });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-resume-gone",
+      tmuxPaneId: "%902",
+      notifyLeaseMs: 100,
+    });
+    const target = service.listActivationTargets(registered.agent.agentId)[0];
+    const offlineAt = "2026-04-01T00:00:00.000Z";
+    store.updateActivationTargetRuntime(target!.targetId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      consecutiveFailures: 1,
+      lastError: "terminal unavailable",
+      updatedAt: offlineAt,
+    });
+    store.updateAgent(registered.agent.agentId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      runtimeKind: registered.agent.runtimeKind,
+      runtimeSessionId: registered.agent.runtimeSessionId,
+      updatedAt: offlineAt,
+      lastSeenAt: offlineAt,
+    });
+
+    const resumed = await service.resumeActivationTarget(registered.agent.agentId, target!.targetId);
+
+    assert.deepEqual(resumed, {
+      targetId: target!.targetId,
+      resumed: false,
+      status: "offline",
+      reason: "terminal_gone",
+    });
+    assert.equal(service.getActivationTarget(target!.targetId).status, "offline");
+    assert.equal(service.getAgent(registered.agent.agentId).status, "offline");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resumeActivationTarget returns a non-destructive result when terminal probe is unknown", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  terminalDispatcher.probeStatusResult = "unknown";
+  const { store, service, dir } = await makeService({ terminalDispatcher });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-resume-unknown",
+      tmuxPaneId: "%903",
+      notifyLeaseMs: 100,
+    });
+    const target = service.listActivationTargets(registered.agent.agentId)[0];
+    const offlineAt = "2026-04-01T00:00:00.000Z";
+    store.updateActivationTargetRuntime(target!.targetId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      consecutiveFailures: 1,
+      lastError: "probe unavailable",
+      updatedAt: offlineAt,
+    });
+    store.updateAgent(registered.agent.agentId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      runtimeKind: registered.agent.runtimeKind,
+      runtimeSessionId: registered.agent.runtimeSessionId,
+      updatedAt: offlineAt,
+      lastSeenAt: offlineAt,
+    });
+
+    const resumed = await service.resumeActivationTarget(registered.agent.agentId, target!.targetId);
+
+    assert.deepEqual(resumed, {
+      targetId: target!.targetId,
+      resumed: false,
+      status: "offline",
+      reason: "probe_unknown",
+    });
+    const after = service.getActivationTarget(target!.targetId);
+    assert.equal(after.status, "offline");
+    assert.equal(after.offlineSince, offlineAt);
+    assert.equal(after.lastError, "probe unavailable");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resumeAgent partially recovers mixed offline targets and reconciles agent status", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  terminalDispatcher.probeStatusResult = "gone";
+  const { store, service, dir } = await makeService({ terminalDispatcher });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-resume-mixed",
+      tmuxPaneId: "%904",
+      notifyLeaseMs: 100,
+    });
+    const webhook = service.addWebhookActivationTarget(registered.agent.agentId, {
+      url: "http://127.0.0.1:8787/hook",
+    });
+    const terminal = service.listActivationTargets(registered.agent.agentId).find((target) => target.kind === "terminal");
+    const offlineAt = "2026-04-01T00:00:00.000Z";
+    store.updateActivationTargetRuntime(terminal!.targetId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      consecutiveFailures: 1,
+      lastError: "terminal unavailable",
+      updatedAt: offlineAt,
+    });
+    store.updateActivationTargetRuntime(webhook.targetId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      consecutiveFailures: 1,
+      lastError: "webhook failure",
+      updatedAt: offlineAt,
+    });
+    store.updateAgent(registered.agent.agentId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      runtimeKind: registered.agent.runtimeKind,
+      runtimeSessionId: registered.agent.runtimeSessionId,
+      updatedAt: offlineAt,
+      lastSeenAt: offlineAt,
+    });
+
+    const resumed = await service.resumeAgent(registered.agent.agentId);
+
+    assert.equal(resumed.resumed, true);
+    assert.equal(resumed.agent.status, "active");
+    assert.equal(resumed.targets.length, 2);
+    assert.deepEqual(
+      resumed.targets.map((entry) => [entry.targetId, entry.resumed, entry.status, entry.reason]).sort(),
+      [
+        [terminal!.targetId, false, "offline", "terminal_gone"],
+        [webhook.targetId, true, "active", "webhook_resumed"],
+      ].sort(),
+    );
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -832,6 +832,48 @@ test("cli inbox send writes a direct text message into the target inbox", () => 
   }
 });
 
+test("cli agent resume and target resume commands are available", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-agent-resume-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%964",
+    CODEX_THREAD_ID: "thread-agent-resume-cli",
+  };
+
+  try {
+    const register = runCli(["agent", "register"], env);
+    assert.equal(register.status, 0, register.stderr);
+    const registered = JSON.parse(register.stdout) as { agent: { agentId: string }; terminalTarget: { targetId: string } };
+
+    const targetResume = runCli([
+      "agent",
+      "target",
+      "resume",
+      registered.agent.agentId,
+      registered.terminalTarget.targetId,
+    ], env);
+    assert.equal(targetResume.status, 0, targetResume.stderr);
+    const targetPayload = JSON.parse(targetResume.stdout) as { resumed: boolean; status: string; reason: string };
+    assert.equal(targetPayload.resumed, false);
+    assert.equal(targetPayload.status, "active");
+    assert.equal(targetPayload.reason, "already_active");
+
+    const agentResume = runCli(["agent", "resume", registered.agent.agentId], env);
+    assert.equal(agentResume.status, 0, agentResume.stderr);
+    const agentPayload = JSON.parse(agentResume.stdout) as { resumed: boolean; agent: { status: string }; targets: Array<{ reason: string }> };
+    assert.equal(agentPayload.resumed, false);
+    assert.equal(agentPayload.agent.status, "active");
+    assert.equal(agentPayload.targets[0]?.reason, "already_active");
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli timer add and list manage agent-bound reminder timers", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-timer-"));
   const env = {
@@ -2156,6 +2198,100 @@ test("control plane can remove agents and gc stale offline agents", async () => 
       const gcResponse = await client.request<{ removedAgents: number } & { deleted?: number }>("/gc", {});
       assert.equal(gcResponse.statusCode, 200);
       assert.equal(gcResponse.data.removedAgents, 1);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane exposes target and agent resume for offline recovery", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-resume-"));
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  const terminalDispatcher = new class extends TerminalDispatcher {
+    override async probeStatus(): Promise<"available" | "gone" | "unknown"> {
+      return "available";
+    }
+  }(async () => ({ stdout: "", stderr: "" }));
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, terminalDispatcher);
+  const server = createServer(service);
+  await adapters.start();
+  await service.start();
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const registered = await client.request<{ agent: { agentId: string } }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-resume",
+        tmuxPaneId: "%950",
+        notifyLeaseMs: 200,
+      });
+      const agentId = registered.data.agent.agentId;
+      const target = service.listActivationTargets(agentId)[0];
+      const offlineAt = "2026-04-01T00:00:00.000Z";
+      store.updateActivationTargetRuntime(target!.targetId, {
+        status: "offline",
+        offlineSince: offlineAt,
+        consecutiveFailures: 2,
+        lastError: "probe bug",
+        updatedAt: offlineAt,
+      });
+      store.updateAgent(agentId, {
+        status: "offline",
+        offlineSince: offlineAt,
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-resume",
+        updatedAt: offlineAt,
+        lastSeenAt: offlineAt,
+      });
+
+      const targetResume = await client.request<{ resumed: boolean; status: string; reason: string }>(
+        `/agents/${encodeURIComponent(agentId)}/targets/${encodeURIComponent(target!.targetId)}/resume`,
+        {},
+      );
+      assert.equal(targetResume.statusCode, 200);
+      assert.equal(targetResume.data.resumed, true);
+      assert.equal(targetResume.data.status, "active");
+      assert.equal(targetResume.data.reason, "terminal_available");
+
+      store.updateActivationTargetRuntime(target!.targetId, {
+        status: "offline",
+        offlineSince: offlineAt,
+        consecutiveFailures: 1,
+        lastError: "probe bug again",
+        updatedAt: offlineAt,
+      });
+      store.updateAgent(agentId, {
+        status: "offline",
+        offlineSince: offlineAt,
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-resume",
+        updatedAt: offlineAt,
+        lastSeenAt: offlineAt,
+      });
+
+      const agentResume = await client.request<{ resumed: boolean; agent: { status: string }; targets: Array<{ resumed: boolean }> }>(
+        `/agents/${encodeURIComponent(agentId)}/resume`,
+        {},
+      );
+      assert.equal(agentResume.statusCode, 200);
+      assert.equal(agentResume.data.resumed, true);
+      assert.equal(agentResume.data.agent.status, "active");
+      assert.equal(agentResume.data.targets.length, 1);
+      assert.equal(agentResume.data.targets[0]?.resumed, true);
     } finally {
       await started.close();
     }

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -155,3 +155,43 @@ test("TerminalDispatcher uses literal text plus carriage return for tmux targets
     "\r",
   ]);
 });
+
+test("TerminalDispatcher probeStatus distinguishes tmux available, gone, and unknown", async () => {
+  const target: TerminalActivationTarget = {
+    targetId: "tgt_tmux_probe",
+    agentId: "agent_codex_tmux",
+    kind: "terminal",
+    status: "offline",
+    offlineSince: "2026-04-07T00:00:00.000Z",
+    consecutiveFailures: 1,
+    lastDeliveredAt: null,
+    lastError: "probe bug",
+    mode: "agent_prompt",
+    notifyLeaseMs: 600000,
+    runtimeKind: "codex",
+    runtimeSessionId: "thread-tmux-probe",
+    backend: "tmux",
+    tmuxPaneId: "%2",
+    tty: null,
+    termProgram: "tmux",
+    itermSessionId: null,
+    createdAt: "2026-04-07T00:00:00.000Z",
+    updatedAt: "2026-04-07T00:00:00.000Z",
+    lastSeenAt: "2026-04-07T00:00:00.000Z",
+  };
+
+  const available = new TerminalDispatcher(async () => ({ stdout: "%2\n", stderr: "" }));
+  assert.equal(await available.probeStatus(target), "available");
+
+  const gone = new TerminalDispatcher(async () => {
+    const error = new Error("can't find pane: %2") as Error & { stderr?: string };
+    error.stderr = "can't find pane: %2";
+    throw error;
+  });
+  assert.equal(await gone.probeStatus(target), "gone");
+
+  const unknown = new TerminalDispatcher(async () => {
+    throw new Error("tmux unavailable");
+  });
+  assert.equal(await unknown.probeStatus(target), "unknown");
+});


### PR DESCRIPTION
Closes #92.

## Summary
- add `agentinbox agent resume <agentId>` and `agentinbox agent target resume <agentId> <targetId>`
- add matching HTTP control-plane endpoints for agent-level and target-level resume
- teach terminal recovery to probe `available / gone / unknown` before restoring offline terminal targets
- reconcile agent status after resume attempts and support partial recovery across mixed targets

## Validation
- `npm run build`
- `node --require ts-node/register --test test/terminal.test.ts`
- `node --require ts-node/register --test --test-name-pattern "resumeActivationTarget restores an offline terminal target when the terminal is available|resumeActivationTarget keeps an offline terminal target offline when the terminal is gone|resumeActivationTarget returns a non-destructive result when terminal probe is unknown|resumeAgent partially recovers mixed offline targets and reconciles agent status|control plane exposes target and agent resume for offline recovery|cli agent resume and target resume commands are available" test/agentinbox.test.ts test/control_plane.test.ts`
