### PR TITLE
feat: add source-specific activation previews

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1,4 +1,5 @@
 import {
+  ActivationItem,
   AppendSourceEventInput,
   DeliveryAttempt,
   DeliveryRequest,
@@ -191,6 +192,13 @@ export class AdapterRegistry {
       return null;
     }
     return this.remoteSource.expandSubscriptionShortcut(source, input);
+  }
+
+  async deriveInlinePreview(source: SubscriptionSource, item: ActivationItem): Promise<string | null> {
+    if (source.sourceType === "local_event") {
+      return null;
+    }
+    return this.remoteSource.deriveInlinePreview(source, item);
   }
 
   status(): Record<string, unknown> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -56,6 +56,7 @@ import {
   assignedAgentIdFromContext,
   deriveInlineItemPreview,
   detectTerminalContext,
+  normalizeInlinePreviewText,
   renderAgentPrompt,
   TerminalDispatcher,
 } from "./terminal";
@@ -1859,7 +1860,8 @@ export class AgentInboxService {
           const source = this.store.getSource(singleItem.sourceId);
           if (source) {
             try {
-              preview = await this.adapters.deriveInlinePreview(source, singleItem);
+              const sourcePreview = await this.adapters.deriveInlinePreview(source, singleItem);
+              preview = typeof sourcePreview === "string" ? normalizeInlinePreviewText(sourcePreview) : null;
             } catch {
               preview = null;
             }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1858,7 +1858,11 @@ export class AgentInboxService {
           const singleItem = input.items[0];
           const source = this.store.getSource(singleItem.sourceId);
           if (source) {
-            preview = await this.adapters.deriveInlinePreview(source, singleItem);
+            try {
+              preview = await this.adapters.deriveInlinePreview(source, singleItem);
+            } catch {
+              preview = null;
+            }
           }
           preview ??= deriveInlineItemPreview(singleItem, input.summary);
         }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1853,9 +1853,15 @@ export class AgentInboxService {
           });
           return "deferred";
         }
