### PR TITLE
chore: upgrade GitHub Actions to node24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout release ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.meta.outputs.tag }}
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -143,7 +143,7 @@ jobs:
           echo "npm package @holon-run/agentinbox@${{ steps.meta.outputs.version }} already exists; skipping publish."
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: AgentInbox ${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
Closes #104

## Summary
- upgrade `actions/checkout` from `v4` to `v6` in CI, docs-site, and release workflows
- upgrade `actions/setup-node` from `v4` to `v6` in CI, docs-site, and release workflows
- upgrade `softprops/action-gh-release` from `v2` to `v3` in the release workflow

These versions all use the Node 24 JavaScript action runtime, which removes the Node 20 deprecation warning from GitHub-hosted runners.

## Verification
- confirmed latest action releases: `actions/checkout@v6.0.2`, `actions/setup-node@v6.3.0`, `softprops/action-gh-release@v3.0.0`
- confirmed each action's `action.yml` uses `node24`
- `git diff --check`
- re-scanned workflow references under `.github/workflows`