### PR TITLE
fix: align inbox ack ordering with read order

### DIFF
--- a/drizzle/migrations/0008_inbox_item_sequence.sql
+++ b/drizzle/migrations/0008_inbox_item_sequence.sql
@@ -9,3 +9,13 @@ create unique index if not exists idx_inbox_items_inbox_sequence
 
 create index if not exists idx_inbox_items_inbox_sequence_order
   on inbox_items(inbox_id, inbox_sequence);
+
+create trigger if not exists trg_inbox_items_set_sequence_after_insert
+after insert on inbox_items
+for each row
+when new.inbox_sequence is null
+begin
+  update inbox_items
+  set inbox_sequence = new.rowid
+  where rowid = new.rowid;
+end;

--- a/drizzle/migrations/0008_inbox_item_sequence.sql
+++ b/drizzle/migrations/0008_inbox_item_sequence.sql
@@ -1,0 +1,11 @@
+alter table inbox_items add column inbox_sequence integer;
+
+update inbox_items
+set inbox_sequence = rowid
+where inbox_sequence is null;
+
+create unique index if not exists idx_inbox_items_inbox_sequence
+  on inbox_items(inbox_sequence);
+
+create index if not exists idx_inbox_items_inbox_sequence_order
+  on inbox_items(inbox_id, inbox_sequence);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -139,6 +139,7 @@ export const inboxItems = sqliteTable("inbox_items", {
   sourceNativeId: text("source_native_id").notNull(),
   eventVariant: text("event_variant").notNull(),
   inboxId: text("inbox_id").notNull(),
+  inboxSequence: integer("inbox_sequence"),
   occurredAt: text("occurred_at").notNull(),
   metadataJson: text("metadata_json").notNull(),
   rawPayloadJson: text("raw_payload_json").notNull(),
@@ -147,8 +148,10 @@ export const inboxItems = sqliteTable("inbox_items", {
 }, (table) => ({
   sourceNativeEventInboxUnique: uniqueIndex("idx_inbox_items_source_native_event_inbox")
     .on(table.sourceId, table.sourceNativeId, table.eventVariant, table.inboxId),
+  inboxSequenceUnique: uniqueIndex("idx_inbox_items_inbox_sequence").on(table.inboxSequence),
   ackedAtIdx: index("idx_inbox_items_acked_at").on(table.ackedAt),
   inboxAckedAtIdx: index("idx_inbox_items_inbox_acked_at").on(table.inboxId, table.ackedAt),
+  inboxSequenceIdx: index("idx_inbox_items_inbox_sequence_order").on(table.inboxId, table.inboxSequence),
   sourceOccurredAtIdx: index("idx_inbox_items_source_occurred_at").on(table.sourceId, table.occurredAt),
 }));
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1053,6 +1053,15 @@ export class AgentInboxStore {
     );
     const inserted = this.changes() > before;
     if (inserted) {
+      const rowId = this.lastInsertRowId();
+      this.db.run(
+        `
+        update inbox_items
+        set inbox_sequence = ?
+        where rowid = ? and inbox_sequence is null
+      `,
+        [rowId, rowId],
+      );
       this.persist();
     }
     return inserted;
@@ -1069,18 +1078,18 @@ export class AgentInboxStore {
 
     if (options?.afterItemId) {
       const anchor = this.getOne(
-        "select occurred_at, item_id from inbox_items where inbox_id = ? and item_id = ?",
+        "select inbox_sequence from inbox_items where inbox_id = ? and item_id = ?",
         [inboxId, options.afterItemId],
       );
       if (!anchor) {
         throw new Error(`unknown inbox item: ${options.afterItemId}`);
       }
-      filters.push("((occurred_at > ?) or (occurred_at = ? and item_id > ?))");
-      params.push(String(anchor.occurred_at), String(anchor.occurred_at), String(anchor.item_id));
+      filters.push("inbox_sequence > ?");
+      params.push(Number(anchor.inbox_sequence));
     }
 
     const rows = this.getAll(
-      `select * from inbox_items where ${filters.join(" and ")} order by occurred_at asc, item_id asc`,
+      `select * from inbox_items where ${filters.join(" and ")} order by inbox_sequence asc`,
       params,
     );
     return rows.map((row) => this.mapInboxItem(row));
@@ -1107,7 +1116,7 @@ export class AgentInboxStore {
 
   ackItemsThrough(inboxId: string, itemId: string, ackedAt: string): number {
     const anchor = this.getOne(
-      "select occurred_at, item_id from inbox_items where inbox_id = ? and item_id = ?",
+      "select inbox_sequence from inbox_items where inbox_id = ? and item_id = ?",
       [inboxId, itemId],
     );
     if (!anchor) {
@@ -1119,9 +1128,9 @@ export class AgentInboxStore {
       set acked_at = ?
       where inbox_id = ?
         and acked_at is null
-        and ((occurred_at < ?) or (occurred_at = ? and item_id <= ?))
+        and inbox_sequence <= ?
     `,
-      [ackedAt, inboxId, String(anchor.occurred_at), String(anchor.occurred_at), String(anchor.item_id)],
+      [ackedAt, inboxId, Number(anchor.inbox_sequence)],
     );
     const changes = this.changes();
     if (changes > 0) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1078,18 +1078,18 @@ export class AgentInboxStore {
 
     if (options?.afterItemId) {
       const anchor = this.getOne(
-        "select inbox_sequence from inbox_items where inbox_id = ? and item_id = ?",
+        "select coalesce(inbox_sequence, rowid) as inbox_sequence from inbox_items where inbox_id = ? and item_id = ?",
         [inboxId, options.afterItemId],
       );
       if (!anchor) {
         throw new Error(`unknown inbox item: ${options.afterItemId}`);
       }
-      filters.push("inbox_sequence > ?");
+      filters.push("coalesce(inbox_sequence, rowid) > ?");
       params.push(Number(anchor.inbox_sequence));
     }
 
     const rows = this.getAll(
-      `select * from inbox_items where ${filters.join(" and ")} order by inbox_sequence asc`,
+      `select * from inbox_items where ${filters.join(" and ")} order by coalesce(inbox_sequence, rowid) asc`,
       params,
     );
     return rows.map((row) => this.mapInboxItem(row));
@@ -1116,7 +1116,7 @@ export class AgentInboxStore {
 
   ackItemsThrough(inboxId: string, itemId: string, ackedAt: string): number {
     const anchor = this.getOne(
-      "select inbox_sequence from inbox_items where inbox_id = ? and item_id = ?",
+      "select coalesce(inbox_sequence, rowid) as inbox_sequence from inbox_items where inbox_id = ? and item_id = ?",
       [inboxId, itemId],
     );
     if (!anchor) {
@@ -1128,7 +1128,7 @@ export class AgentInboxStore {
       set acked_at = ?
       where inbox_id = ?
         and acked_at is null
-        and inbox_sequence <= ?
+        and coalesce(inbox_sequence, rowid) <= ?
     `,
       [ackedAt, inboxId, Number(anchor.inbox_sequence)],
     );

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -137,6 +137,41 @@ async function makeService(options?: {
   return { store, service, dir };
 }
 
+async function makeServiceFromDbPath(
+  dbPath: string,
+  dir: string,
+  options?: {
+    dispatcher?: ActivationDispatcher;
+    terminalDispatcher?: TerminalDispatcher;
+    activationGate?: ActivationGate;
+    activationWindowMs?: number;
+    activationMaxItems?: number;
+  },
+): Promise<{ store: AgentInboxStore; service: AgentInboxService }> {
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input), {
+    homeDir: dir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(
+    store,
+    adapters,
+    options?.dispatcher,
+    new SqliteEventBusBackend(store),
+    {
+      windowMs: options?.activationWindowMs,
+      maxItems: options?.activationMaxItems,
+    },
+    options?.terminalDispatcher ?? new TerminalDispatcher(async () => ({
+      stdout: "",
+      stderr: "",
+    })),
+    options?.activationGate,
+  );
+  return { store, service };
+}
+
 async function registerTmuxAgent(service: AgentInboxService, suffix: string): Promise<{ agentId: string; targetId: string }> {
   const registered = service.registerAgent({
     backend: "tmux",
@@ -2055,6 +2090,63 @@ test("ack through matches visible inbox order for same-timestamp items", async (
   } finally {
     await service.stop();
     store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ack through still follows visible order when older binaries left inbox_sequence null", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "same-ts-null-seq");
+    const inboxId = (service.getInboxDetailsByAgent(alpha.agentId) as { inbox: { inboxId: string } }).inbox.inboxId;
+
+    for (const event of ["evt-1", "evt-2", "evt-3"]) {
+      store.insertInboxItem({
+        itemId: `item-${event}`,
+        sourceId: "src-manual",
+        sourceNativeId: event,
+        eventVariant: "message.created",
+        inboxId,
+        occurredAt: "2026-04-01T00:00:00.000Z",
+        metadata: {},
+        rawPayload: { text: event },
+        deliveryHandle: null,
+        ackedAt: null,
+      });
+    }
+
+    await service.stop();
+    store.close();
+
+    const dbPath = path.join(dir, "agentinbox.sqlite");
+    const SQL = await initSqlJs({
+      locateFile: (file: string) => require.resolve(`sql.js/dist/${file}`),
+    });
+    const db = new SQL.Database(fs.readFileSync(dbPath));
+    db.exec(`update inbox_items set inbox_sequence = null where inbox_id = '${inboxId}';`);
+    fs.writeFileSync(dbPath, Buffer.from(db.export()));
+    db.close();
+
+    const reopened = await makeServiceFromDbPath(dbPath, dir);
+
+    const visible = reopened.service.listInboxItems(alpha.agentId);
+    assert.deepEqual(visible.map((item) => item.sourceNativeId), ["evt-1", "evt-2", "evt-3"]);
+
+    const ack = reopened.service.ackInboxItemsThrough(alpha.agentId, visible[1]!.itemId);
+    assert.equal(ack.acked, 2);
+
+    const unread = reopened.service.listInboxItems(alpha.agentId);
+    assert.deepEqual(unread.map((item) => item.sourceNativeId), ["evt-3"]);
+
+    await reopened.service.stop();
+    reopened.store.close();
+  } finally {
+    try {
+      await service.stop();
+    } catch {}
+    try {
+      store.close();
+    } catch {}
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -184,7 +184,7 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 8);
+    assert.equal(state.appliedCount, 9);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 0);
@@ -201,7 +201,7 @@ test("store upgrades a legacy v12 database with backup and forward migration", a
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 8);
+    assert.equal(state.appliedCount, 9);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 1);
@@ -2009,6 +2009,49 @@ test("inbox read defaults to unacked items and ack through clears a processed ba
 
     const history = service.listInboxItems(alpha.agentId, { includeAcked: true });
     assert.equal(history.filter((item) => item.ackedAt !== null).length, 2);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ack through matches visible inbox order for same-timestamp items", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "same-ts");
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "same-ts",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: alpha.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    for (const event of ["evt-1", "evt-2", "evt-3", "evt-4"]) {
+      await service.appendSourceEventByCaller(source.sourceId, {
+        sourceNativeId: event,
+        eventVariant: "message.created",
+        metadata: {},
+        rawPayload: { text: event },
+        occurredAt: "2026-04-01T00:00:00.000Z",
+      });
+    }
+
+    const poll = await service.pollSubscription(subscription.subscriptionId);
+    assert.equal(poll.inboxItemsCreated, 4);
+
+    const allItems = service.listInboxItems(alpha.agentId, { includeAcked: true });
+    assert.deepEqual(allItems.map((item) => item.sourceNativeId), ["evt-1", "evt-2", "evt-3", "evt-4"]);
+
+    const ack = service.ackInboxItemsThrough(alpha.agentId, allItems[2]!.itemId);
+    assert.equal(ack.acked, 3);
+
+    const unread = service.listInboxItems(alpha.agentId);
+    assert.deepEqual(unread.map((item) => item.sourceNativeId), ["evt-4"]);
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
Closes #113

## Summary
- add a persisted `inbox_sequence` ordering key to `inbox_items`
- use `inbox_sequence` consistently for inbox read order, `afterItemId` cursoring, and `ack --through` cutoff semantics
- backfill existing rows from their current insertion order during migration and add a same-timestamp regression test

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "store migrates a new database using drizzle SQL migrations|store upgrades a legacy v12 database with backup and forward migration|inbox read defaults to unacked items and ack through clears a processed batch|ack through matches visible inbox order for same-timestamp items" test/agentinbox.test.ts