-        const preview = totalUnackedCount === 1 && input.items.length === 1
-          ? deriveInlineItemPreview(input.items[0], input.summary)
-          : null;
+        let preview: string | null = null;
+        if (totalUnackedCount === 1 && input.items.length === 1) {
+          const singleItem = input.items[0];
+          const source = this.store.getSource(singleItem.sourceId);
+          if (source) {
+            preview = await this.adapters.deriveInlinePreview(source, singleItem);
+          }
+          preview ??= deriveInlineItemPreview(singleItem, input.summary);
+        }
         const prompt = renderAgentPrompt({
           inboxId: inbox.inboxId,
           totalUnackedCount,

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -1,5 +1,5 @@
 import { ManagedSourceEnsureResponse, ManagedStreamReadResponse, UxcDaemonClient } from "@holon-run/uxc-daemon-client";
-import { AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "../model";
+import { ActivationItem, AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "../model";
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
 import { nowIso } from "../util";
@@ -239,6 +239,17 @@ export class RemoteSourceRuntime {
       args: input.args,
       source: profileInputSource(source),
     });
+  }
+
+  async deriveInlinePreview(source: SubscriptionSource, item: ActivationItem): Promise<string | null> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return null;
+    }
+    const profile = await this.profileRegistry.resolve(source, this.homeDir);
+    if (typeof profile.deriveInlinePreview !== "function") {
+      return null;
+    }
+    return profile.deriveInlinePreview(item, profileInputSource(source));
   }
 
   private async syncAll(): Promise<void> {

--- a/src/sources/remote_profiles.ts
+++ b/src/sources/remote_profiles.ts
@@ -2,7 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { PollSubscriptionConfig, RuntimeInvokeOptions } from "@holon-run/uxc-daemon-client";
-import { AppendSourceEventInput, CleanupPolicy, SourceSchemaField, SubscriptionFilter, SubscriptionSource } from "../model";
+import { ActivationItem, AppendSourceEventInput, CleanupPolicy, SourceSchemaField, SubscriptionFilter, SubscriptionSource } from "../model";
+import { normalizeInlinePreviewText } from "../terminal";
 import {
   deriveGithubTrackedResource,
   expandGithubSubscriptionShortcut,
@@ -94,6 +95,7 @@ export interface RemoteSourceProfile {
   expandSubscriptionShortcut?(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | null;
   deriveTrackedResource?(filter: SubscriptionFilter, source: SubscriptionSource): { ref: string } | null;
   projectLifecycleSignal?(rawPayload: Record<string, unknown>, source: SubscriptionSource): LifecycleSignal | null;
+  deriveInlinePreview?(item: ActivationItem, source: SubscriptionSource): string | null;
 }
 
 const REMOTE_USER_PROFILE_ROOT_DIR = "source-profiles";
@@ -186,6 +188,7 @@ function validateProfileContract(profile: RemoteSourceProfile, sourcePath: strin
   validateOptionalHook(profile.expandSubscriptionShortcut, "expandSubscriptionShortcut", sourcePath);
   validateOptionalHook(profile.deriveTrackedResource, "deriveTrackedResource", sourcePath);
   validateOptionalHook(profile.projectLifecycleSignal, "projectLifecycleSignal", sourcePath);
+  validateOptionalHook(profile.deriveInlinePreview, "deriveInlinePreview", sourcePath);
 }
 
 function validateOptionalHook(value: unknown, name: string, sourcePath: string): void {
@@ -364,6 +367,36 @@ const GITHUB_REPO_CI_PROFILE: RemoteSourceProfile = {
       ],
       eventVariantExamples: ["workflow_run.ci.completed.failure", "workflow_run.nightly_checks.observed"],
     };
+  },
+  deriveInlinePreview(item: ActivationItem): string | null {
+    const repoFullName = asNonEmptyString(item.metadata.repoFullName);
+    const workflowName = asNonEmptyString(item.metadata.name)
+      ?? asNonEmptyString(item.metadata.displayTitle)
+      ?? asNonEmptyString(item.rawPayload.name)
+      ?? asNonEmptyString(item.rawPayload.display_title);
+    const headBranch = asNonEmptyString(item.metadata.headBranch) ?? asNonEmptyString(item.rawPayload.head_branch);
+    const conclusion = asNonEmptyString(item.metadata.conclusion) ?? asNonEmptyString(item.rawPayload.conclusion);
+    const status = asNonEmptyString(item.metadata.status) ?? asNonEmptyString(item.rawPayload.status);
+
+    const parts: string[] = [];
+    if (workflowName) {
+      parts.push(workflowName);
+    } else {
+      parts.push("Workflow run");
+    }
+    if (conclusion) {
+      parts.push(`completed ${conclusion}`);
+    } else if (status) {
+      parts.push(status);
+    }
+    if (repoFullName) {
+      parts.push(`for ${repoFullName}`);
+    }
+    if (headBranch) {
+      parts.push(`on ${headBranch}`);
+    }
+
+    return normalizeInlinePreviewText(parts.join(" "));
   },
   validateConfig(source: SubscriptionSource): void {
     parseGithubCiSourceConfig(source);

--- a/src/sources/remote_profiles.ts
+++ b/src/sources/remote_profiles.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { PollSubscriptionConfig, RuntimeInvokeOptions } from "@holon-run/uxc-daemon-client";
 import { ActivationItem, AppendSourceEventInput, CleanupPolicy, SourceSchemaField, SubscriptionFilter, SubscriptionSource } from "../model";
-import { normalizeInlinePreviewText } from "../terminal";
 import {
   deriveGithubTrackedResource,
   expandGithubSubscriptionShortcut,
@@ -396,7 +395,7 @@ const GITHUB_REPO_CI_PROFILE: RemoteSourceProfile = {
       parts.push(`on ${headBranch}`);
     }
 
-    return normalizeInlinePreviewText(parts.join(" "));
+    return parts.join(" ");
   },
   validateConfig(source: SubscriptionSource): void {
     parseGithubCiSourceConfig(source);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -104,12 +104,16 @@ export function deriveInlineItemPreview(item: ActivationItem, summary?: string |
   }
 
   for (const candidate of candidates) {
-    const preview = normalizeInlinePreview(candidate);
+    const preview = normalizeInlinePreviewText(candidate);
     if (preview) {
       return preview;
     }
   }
   return null;
+}
+
+export function normalizeInlinePreviewText(candidate: string): string | null {
+  return normalizeInlinePreview(candidate);
 }
 
 export function assignedAgentIdFromContext(input: {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2704,6 +2704,157 @@ test("single non-preview-friendly item falls back to the generic terminal prompt
   }
 });
 
+test("single github_repo_ci item uses source-specific inline preview in the terminal prompt", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-github-ci-preview",
+      tmuxPaneId: "%59",
+      notifyLeaseMs: 100,
+    });
+    const source = await service.registerSource({
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      config: {
+        owner: "holon-run",
+        repo: "agentinbox",
+      },
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceNativeId: "workflow_run:101",
+      sourceId: source.sourceId,
+      eventVariant: "workflow_run.ci.completed.success",
+      metadata: {
+        repoFullName: "holon-run/agentinbox",
+        name: "Node Tests",
+        status: "completed",
+        conclusion: "success",
+        headBranch: "feature/issue-112",
+      },
+      rawPayload: {
+        id: 101,
+        name: "Node Tests",
+        status: "completed",
+        conclusion: "success",
+        head_branch: "feature/issue-112",
+      },
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.match(
+      terminalDispatcher.calls[0]!.prompt,
+      /Preview: Node Tests completed success for holon-run\/agentinbox on feature\/issue-112\./,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("user-defined remote_source profiles can opt into source-specific inline previews", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "preview-hook.mjs"),
+      `export default {
+  id: "demo.preview-hook",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      operation_id: "get:/events",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(rawPayload) {
+    return {
+      sourceNativeId: String(rawPayload.id ?? "evt-remote-preview"),
+      eventVariant: "demo.event",
+      metadata: {},
+      rawPayload
+    };
+  },
+  deriveInlinePreview(item) {
+    return item.rawPayload.kind === "build" ? "Remote build finished for demo service" : null;
+  }
+};\n`,
+    );
+
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-remote-preview-hook",
+      tmuxPaneId: "%60",
+      notifyLeaseMs: 100,
+    });
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "demo/preview-hook",
+      config: {
+        profilePath: "preview-hook.mjs",
+      },
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceNativeId: "evt-remote-preview",
+      sourceId: source.sourceId,
+      eventVariant: "demo.event",
+      metadata: {},
+      rawPayload: {
+        kind: "build",
+        body: "{\"kind\":\"structured\",\"value\":42}",
+      },
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.match(
+      terminalDispatcher.calls[0]!.prompt,
+      /Preview: Remote build finished for demo service\./,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("preview-aware terminal prompts still dedupe unchanged lease reminders", async () => {
   const terminalDispatcher = new RecordingTerminalDispatcher();
   const { service, dir, store } = await makeService({

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2941,6 +2941,90 @@ test("source-specific preview hook failures fall back to the generic preview", a
   }
 });
 
+test("source-specific previews are normalized at the core call boundary", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "preview-hook-unbounded.mjs"),
+      `export default {
+  id: "demo.preview-hook-unbounded",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      operation_id: "get:/events",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(rawPayload) {
+    return {
+      sourceNativeId: String(rawPayload.id ?? "evt-remote-preview-unbounded"),
+      eventVariant: "demo.event",
+      metadata: {},
+      rawPayload
+    };
+  },
+  deriveInlinePreview() {
+    return "Line one from source hook\\nLine two should collapse and this sentence is intentionally long so the core normalization path has to truncate it before rendering into the terminal activation prompt.";
+  }
+};\n`,
+    );
+
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-remote-preview-unbounded",
+      tmuxPaneId: "%62",
+      notifyLeaseMs: 100,
+    });
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "demo/preview-hook-unbounded",
+      config: {
+        profilePath: "preview-hook-unbounded.mjs",
+      },
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceNativeId: "evt-remote-preview-unbounded",
+      sourceId: source.sourceId,
+      eventVariant: "demo.event",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    const prompt = terminalDispatcher.calls[0]!.prompt;
+    assert.match(prompt, /Preview: Line one from source hook Line two should collapse/);
+    assert.doesNotMatch(prompt, /\n/);
+    assert.match(prompt, /\.\.\./);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("preview-aware terminal prompts still dedupe unchanged lease reminders", async () => {
   const terminalDispatcher = new RecordingTerminalDispatcher();
   const { service, dir, store } = await makeService({

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2855,6 +2855,92 @@ test("user-defined remote_source profiles can opt into source-specific inline pr
   }
 });
 
+test("source-specific preview hook failures fall back to the generic preview", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "preview-hook-error.mjs"),
+      `export default {
+  id: "demo.preview-hook-error",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      operation_id: "get:/events",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(rawPayload) {
+    return {
+      sourceNativeId: String(rawPayload.id ?? "evt-remote-preview-error"),
+      eventVariant: "demo.event",
+      metadata: {},
+      rawPayload
+    };
+  },
+  deriveInlinePreview() {
+    throw new Error("broken preview hook");
+  }
+};\n`,
+    );
+
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-remote-preview-hook-error",
+      tmuxPaneId: "%61",
+      notifyLeaseMs: 100,
+    });
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "demo/preview-hook-error",
+      config: {
+        profilePath: "preview-hook-error.mjs",
+      },
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceNativeId: "evt-remote-preview-error",
+      sourceId: source.sourceId,
+      eventVariant: "demo.event",
+      metadata: {},
+      rawPayload: {
+        message: "Fallback generic preview still works when the source hook crashes.",
+      },
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.match(
+      terminalDispatcher.calls[0]!.prompt,
+      /Preview: Fallback generic preview still works when the source hook crashes\./,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("preview-aware terminal prompts still dedupe unchanged lease reminders", async () => {
   const terminalDispatcher = new RecordingTerminalDispatcher();
   const { service, dir, store } = await makeService({


### PR DESCRIPTION
## Summary
- add a source/profile-level inline preview hook for single-item terminal activations
- consult source-specific previews before the existing generic fallback
- implement structured activation previews for builtin `github_repo_ci` and cover user-defined remote profiles

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "single preview-friendly unacked item is inlined into the terminal prompt|single non-preview-friendly item falls back to the generic terminal prompt|single github_repo_ci item uses source-specific inline preview in the terminal prompt|user-defined remote_source profiles can opt into source-specific inline previews|preview-aware terminal prompts still dedupe unchanged lease reminders" test/agentinbox.test.ts