### PR TITLE
Improve terminal activity gating heuristics

### DIFF
--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -6,8 +6,8 @@ import os from "node:os";
 import { TerminalActivationTarget } from "./model";
 
 const execFileAsync = promisify(execFile);
-const DEFAULT_ITERM2_SAMPLE_DELAY_MS = 250;
-const DEFAULT_TMUX_SAMPLE_DELAY_MS = 250;
+const DEFAULT_ITERM2_SAMPLE_DELAY_MS = 900;
+const DEFAULT_TMUX_SAMPLE_DELAY_MS = 900;
 const ACTIVE_BUFFER_MARKERS = [
   "esc to interrupt",
   "Working (",
@@ -15,6 +15,7 @@ const ACTIVE_BUFFER_MARKERS = [
 ];
 const TYPING_PROMPT_PREFIXES = [
   "› ",
+  "❯ ",
   "> ",
 ];
 
@@ -326,22 +327,41 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
     if (containsActiveBufferMarker(second)) {
       return { presence: "available", busy: "busy" };
     }
-    if (paneState.active && hasVisibleTypingPrompt(second)) {
+    const cursorHint = evaluateCursorAwareTypingPrompt(target, paneState, second);
+    if (cursorHint === "busy") {
+      return { presence: "available", busy: "busy" };
+    }
+    if (cursorHint === "unknown" && paneState.active && hasVisibleTypingPrompt(second)) {
       return { presence: "available", busy: "busy" };
     }
     return { presence: "available", busy: "unknown" };
   }
 
-  private async readPaneState(paneId: string): Promise<{ active: boolean; dead: boolean } | "missing" | "unknown"> {
+  private async readPaneState(paneId: string): Promise<{
+    active: boolean;
+    dead: boolean;
+    cursorX: number | null;
+    cursorY: number | null;
+    height: number | null;
+  } | "missing" | "unknown"> {
     try {
-      const result = await this.execAsync("tmux", ["display-message", "-p", "-t", paneId, "#{pane_active} #{pane_dead}"]);
-      const [active, dead] = result.stdout.trim().split(/\s+/, 2);
+      const result = await this.execAsync("tmux", [
+        "display-message",
+        "-p",
+        "-t",
+        paneId,
+        "#{pane_active} #{pane_dead} #{cursor_x} #{cursor_y} #{pane_height}",
+      ]);
+      const [active, dead, cursorX, cursorY, height] = result.stdout.trim().split(/\s+/, 5);
       if (!active || !dead) {
         return "unknown";
       }
       return {
         active: active === "1",
         dead: dead === "1",
+        cursorX: parseOptionalInt(cursorX),
+        cursorY: parseOptionalInt(cursorY),
+        height: parseOptionalInt(height),
       };
     } catch (error) {
       if (isTmuxMissingPaneError(error)) {
@@ -380,6 +400,58 @@ function hasVisibleTypingPrompt(bufferTail: string): boolean {
     }
   }
   return false;
+}
+
+function evaluateCursorAwareTypingPrompt(
+  target: TerminalActivationTarget,
+  paneState: { cursorX: number | null; cursorY: number | null; height: number | null },
+  bufferTail: string,
+): "busy" | "not_busy" | "unknown" {
+  const prefix = runtimeTypingPromptPrefix(target.runtimeKind);
+  if (!prefix) {
+    return "unknown";
+  }
+  if (paneState.cursorX == null || paneState.cursorY == null || paneState.height == null) {
+    return "unknown";
+  }
+
+  const lines = bufferTail
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => line.trimEnd());
+  if (lines.length === 0) {
+    return "unknown";
+  }
+
+  const captureStartRow = Math.max(0, paneState.height - lines.length);
+  const lineIndex = paneState.cursorY - captureStartRow;
+  if (lineIndex < 0 || lineIndex >= lines.length) {
+    return "not_busy";
+  }
+
+  const line = lines[lineIndex] ?? "";
+  if (!line.startsWith(prefix)) {
+    return "not_busy";
+  }
+  return paneState.cursorX > prefix.length ? "busy" : "not_busy";
+}
+
+function runtimeTypingPromptPrefix(runtimeKind: TerminalActivationTarget["runtimeKind"]): string | null {
+  if (runtimeKind === "codex") {
+    return "› ";
+  }
+  if (runtimeKind === "claude_code") {
+    return "❯ ";
+  }
+  return null;
+}
+
+function parseOptionalInt(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function normalizeBufferTail(buffer: string): string | null {

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -15,7 +15,6 @@ const ACTIVE_BUFFER_MARKERS = [
 ];
 const TYPING_PROMPT_PREFIXES = [
   "› ",
-  "❯ ",
   "> ",
 ];
 
@@ -331,7 +330,11 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
     if (cursorHint === "busy") {
       return { presence: "available", busy: "busy" };
     }
-    if (cursorHint === "unknown" && paneState.active && hasVisibleTypingPrompt(second)) {
+    if (
+      cursorHint === "unknown" &&
+      paneState.active &&
+      hasVisibleTypingPrompt(second, typingPromptPrefixesForRuntime(target.runtimeKind))
+    ) {
       return { presence: "available", busy: "busy" };
     }
     return { presence: "available", busy: "unknown" };
@@ -385,7 +388,7 @@ function containsActiveBufferMarker(bufferTail: string): boolean {
   return ACTIVE_BUFFER_MARKERS.some((marker) => bufferTail.includes(marker));
 }
 
-function hasVisibleTypingPrompt(bufferTail: string): boolean {
+function hasVisibleTypingPrompt(bufferTail: string, prefixes: readonly string[] = TYPING_PROMPT_PREFIXES): boolean {
   const lines = bufferTail
     .split("\n")
     .map((line) => line.trimEnd())
@@ -394,7 +397,7 @@ function hasVisibleTypingPrompt(bufferTail: string): boolean {
   if (!lastLine) {
     return false;
   }
-  for (const prefix of TYPING_PROMPT_PREFIXES) {
+  for (const prefix of prefixes) {
     if (lastLine.startsWith(prefix) && lastLine.slice(prefix.length).trim().length > 0) {
       return true;
     }
@@ -426,7 +429,7 @@ function evaluateCursorAwareTypingPrompt(
   const captureStartRow = Math.max(0, paneState.height - lines.length);
   const lineIndex = paneState.cursorY - captureStartRow;
   if (lineIndex < 0 || lineIndex >= lines.length) {
-    return "not_busy";
+    return "unknown";
   }
 
   const line = lines[lineIndex] ?? "";
@@ -444,6 +447,16 @@ function runtimeTypingPromptPrefix(runtimeKind: TerminalActivationTarget["runtim
     return "❯ ";
   }
   return null;
+}
+
+function typingPromptPrefixesForRuntime(runtimeKind: TerminalActivationTarget["runtimeKind"]): readonly string[] {
+  if (runtimeKind === "codex") {
+    return ["› "];
+  }
+  if (runtimeKind === "claude_code") {
+    return ["❯ ", "› "];
+  }
+  return TYPING_PROMPT_PREFIXES;
 }
 
 function parseOptionalInt(value: string | undefined): number | null {

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -587,6 +587,28 @@ test("TmuxTerminalStateProbe does not mark busy from cursor hint when the cursor
   });
 });
 
+test("TmuxTerminalStateProbe falls back to prompt heuristics when the cursor row is outside the captured tail", async () => {
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      return { stdout: "1 0 6 10 28\n", stderr: "" };
+    }
+    if (args[0] === "capture-pane") {
+      return {
+        stdout: "question text\n\n› abcdefg\n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "available",
+    busy: "busy",
+  });
+});
+
 test("TmuxTerminalStateProbe falls back to prompt heuristics when cursor metadata is unavailable", async () => {
   const probe = new TmuxTerminalStateProbe(async (_file, args) => {
     if (args[0] === "display-message") {
@@ -604,6 +626,30 @@ test("TmuxTerminalStateProbe falls back to prompt heuristics when cursor metadat
   });
 
   assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "available",
+    busy: "busy",
+  });
+});
+
+test("TmuxTerminalStateProbe reports busy when the cursor is past a claude_code prompt prefix on the input row", async () => {
+  const target = makeTmuxTarget();
+  target.runtimeKind = "claude_code";
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      return { stdout: "1 0 7 27 28\n", stderr: "" };
+    }
+    if (args[0] === "capture-pane") {
+      return {
+        stdout: "question text\n\n❯ rewrite this\n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(target), {
     presence: "available",
     busy: "busy",
   });

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -483,7 +483,7 @@ test("TmuxTerminalStateProbe reports busy when the buffer tail changes", async (
   const buffers = ["first snapshot", "second snapshot"];
   const probe = new TmuxTerminalStateProbe(async (_file, args) => {
     if (args[0] === "display-message") {
-      return { stdout: "1 0\n", stderr: "" };
+      return { stdout: "1 0 0 27 28\n", stderr: "" };
     }
     if (args[0] === "capture-pane") {
       return { stdout: `${buffers.shift() ?? "second snapshot"}\n`, stderr: "" };
@@ -502,7 +502,7 @@ test("TmuxTerminalStateProbe reports busy when the buffer tail changes", async (
 test("TmuxTerminalStateProbe reports busy when the stable buffer shows a codex activity marker", async () => {
   const probe = new TmuxTerminalStateProbe(async (_file, args) => {
     if (args[0] === "display-message") {
-      return { stdout: "1 0\n", stderr: "" };
+      return { stdout: "1 0 0 27 28\n", stderr: "" };
     }
     if (args[0] === "capture-pane") {
       return {
@@ -521,7 +521,73 @@ test("TmuxTerminalStateProbe reports busy when the stable buffer shows a codex a
   });
 });
 
-test("TmuxTerminalStateProbe reports busy when the active pane shows typed prompt input", async () => {
+test("TmuxTerminalStateProbe reports busy when the cursor is past a codex prompt prefix on the input row", async () => {
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      return { stdout: "1 0 6 27 28\n", stderr: "" };
+    }
+    if (args[0] === "capture-pane") {
+      return {
+        stdout: "question text\n\n› abcdefg\n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "available",
+    busy: "busy",
+  });
+});
+
+test("TmuxTerminalStateProbe does not mark busy from cursor hint when the cursor is still inside the prompt prefix", async () => {
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      return { stdout: "1 0 1 27 28\n", stderr: "" };
+    }
+    if (args[0] === "capture-pane") {
+      return {
+        stdout: "question text\n\n› abcdefg\n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "available",
+    busy: "unknown",
+  });
+});
+
+test("TmuxTerminalStateProbe does not mark busy from cursor hint when the cursor row is not on the prompt line", async () => {
+  const probe = new TmuxTerminalStateProbe(async (_file, args) => {
+    if (args[0] === "display-message") {
+      return { stdout: "1 0 6 26 28\n", stderr: "" };
+    }
+    if (args[0] === "capture-pane") {
+      return {
+        stdout: "question text\n\n› abcdefg\n",
+        stderr: "",
+      };
+    }
+    throw new Error(`unexpected command: ${args.join(" ")}`);
+  }, {
+    sleep: async () => {},
+  });
+
+  assert.deepEqual(await probe.check(makeTmuxTarget()), {
+    presence: "available",
+    busy: "unknown",
+  });
+});
+
+test("TmuxTerminalStateProbe falls back to prompt heuristics when cursor metadata is unavailable", async () => {
   const probe = new TmuxTerminalStateProbe(async (_file, args) => {
     if (args[0] === "display-message") {
       return { stdout: "1 0\n", stderr: "" };
@@ -546,7 +612,7 @@ test("TmuxTerminalStateProbe reports busy when the active pane shows typed promp
 test("TmuxTerminalStateProbe reports unknown when the pane is stable and prompt is empty", async () => {
   const probe = new TmuxTerminalStateProbe(async (_file, args) => {
     if (args[0] === "display-message") {
-      return { stdout: "1 0\n", stderr: "" };
+      return { stdout: "1 0 0 27 28\n", stderr: "" };
     }
     if (args[0] === "capture-pane") {
       return {


### PR DESCRIPTION
Closes #114

## Summary
- increase terminal buffer sampling windows so buffer changes become the primary busy signal
- add tmux cursor-aware typing detection for Codex and Claude-style prompt lines
- keep generic prompt matching as a fallback hint instead of the main gating mechanism

## Validation
- npm run build
- node --require ./node_modules/ts-node/register --test test/runtime_gate.test.ts
- node --require ./node_modules/ts-node/register --test --test-name-pattern "busy terminal gate defers activation without counting a dispatch failure|offline terminal gate marks the target offline before dispatch|terminal target goes offline when dispatch fails and probe confirms disappearance" test/agentinbox.test.ts

## Notes
- This PR intentionally does not add the iTerm2 Python probe yet. That can follow once we have a backend-specific path for higher precision session inspection.