### PR TITLE
fix: deduplicate unchanged terminal reminders

### DIFF
--- a/drizzle/migrations/0007_activation_dispatch_last_notified_fingerprint.sql
+++ b/drizzle/migrations/0007_activation_dispatch_last_notified_fingerprint.sql
@@ -1,0 +1,2 @@
+alter table activation_dispatch_states
+  add column last_notified_fingerprint text;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -122,6 +122,7 @@ export const activationDispatchStates = sqliteTable("activation_dispatch_states"
   targetId: text("target_id").notNull(),
   status: text("status").notNull(),
   leaseExpiresAt: text("lease_expires_at"),
+  lastNotifiedFingerprint: text("last_notified_fingerprint"),
   pendingNewItemCount: integer("pending_new_item_count").notNull(),
   pendingSummary: text("pending_summary"),
   pendingSubscriptionIdsJson: text("pending_subscription_ids_json").notNull(),

--- a/src/model.ts
+++ b/src/model.ts
@@ -133,6 +133,7 @@ export interface ActivationDispatchState {
   targetId: string;
   status: ActivationDispatchStatus;
   leaseExpiresAt: string | null;
+  lastNotifiedFingerprint: string | null;
   pendingNewItemCount: number;
   pendingSummary: string | null;
   pendingSubscriptionIds: string[];

--- a/src/service.ts
+++ b/src/service.ts
@@ -37,6 +37,7 @@ import {
   WatchInboxOptions,
   WebhookActivationTarget,
 } from "./model";
+import { createHash } from "node:crypto";
 import { AgentInboxStore } from "./store";
 import { AdapterRegistry } from "./adapters";
 import {
@@ -1671,15 +1672,26 @@ export class AgentInboxService {
       const state = this.store.getActivationDispatchState(buffer.agentId, buffer.targetId);
       if (!state) {
         const inbox = this.ensureInboxForAgent(buffer.agentId);
+        const unackedItems = this.store.listInboxItems(inbox.inboxId, { includeAcked: false }).map((item) => ({
+          itemId: item.itemId,
+          sourceId: item.sourceId,
+          sourceNativeId: item.sourceNativeId,
+          eventVariant: item.eventVariant,
+          inboxId: item.inboxId,
+          occurredAt: item.occurredAt,
+          metadata: item.metadata,
+          rawPayload: item.rawPayload,
+          deliveryHandle: item.deliveryHandle,
+        }));
         const dispatched = await this.dispatchActivationTarget({
           agentId: buffer.agentId,
           targetId: buffer.targetId,
           newItemCount: entries.length,
-          totalUnackedCount: this.store.countInboxItems(inbox.inboxId, false),
-          summary: entries[0]?.summary ?? null,
+          totalUnackedCount: unackedItems.length,
+          summary: latestSummary(entries),
           subscriptionIds: uniqueSortedNullable(entries.map((entry) => entry.subscriptionId)),
           sourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
-          items: entries.map((entry) => entry.item),
+          items: unackedItems,
         });
         if (dispatched === "retryable_failure") {
           this.upsertDirtyDispatchState(buffer.agentId, buffer.targetId, entries);
@@ -2676,11 +2688,14 @@ function terminalReminderFingerprint(
   summary: string | null,
   items: ActivationItem[],
 ): string {
-  return JSON.stringify({
+  const payload = JSON.stringify({
     totalUnackedCount,
     summary: summary ?? null,
-    itemIds: items.map((item) => item.itemId),
+    itemIds: items
+      .map((item) => item.itemId)
+      .sort((left, right) => left.localeCompare(right)),
   });
+  return createHash("sha256").update(payload).digest("hex");
 }
 
 function summarizeSourceEvent(sourceType: string, sourceKey: string, eventVariant: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -100,7 +100,7 @@ interface InboxWatcher {
   onItems(items: InboxItem[]): void;
 }
 
-type ActivationDispatchOutcome = "dispatched" | "retryable_failure" | "offline" | "deferred";
+type ActivationDispatchOutcome = "dispatched" | "retryable_failure" | "offline" | "deferred" | "suppressed";
 
 export interface InboxWatchSession {
   initialItems: InboxItem[];
@@ -1690,8 +1690,9 @@ export class AgentInboxService {
           targetId: buffer.targetId,
           status: "dirty",
           leaseExpiresAt: state.leaseExpiresAt,
+          lastNotifiedFingerprint: state.lastNotifiedFingerprint,
           pendingNewItemCount: state.pendingNewItemCount + entries.length,
-          pendingSummary: state.pendingSummary ?? entries[0]?.summary ?? null,
+          pendingSummary: latestSummary(entries) ?? state.pendingSummary,
           pendingSubscriptionIds: uniqueSortedNullable([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)]),
           pendingSourceIds: uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)]),
           updatedAt: nowIso(),
@@ -1748,6 +1749,19 @@ export class AgentInboxService {
     if (reason === "ack" && state.status !== "dirty") {
       return;
     }
+    if (reason === "lease" && state.status === "notified") {
+      const target = this.getActivationTarget(targetId);
+      if (target.kind !== "terminal") {
+        // Webhook targets keep the existing lease-based behavior.
+      } else {
+        this.store.upsertActivationDispatchState({
+          ...state,
+          leaseExpiresAt: new Date(Date.now() + target.notifyLeaseMs).toISOString(),
+          updatedAt: nowIso(),
+        });
+        return;
+      }
+    }
 
     const dispatched = await this.dispatchActivationTarget({
       agentId,
@@ -1798,6 +1812,7 @@ export class AgentInboxService {
     if (target.status === "offline") {
       return "offline";
     }
+    const state = this.store.getActivationDispatchState(input.agentId, input.targetId);
     const inbox = this.ensureInboxForAgent(input.agentId);
     const summary = summarizeActivation(inbox.inboxId, input.newItemCount, input.summary);
     const totalUnackedCount = input.totalUnackedCount ?? this.store.countInboxItems(inbox.inboxId, false);
@@ -1815,6 +1830,7 @@ export class AgentInboxService {
             targetId: input.targetId,
             status: "dirty",
             leaseExpiresAt: new Date(Date.now() + DEFAULT_NOTIFY_RETRY_MS).toISOString(),
+            lastNotifiedFingerprint: state?.lastNotifiedFingerprint ?? null,
             pendingNewItemCount: input.newItemCount,
             pendingSummary: input.summary,
             pendingSubscriptionIds: uniqueSortedNullable(input.subscriptionIds),
@@ -1822,6 +1838,22 @@ export class AgentInboxService {
             updatedAt: nowIso(),
           });
           return "deferred";
+        }
+        const promptFingerprint = terminalReminderFingerprint(totalUnackedCount, input.summary, input.items);
+        if (state?.status === "dirty" && state.lastNotifiedFingerprint === promptFingerprint) {
+          this.store.upsertActivationDispatchState({
+            agentId: input.agentId,
+            targetId: input.targetId,
+            status: "notified",
+            leaseExpiresAt: new Date(Date.now() + target.notifyLeaseMs).toISOString(),
+            lastNotifiedFingerprint: promptFingerprint,
+            pendingNewItemCount: 0,
+            pendingSummary: null,
+            pendingSubscriptionIds: [],
+            pendingSourceIds: [],
+            updatedAt: nowIso(),
+          });
+          return "suppressed";
         }
         const prompt = renderAgentPrompt({
           inboxId: inbox.inboxId,
@@ -1857,6 +1889,9 @@ export class AgentInboxService {
         targetId: input.targetId,
         status: "notified",
         leaseExpiresAt: new Date(Date.now() + target.notifyLeaseMs).toISOString(),
+        lastNotifiedFingerprint: target.kind === "terminal"
+          ? terminalReminderFingerprint(totalUnackedCount, input.summary, input.items)
+          : state?.lastNotifiedFingerprint ?? null,
         pendingNewItemCount: 0,
         pendingSummary: null,
         pendingSubscriptionIds: [],
@@ -1890,8 +1925,9 @@ export class AgentInboxService {
       targetId,
       status: "dirty",
       leaseExpiresAt: new Date(Date.now() + DEFAULT_NOTIFY_RETRY_MS).toISOString(),
+      lastNotifiedFingerprint: this.store.getActivationDispatchState(agentId, targetId)?.lastNotifiedFingerprint ?? null,
       pendingNewItemCount: entries.length,
-      pendingSummary: entries[0]?.summary ?? null,
+      pendingSummary: latestSummary(entries),
       pendingSubscriptionIds: uniqueSortedNullable(entries.map((entry) => entry.subscriptionId)),
       pendingSourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
       updatedAt: nowIso(),
@@ -2623,6 +2659,28 @@ function summarizeActivation(inboxId: string, newItemCount: number, firstSummary
     return `${newItemCount} new ${itemWord} in ${inboxId} from ${firstSummary}`;
   }
   return `${newItemCount} new ${itemWord} in ${inboxId}`;
+}
+
+function latestSummary(entries: Array<{ summary: string | null }>): string | null {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const summary = entries[index]?.summary;
+    if (summary) {
+      return summary;
+    }
+  }
+  return null;
+}
+
+function terminalReminderFingerprint(
+  totalUnackedCount: number,
+  summary: string | null,
+  items: ActivationItem[],
+): string {
+  return JSON.stringify({
+    totalUnackedCount,
+    summary: summary ?? null,
+    itemIds: items.map((item) => item.itemId),
+  });
 }
 
 function summarizeSourceEvent(sourceType: string, sourceKey: string, eventVariant: string): string {

--- a/src/store.ts
+++ b/src/store.ts
@@ -992,12 +992,13 @@ export class AgentInboxStore {
     this.db.run(
       `
       insert into activation_dispatch_states (
-        agent_id, target_id, status, lease_expires_at, pending_new_item_count, pending_summary,
+        agent_id, target_id, status, lease_expires_at, last_notified_fingerprint, pending_new_item_count, pending_summary,
         pending_subscription_ids_json, pending_source_ids_json, updated_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       on conflict(agent_id, target_id) do update set
         status = excluded.status,
         lease_expires_at = excluded.lease_expires_at,
+        last_notified_fingerprint = excluded.last_notified_fingerprint,
         pending_new_item_count = excluded.pending_new_item_count,
         pending_summary = excluded.pending_summary,
         pending_subscription_ids_json = excluded.pending_subscription_ids_json,
@@ -1009,6 +1010,7 @@ export class AgentInboxStore {
         state.targetId,
         state.status,
         state.leaseExpiresAt ?? null,
+        state.lastNotifiedFingerprint ?? null,
         state.pendingNewItemCount,
         state.pendingSummary ?? null,
         JSON.stringify(state.pendingSubscriptionIds),
@@ -1633,6 +1635,7 @@ export class AgentInboxStore {
       targetId: String(row.target_id),
       status: row.status as ActivationDispatchState["status"],
       leaseExpiresAt: row.lease_expires_at ? String(row.lease_expires_at) : null,
+      lastNotifiedFingerprint: row.last_notified_fingerprint ? String(row.last_notified_fingerprint) : null,
       pendingNewItemCount: Number(row.pending_new_item_count),
       pendingSummary: row.pending_summary ? String(row.pending_summary) : null,
       pendingSubscriptionIds: parseJson<string[]>(row.pending_subscription_ids_json as string),

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -184,7 +184,7 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 7);
+    assert.equal(state.appliedCount, 8);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 0);
@@ -201,7 +201,7 @@ test("store upgrades a legacy v12 database with backup and forward migration", a
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 7);
+    assert.equal(state.appliedCount, 8);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 1);
@@ -1491,6 +1491,7 @@ test("subscription remove preserves unrelated activation dispatch state", async 
       targetId: registered.terminalTarget.targetId,
       status: "notified",
       leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+      lastNotifiedFingerprint: null,
       pendingNewItemCount: 1,
       pendingSummary: "standing-subscription",
       pendingSubscriptionIds: [first.subscriptionId],
@@ -2469,6 +2470,127 @@ test("terminal activation prompts use the current unacked inbox total", async ()
     assert.equal(terminalDispatcher.calls.length, 2);
     assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 1 unacked item in inbox/);
     assert.doesNotMatch(terminalDispatcher.calls[1]!.prompt, /2 new items arrived/);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("lease expiry does not repeat identical terminal prompts for unchanged inbox state", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-terminal-reminder-dedupe",
+      tmuxPaneId: "%53",
+      notifyLeaseMs: 50,
+    });
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-event-terminal-reminder-dedupe",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-reminder-1",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+
+    await sleep(70);
+    await (service as any).syncActivationDispatchStates();
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    const state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    assert.ok(state);
+    assert.equal(state.status, "notified");
+    assert.ok(state.leaseExpiresAt);
+    assert.ok(Date.parse(state.leaseExpiresAt!) > Date.parse(state.updatedAt));
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("dirty terminal reminders re-notify only when the effective prompt changes", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-terminal-reminder-changes",
+      tmuxPaneId: "%54",
+      notifyLeaseMs: 50,
+    });
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-event-terminal-reminder-changes",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-change-1",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-change-2",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+
+    await sleep(70);
+    await (service as any).syncActivationDispatchStates();
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 2);
+    assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 2 unacked items in inbox/);
+    const state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    assert.ok(state?.lastNotifiedFingerprint);
+    assert.equal(state?.pendingNewItemCount, 0);
+    assert.equal(state?.pendingSummary, null);
   } finally {
     await service.stop();
     store.close();

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2598,6 +2598,73 @@ test("dirty terminal reminders re-notify only when the effective prompt changes"
   }
 });
 
+test("terminal reminder fingerprints use the canonical unacked item set", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-terminal-reminder-canonical-items",
+      tmuxPaneId: "%55",
+      notifyLeaseMs: 50,
+    });
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-event-terminal-reminder-canonical-items",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-canonical-1",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    const initialState = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    assert.ok(initialState?.lastNotifiedFingerprint);
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-canonical-2",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+
+    const allItems = service.listInboxItems(registered.agent.agentId, { includeAcked: false });
+    assert.equal(allItems.length, 2);
+    service.ackInboxItemsThrough(registered.agent.agentId, allItems[0]!.itemId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 2);
+    const updatedState = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    assert.ok(updatedState?.lastNotifiedFingerprint);
+    assert.notEqual(updatedState?.lastNotifiedFingerprint, initialState?.lastNotifiedFingerprint);
+    assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 1 unacked item in inbox/);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("terminal target goes offline when dispatch fails and probe confirms disappearance", async () => {
   const terminalDispatcher = new FailingTerminalDispatcher();
   terminalDispatcher.probeResult = false;


### PR DESCRIPTION
## Summary
- suppress lease-based terminal re-prompts when the unacked inbox state is unchanged
- track a terminal reminder fingerprint in activation dispatch state so dirty reminder updates only re-notify when the effective prompt changed
- coalesce pending terminal reminder summary state to the latest effective summary before dispatch

## Testing
- `npm run build`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern "store migrates a new database using drizzle SQL migrations|store upgrades a legacy v12 database with backup and forward migration|lease expiry does not repeat identical terminal prompts for unchanged inbox state|dirty terminal reminders re-notify only when the effective prompt changes|terminal activation prompts use the current unacked inbox total|webhook and terminal targets share ack-gated notification flow" test/agentinbox.test.ts`

## Notes
- lease suppression is terminal-only; webhook activation lease behavior stays unchanged
- fingerprinting includes the current unacked item ids, so replacing one unacked item with another still produces a fresh prompt even when the count stays the same