### PR TITLE
feat: inline single-item terminal previews

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -1863,7 +1863,7 @@ export class AgentInboxService {
           preview,
         });
         terminalPrompt = prompt;
-        const promptFingerprint = terminalReminderFingerprint(prompt);
+        const promptFingerprint = terminalReminderFingerprint(prompt, input.items);
         if (state?.status === "dirty" && state.lastNotifiedFingerprint === promptFingerprint) {
           this.store.upsertActivationDispatchState({
             agentId: input.agentId,
@@ -1909,7 +1909,7 @@ export class AgentInboxService {
         status: "notified",
         leaseExpiresAt: new Date(Date.now() + target.notifyLeaseMs).toISOString(),
         lastNotifiedFingerprint: target.kind === "terminal"
-          ? terminalReminderFingerprint(terminalPrompt ?? "")
+          ? terminalReminderFingerprint(terminalPrompt ?? "", input.items)
           : state?.lastNotifiedFingerprint ?? null,
         pendingNewItemCount: 0,
         pendingSummary: null,
@@ -2690,8 +2690,14 @@ function latestSummary(entries: Array<{ summary: string | null }>): string | nul
   return null;
 }
 
-function terminalReminderFingerprint(prompt: string): string {
-  return createHash("sha256").update(prompt).digest("hex");
+function terminalReminderFingerprint(prompt: string, items: ActivationItem[]): string {
+  const payload = JSON.stringify({
+    prompt,
+    itemIds: items
+      .map((item) => item.itemId)
+      .sort((left, right) => left.localeCompare(right)),
+  });
+  return createHash("sha256").update(payload).digest("hex");
 }
 
 function summarizeSourceEvent(sourceType: string, sourceKey: string, eventVariant: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -1829,6 +1829,7 @@ export class AgentInboxService {
     const inbox = this.ensureInboxForAgent(input.agentId);
     const summary = summarizeActivation(inbox.inboxId, input.newItemCount, input.summary);
     const totalUnackedCount = input.totalUnackedCount ?? this.store.countInboxItems(inbox.inboxId, false);
+    let terminalPrompt: string | null = null;
     try {
       if (target.kind === "terminal") {
         const gate = await this.activationGate.evaluate(target);
@@ -1852,7 +1853,17 @@ export class AgentInboxService {
           });
           return "deferred";
         }
-        const promptFingerprint = terminalReminderFingerprint(totalUnackedCount, input.summary, input.items);
+        const preview = totalUnackedCount === 1 && input.items.length === 1
+          ? deriveInlineItemPreview(input.items[0], input.summary)
+          : null;
+        const prompt = renderAgentPrompt({
+          inboxId: inbox.inboxId,
+          totalUnackedCount,
+          summary: input.summary,
+          preview,
+        });
+        terminalPrompt = prompt;
+        const promptFingerprint = terminalReminderFingerprint(prompt);
         if (state?.status === "dirty" && state.lastNotifiedFingerprint === promptFingerprint) {
           this.store.upsertActivationDispatchState({
             agentId: input.agentId,
@@ -1868,14 +1879,6 @@ export class AgentInboxService {
           });
           return "suppressed";
         }
-        const prompt = renderAgentPrompt({
-          inboxId: inbox.inboxId,
-          totalUnackedCount,
-          summary: input.summary,
-          preview: totalUnackedCount === 1 && input.items.length === 1
-            ? deriveInlineItemPreview(input.items[0], input.summary)
-            : null,
-        });
         await this.terminalDispatcher.dispatch(target, prompt);
       } else {
         const activation: Activation = {
@@ -1906,7 +1909,7 @@ export class AgentInboxService {
         status: "notified",
         leaseExpiresAt: new Date(Date.now() + target.notifyLeaseMs).toISOString(),
         lastNotifiedFingerprint: target.kind === "terminal"
-          ? terminalReminderFingerprint(totalUnackedCount, input.summary, input.items)
+          ? terminalReminderFingerprint(terminalPrompt ?? "")
           : state?.lastNotifiedFingerprint ?? null,
         pendingNewItemCount: 0,
         pendingSummary: null,
@@ -2687,19 +2690,8 @@ function latestSummary(entries: Array<{ summary: string | null }>): string | nul
   return null;
 }
 
-function terminalReminderFingerprint(
-  totalUnackedCount: number,
-  summary: string | null,
-  items: ActivationItem[],
-): string {
-  const payload = JSON.stringify({
-    totalUnackedCount,
-    summary: summary ?? null,
-    itemIds: items
-      .map((item) => item.itemId)
-      .sort((left, right) => left.localeCompare(right)),
-  });
-  return createHash("sha256").update(payload).digest("hex");
+function terminalReminderFingerprint(prompt: string): string {
+  return createHash("sha256").update(prompt).digest("hex");
 }
 
 function summarizeSourceEvent(sourceType: string, sourceKey: string, eventVariant: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -54,6 +54,7 @@ import { withResolvedIdentity } from "./source_resolution";
 import { matchSubscriptionFilter, validateSubscriptionFilter } from "./filter";
 import {
   assignedAgentIdFromContext,
+  deriveInlineItemPreview,
   detectTerminalContext,
   renderAgentPrompt,
   TerminalDispatcher,
@@ -1871,6 +1872,9 @@ export class AgentInboxService {
           inboxId: inbox.inboxId,
           totalUnackedCount,
           summary: input.summary,
+          preview: totalUnackedCount === 1 && input.items.length === 1
+            ? deriveInlineItemPreview(input.items[0], input.summary)
+            : null,
         });
         await this.terminalDispatcher.dispatch(target, prompt);
       } else {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4,7 +4,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { RuntimeKind, TerminalActivationTarget, TerminalBackend } from "./model";
+import { ActivationItem, RuntimeKind, TerminalActivationTarget, TerminalBackend } from "./model";
 
 const execFileAsync = promisify(execFile);
 type ExecFileAsyncLike = (
@@ -68,14 +68,47 @@ export function renderAgentPrompt(input: {
   totalUnackedCount?: number;
   newItemCount?: number;
   summary?: string | null;
+  preview?: string | null;
 }): string {
   const totalUnackedCount = input.totalUnackedCount ?? input.newItemCount ?? 0;
   const itemWord = totalUnackedCount === 1 ? "item" : "items";
   const base = `AgentInbox: ${totalUnackedCount} unacked ${itemWord} in inbox ${input.inboxId}.`;
+  if (totalUnackedCount === 1 && input.preview) {
+    return `${base} Preview: ${input.preview}. Read the inbox for full details if needed.`;
+  }
   if (input.summary) {
     return `${base} Summary: ${input.summary}. Please read the inbox, process them, and ack when finished.`;
   }
   return `${base} Please read the inbox, process them, and ack when finished.`;
+}
+
+const MAX_INLINE_PREVIEW_INPUT_CHARS = 240;
+const MAX_INLINE_PREVIEW_CHARS = 96;
+const INLINE_PREVIEW_KEYS = ["message", "text", "body", "title"] as const;
+
+export function deriveInlineItemPreview(item: ActivationItem, summary?: string | null): string | null {
+  const candidates: string[] = [];
+  for (const key of INLINE_PREVIEW_KEYS) {
+    const rawPayloadValue = item.rawPayload[key];
+    if (typeof rawPayloadValue === "string") {
+      candidates.push(rawPayloadValue);
+    }
+    const metadataValue = item.metadata[key];
+    if (typeof metadataValue === "string") {
+      candidates.push(metadataValue);
+    }
+  }
+  if (isPreviewFriendlySummary(summary)) {
+    candidates.push(summary);
+  }
+
+  for (const candidate of candidates) {
+    const preview = normalizeInlinePreview(candidate);
+    if (preview) {
+      return preview;
+    }
+  }
+  return null;
 }
 
 export function assignedAgentIdFromContext(input: {
@@ -213,6 +246,47 @@ function normalizeItermSessionId(raw: string | undefined): string | null {
   }
   const parts = value.split(":");
   return parts[parts.length - 1] || null;
+}
+
+function normalizeInlinePreview(value: string): string | null {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.length > MAX_INLINE_PREVIEW_INPUT_CHARS) {
+    return null;
+  }
+  if (looksStructured(normalized)) {
+    return null;
+  }
+  if (normalized.length <= MAX_INLINE_PREVIEW_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MAX_INLINE_PREVIEW_CHARS - 3).trimEnd()}...`;
+}
+
+function isPreviewFriendlySummary(summary?: string | null): summary is string {
+  if (typeof summary !== "string") {
+    return false;
+  }
+  const normalized = summary.trim();
+  if (!normalized) {
+    return false;
+  }
+  if (!normalized.includes(" ")) {
+    return false;
+  }
+  if (/^[a-z0-9_.-]+:/i.test(normalized)) {
+    return false;
+  }
+  return true;
+}
+
+function looksStructured(value: string): boolean {
+  if ((value.startsWith("{") && value.endsWith("}")) || (value.startsWith("[") && value.endsWith("]"))) {
+    return true;
+  }
+  return false;
 }
 
 function detectRuntimeContext(env: NodeJS.ProcessEnv): {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -74,7 +74,8 @@ export function renderAgentPrompt(input: {
   const itemWord = totalUnackedCount === 1 ? "item" : "items";
   const base = `AgentInbox: ${totalUnackedCount} unacked ${itemWord} in inbox ${input.inboxId}.`;
   if (totalUnackedCount === 1 && input.preview) {
-    return `${base} Preview: ${input.preview}. Read the inbox for full details if needed.`;
+    const suffix = /(?:[.!?…]|\.{3})$/.test(input.preview) ? "" : ".";
+    return `${base} Preview: ${input.preview}${suffix} Read the inbox for full details if needed.`;
   }
   if (input.summary) {
     return `${base} Summary: ${input.summary}. Please read the inbox, process them, and ack when finished.`;

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2569,6 +2569,60 @@ test("single non-preview-friendly item falls back to the generic terminal prompt
   }
 });
 
+test("preview-aware terminal prompts still dedupe unchanged lease reminders", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-inline-preview-dedupe",
+      tmuxPaneId: "%58",
+      notifyLeaseMs: 50,
+    });
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-event-inline-preview-dedupe",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-inline-preview-dedupe",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: { message: "Review PR #51 CI failure and push a fix." },
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    const firstPrompt = terminalDispatcher.calls[0]!.prompt;
+    assert.match(firstPrompt, /Preview: Review PR #51 CI failure and push a fix\./);
+
+    await sleep(70);
+    await (service as any).syncActivationDispatchStates();
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    const state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    assert.ok(state?.lastNotifiedFingerprint);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("lease expiry does not repeat identical terminal prompts for unchanged inbox state", async () => {
   const terminalDispatcher = new RecordingTerminalDispatcher();
   const { service, dir, store } = await makeService({

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2477,6 +2477,98 @@ test("terminal activation prompts use the current unacked inbox total", async ()
   }
 });
 
+test("single preview-friendly unacked item is inlined into the terminal prompt", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-inline-preview",
+      tmuxPaneId: "%56",
+      notifyLeaseMs: 100,
+    });
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-event-inline-preview",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-inline-preview",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: { message: "Review PR #51 CI failure and push a fix." },
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.match(terminalDispatcher.calls[0]!.prompt, /Preview: Review PR #51 CI failure and push a fix\./);
+    assert.match(terminalDispatcher.calls[0]!.prompt, /Read the inbox for full details if needed\./);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("single non-preview-friendly item falls back to the generic terminal prompt", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-inline-preview-fallback",
+      tmuxPaneId: "%57",
+      notifyLeaseMs: 100,
+    });
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-event-inline-preview-fallback",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-inline-structured",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: { body: "{\"kind\":\"structured\",\"value\":42}" },
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.doesNotMatch(terminalDispatcher.calls[0]!.prompt, /Preview:/);
+    assert.match(terminalDispatcher.calls[0]!.prompt, /Please read the inbox, process them, and ack when finished\./);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("lease expiry does not repeat identical terminal prompts for unchanged inbox state", async () => {
   const terminalDispatcher = new RecordingTerminalDispatcher();
   const { service, dir, store } = await makeService({

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { assignedAgentIdFromContext, detectTerminalContext, renderAgentPrompt, TerminalDispatcher } from "../src/terminal";
+import { assignedAgentIdFromContext, deriveInlineItemPreview, detectTerminalContext, renderAgentPrompt, TerminalDispatcher } from "../src/terminal";
 import { TerminalActivationTarget } from "../src/model";
 
 test("detectTerminalContext derives codex runtime and iTerm2 session", () => {
@@ -53,6 +53,53 @@ test("renderAgentPrompt accepts legacy newItemCount input", () => {
     prompt,
     "AgentInbox: 1 unacked item in inbox inbox_123. Please read the inbox, process them, and ack when finished.",
   );
+});
+
+test("renderAgentPrompt includes inline preview for single-item prompts", () => {
+  const prompt = renderAgentPrompt({
+    inboxId: "inbox_123",
+    totalUnackedCount: 1,
+    preview: "Review PR #51 CI failure and push a fix",
+  });
+
+  assert.equal(
+    prompt,
+    "AgentInbox: 1 unacked item in inbox inbox_123. Preview: Review PR #51 CI failure and push a fix. Read the inbox for full details if needed.",
+  );
+});
+
+test("deriveInlineItemPreview truncates short text payloads and skips structured payloads", () => {
+  const preview = deriveInlineItemPreview({
+    itemId: "item_1",
+    sourceId: "src_1",
+    sourceNativeId: "evt_1",
+    eventVariant: "message.created",
+    inboxId: "inbox_1",
+    occurredAt: "2026-04-16T00:00:00.000Z",
+    metadata: {},
+    rawPayload: {
+      message: "This is a fairly long single-line message that should still become a short inline preview in the terminal prompt without dumping the full payload verbatim.",
+    },
+    deliveryHandle: null,
+  });
+  assert.ok(preview);
+  assert.match(preview!, /^This is a fairly long single-line message/);
+  assert.ok(preview!.endsWith("..."));
+
+  const structured = deriveInlineItemPreview({
+    itemId: "item_2",
+    sourceId: "src_1",
+    sourceNativeId: "evt_2",
+    eventVariant: "message.created",
+    inboxId: "inbox_1",
+    occurredAt: "2026-04-16T00:00:00.000Z",
+    metadata: {},
+    rawPayload: {
+      body: "{\"kind\":\"structured\",\"value\":42}",
+    },
+    deliveryHandle: null,
+  });
+  assert.equal(structured, null);
 });
 
 test("TerminalDispatcher uses two-step it2api submission for iTerm2 targets", async () => {

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -68,6 +68,19 @@ test("renderAgentPrompt includes inline preview for single-item prompts", () => 
   );
 });
 
+test("renderAgentPrompt does not add duplicate punctuation after previews", () => {
+  const prompt = renderAgentPrompt({
+    inboxId: "inbox_123",
+    totalUnackedCount: 1,
+    preview: "Review PR #51 CI failure and push a fix...",
+  });
+
+  assert.equal(
+    prompt,
+    "AgentInbox: 1 unacked item in inbox inbox_123. Preview: Review PR #51 CI failure and push a fix... Read the inbox for full details if needed.",
+  );
+});
+
 test("deriveInlineItemPreview truncates short text payloads and skips structured payloads", () => {
   const preview = deriveInlineItemPreview({
     itemId: "item_1",


### PR DESCRIPTION
Closes #107

## Summary
- inline a short preview into terminal activation prompts when exactly one preview-friendly unacked item exists
- aggressively truncate previews and fall back to the generic prompt for long or structured items
- keep multi-item prompts and the existing ack-driven inbox model unchanged

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "renderAgentPrompt accepts legacy newItemCount input|renderAgentPrompt includes inline preview for single-item prompts|deriveInlineItemPreview truncates short text payloads and skips structured payloads|terminal activation prompts use the current unacked inbox total|single preview-friendly unacked item is inlined into the terminal prompt|single non-preview-friendly item falls back to the generic terminal prompt" test/terminal.test.ts test/agentinbox.test.ts