### PR TITLE
fix: land activation prompt follow-up

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -1670,10 +1670,12 @@ export class AgentInboxService {
     try {
       const state = this.store.getActivationDispatchState(buffer.agentId, buffer.targetId);
       if (!state) {
+        const inbox = this.ensureInboxForAgent(buffer.agentId);
         const dispatched = await this.dispatchActivationTarget({
           agentId: buffer.agentId,
           targetId: buffer.targetId,
           newItemCount: entries.length,
+          totalUnackedCount: this.store.countInboxItems(inbox.inboxId, false),
           summary: entries[0]?.summary ?? null,
           subscriptionIds: uniqueSortedNullable(entries.map((entry) => entry.subscriptionId)),
           sourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
@@ -1751,6 +1753,7 @@ export class AgentInboxService {
       agentId,
       targetId,
       newItemCount: state.pendingNewItemCount > 0 ? state.pendingNewItemCount : unacked,
+      totalUnackedCount: unacked,
       summary: state.pendingSummary,
       subscriptionIds: state.pendingSubscriptionIds,
       sourceIds: state.pendingSourceIds,
@@ -1785,6 +1788,7 @@ export class AgentInboxService {
     agentId: string;
     targetId: string;
     newItemCount: number;
+    totalUnackedCount?: number;
     summary: string | null;
     subscriptionIds: string[];
     sourceIds: string[];
@@ -1796,6 +1800,7 @@ export class AgentInboxService {
     }
     const inbox = this.ensureInboxForAgent(input.agentId);
     const summary = summarizeActivation(inbox.inboxId, input.newItemCount, input.summary);
+    const totalUnackedCount = input.totalUnackedCount ?? this.store.countInboxItems(inbox.inboxId, false);
     try {
       if (target.kind === "terminal") {
         const gate = await this.activationGate.evaluate(target);
@@ -1818,7 +1823,6 @@ export class AgentInboxService {
           });
           return "deferred";
         }
-        const totalUnackedCount = this.store.countInboxItems(inbox.inboxId, false);
         const prompt = renderAgentPrompt({
           inboxId: inbox.inboxId,
           totalUnackedCount,

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -65,11 +65,13 @@ export function detectTerminalContext(env: NodeJS.ProcessEnv = process.env): Det
 
 export function renderAgentPrompt(input: {
   inboxId: string;
-  totalUnackedCount: number;
+  totalUnackedCount?: number;
+  newItemCount?: number;
   summary?: string | null;
 }): string {
-  const itemWord = input.totalUnackedCount === 1 ? "item" : "items";
-  const base = `AgentInbox: ${input.totalUnackedCount} unacked ${itemWord} in inbox ${input.inboxId}.`;
+  const totalUnackedCount = input.totalUnackedCount ?? input.newItemCount ?? 0;
+  const itemWord = totalUnackedCount === 1 ? "item" : "items";
+  const base = `AgentInbox: ${totalUnackedCount} unacked ${itemWord} in inbox ${input.inboxId}.`;
   if (input.summary) {
     return `${base} Summary: ${input.summary}. Please read the inbox, process them, and ack when finished.`;
   }

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { assignedAgentIdFromContext, detectTerminalContext, TerminalDispatcher } from "../src/terminal";
+import { assignedAgentIdFromContext, detectTerminalContext, renderAgentPrompt, TerminalDispatcher } from "../src/terminal";
 import { TerminalActivationTarget } from "../src/model";
 
 test("detectTerminalContext derives codex runtime and iTerm2 session", () => {
@@ -41,6 +41,18 @@ test("assignedAgentIdFromContext prefers runtime session ids", () => {
   });
 
   assert.equal(agentId, "agent_codex_019d57fd65247e20a850a89e81957100");
+});
+
+test("renderAgentPrompt accepts legacy newItemCount input", () => {
+  const prompt = renderAgentPrompt({
+    inboxId: "inbox_123",
+    newItemCount: 1,
+  });
+
+  assert.equal(
+    prompt,
+    "AgentInbox: 1 unacked item in inbox inbox_123. Please read the inbox, process them, and ack when finished.",
+  );
 });
 
 test("TerminalDispatcher uses two-step it2api submission for iTerm2 targets", async () => {


### PR DESCRIPTION
## Summary
- land the review follow-up that missed PR #100
- keep `renderAgentPrompt()` backward-compatible with legacy `newItemCount`
- thread already-known unacked totals into terminal prompt dispatch to avoid redundant count queries

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "terminal activation prompts use the current unacked inbox total|webhook and terminal targets share ack-gated notification flow|renderAgentPrompt accepts legacy newItemCount input" test/agentinbox.test.ts test/terminal.test.ts

## Context
PR #100 merged before commit `d577c27` landed, so this PR carries only that follow-up change.