### PR TITLE
feat: repick iTerm2 Python API cursor-aware terminal activity detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "files": [
     "dist/src/",
+    "scripts/",
     "drizzle/",
     "README.md",
     "LICENSE"

--- a/scripts/iterm2_cursor_probe.py
+++ b/scripts/iterm2_cursor_probe.py
@@ -40,6 +40,7 @@ def probe_session(connection, session_id):
                     "status": "available",
                     "cursor": {"x": cursor.x, "y": cursor.y},
                     "screen_height": screen.number_of_lines,
+                    "start_line": start_line,
                     "lines": lines
                 }
             except Exception as e:

--- a/scripts/iterm2_cursor_probe.py
+++ b/scripts/iterm2_cursor_probe.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+iTerm2 Python API cursor probe for AgentInbox.
+Returns session state including cursor position and buffer contents.
+"""
+
+import sys
+import json
+import asyncio
+
+
+def probe_session(connection, session_id):
+    """Probe iTerm2 session state and return cursor position with buffer contents."""
+    try:
+        import iterm2
+
+        async def get_session_state():
+            try:
+                app = await iterm2.async_get_app(connection)
+                session = app.get_session_by_id(session_id)
+
+                if not session:
+                    return {"status": "gone"}
+
+                screen = await session.async_get_screen_contents()
+                cursor = screen.cursor_coord
+
+                # Get the last few lines of content
+                lines = []
+                start_line = max(0, screen.number_of_lines - 5)
+                for i in range(start_line, screen.number_of_lines):
+                    try:
+                        line = screen.line(i)
+                        line_str = line.string if hasattr(line, 'string') else str(line)
+                        lines.append(line_str)
+                    except Exception:
+                        break
+
+                return {
+                    "status": "available",
+                    "cursor": {"x": cursor.x, "y": cursor.y},
+                    "screen_height": screen.number_of_lines,
+                    "lines": lines
+                }
+            except Exception as e:
+                return {"status": "error", "error": str(e)}
+
+        return get_session_state()
+
+    except ImportError:
+        return {"status": "error", "error": "iterm2 module not installed"}
+
+
+def main():
+    if len(sys.argv) < 2:
+        result = {"status": "error", "error": "missing session_id argument"}
+        print(json.dumps(result))
+        sys.exit(1)
+
+    session_id = sys.argv[1]
+
+    # Try to import iterm2 and run the probe
+    try:
+        import iterm2
+        result = iterm2.run_until_complete(probe_session, session_id)
+        print(json.dumps(result))
+
+        # Exit with error code if status is not "available" or "gone"
+        if result.get("status") not in ["available", "gone"]:
+            sys.exit(1)
+        else:
+            sys.exit(0)
+
+    except ImportError:
+        result = {"status": "error", "error": "iterm2 module not installed"}
+        print(json.dumps(result))
+        sys.exit(1)
+    except Exception as e:
+        result = {"status": "error", "error": str(e)}
+        print(json.dumps(result))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -264,6 +264,30 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
             return { presence: "available", busy: "busy" };
           }
 
+          // If cursor-aware detection is certain it's not busy, don't apply prompt heuristics
+          if (busyStatus === "not_busy") {
+            // Still check for buffer changes and active markers
+            await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? DEFAULT_ITERM2_SAMPLE_DELAY_MS);
+            const secondResult = await this.execAsync("python3", [scriptPath, sessionId], {
+              env: { ...process.env, PYTHONIOENCODING: "utf-8" }
+            });
+            const secondData = JSON.parse(secondResult.stdout);
+
+            if (secondData.status === "available" && secondData.lines) {
+              const secondBufferTail = secondData.lines.join("\n");
+              if (bufferTail !== secondBufferTail) {
+                return { presence: "available", busy: "busy" };
+              }
+            }
+
+            // Check for active buffer markers
+            if (containsActiveBufferMarker(bufferTail)) {
+              return { presence: "available", busy: "busy" };
+            }
+
+            return { presence: "available", busy: "idle" };
+          }
+
           // If cursor-aware detection is uncertain, fall back to buffer change detection
           if (busyStatus === "unknown") {
             await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? DEFAULT_ITERM2_SAMPLE_DELAY_MS);
@@ -278,16 +302,16 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
                 return { presence: "available", busy: "busy" };
               }
             }
-          }
 
-          // Check for active buffer markers
-          if (containsActiveBufferMarker(bufferTail)) {
-            return { presence: "available", busy: "busy" };
-          }
+            // Check for active buffer markers
+            if (containsActiveBufferMarker(bufferTail)) {
+              return { presence: "available", busy: "busy" };
+            }
 
-          // Check for generic typing prompts as fallback
-          if (hasVisibleTypingPrompt(bufferTail)) {
-            return { presence: "available", busy: "busy" };
+            // Only apply generic typing prompts as fallback when cursor-aware detection is uncertain
+            if (hasVisibleTypingPrompt(bufferTail)) {
+              return { presence: "available", busy: "busy" };
+            }
           }
 
           // Return the cursor-aware detection result
@@ -931,22 +955,49 @@ function resolvePythonProbeScript(override?: string): string {
   if (override) {
     return override;
   }
-  const candidates = [
-    // Check relative to the project root
-    path.join(__dirname, "..", "scripts", "iterm2_cursor_probe.py"),
-    // Check installed location
-    path.join(process.cwd(), "scripts", "iterm2_cursor_probe.py"),
-    // Check development location
-    "/Users/jolestar/opensource/src/github.com/holon-run/agentinbox/scripts/iterm2_cursor_probe.py",
-  ];
+
+  const scriptRelativePath = path.join("scripts", "iterm2_cursor_probe.py");
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+
+  const addCandidate = (candidate: string): void => {
+    const normalized = path.normalize(candidate);
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      candidates.push(normalized);
+    }
+  };
+
+  // Search upward from the current module's directory
+  let currentDir = __dirname;
+  for (let i = 0; i < 5; i++) { // Limit upward search depth
+    addCandidate(path.join(currentDir, scriptRelativePath));
+    addCandidate(path.join(currentDir, "dist", scriptRelativePath));
+    addCandidate(path.join(currentDir, "dist", "src", scriptRelativePath));
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  // Check process working directory and its dist paths
+  addCandidate(path.join(process.cwd(), scriptRelativePath));
+  addCandidate(path.join(process.cwd(), "dist", scriptRelativePath));
+  addCandidate(path.join(process.cwd(), "dist", "src", scriptRelativePath));
+
+  // Check all candidates
   for (const candidate of candidates) {
     if (fs.existsSync(candidate)) {
       return candidate;
     }
   }
-  // Return the first candidate even if it doesn't exist
-  // This allows tests to mock the script execution
-  return candidates[0];
+
+  throw new Error(
+    `Unable to locate iterm2_cursor_probe.py. Checked: ${candidates.join(", ")}. ` +
+      "Ensure scripts/iterm2_cursor_probe.py is shipped with the package or copied into dist/ during build."
+  );
 }
 
 function runtimeTypingPromptPrefix(runtimeKind: TerminalActivationTarget["runtimeKind"]): string | null {
@@ -964,18 +1015,29 @@ function evaluateCursorAwareTypingPrompt(
   cursorPosition: { x: number; y: number },
   screenHeight: number,
   runtimeKind: string
-): TerminalBusyStatus {
+): "busy" | "not_busy" | "unknown" {
   const lines = bufferTail.split("\n");
   const lastLineIndex = lines.length - 1;
 
-  // If cursor row is beyond captured buffer, return unknown
-  if (cursorPosition.y > lastLineIndex) {
+  // Cursor coordinates are in full-screen rows, while bufferTail only contains
+  // the last visible lines of the screen. First ensure the cursor is on the
+  // terminal's last visible row, then map that row into the captured window.
+  if (cursorPosition.y !== screenHeight - 1) {
+    return "not_busy";
+  }
+
+  // Map the cursor position into the captured buffer window
+  const capturedStartRow = Math.max(0, screenHeight - lines.length);
+  const cursorRowInBuffer = cursorPosition.y - capturedStartRow;
+
+  // If the last visible screen row is not represented by the captured tail,
+  // or does not map to the last captured line, we cannot evaluate reliably.
+  if (cursorRowInBuffer < 0 || cursorRowInBuffer > lastLineIndex) {
     return "unknown";
   }
 
-  // Check if cursor is on the last visible line
-  if (cursorPosition.y < lastLineIndex) {
-    return "unknown";
+  if (cursorRowInBuffer !== lastLineIndex) {
+    return "not_busy";
   }
 
   const lastLine = lines[lastLineIndex] || "";
@@ -997,5 +1059,5 @@ function evaluateCursorAwareTypingPrompt(
     }
   }
 
-  return "unknown";
+  return "not_busy";
 }

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -250,12 +250,14 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
           const bufferTail = data.lines.join("\n");
           const cursorPosition = { x: data.cursor.x, y: data.cursor.y };
           const screenHeight = data.screen_height;
+          const startLine = data.start_line ?? 0;
 
           // Perform cursor-aware typing detection
           const busyStatus = evaluateCursorAwareTypingPrompt(
             bufferTail,
             cursorPosition,
             screenHeight,
+            startLine,
             runtimeKind
           );
 
@@ -1014,21 +1016,21 @@ function evaluateCursorAwareTypingPrompt(
   bufferTail: string,
   cursorPosition: { x: number; y: number },
   screenHeight: number,
+  startLine: number,
   runtimeKind: string
 ): "busy" | "not_busy" | "unknown" {
   const lines = bufferTail.split("\n");
   const lastLineIndex = lines.length - 1;
 
   // Cursor coordinates are in full-screen rows, while bufferTail only contains
-  // the last visible lines of the screen. First ensure the cursor is on the
+  // the lines from startLine to end of screen. First ensure the cursor is on the
   // terminal's last visible row, then map that row into the captured window.
   if (cursorPosition.y !== screenHeight - 1) {
     return "not_busy";
   }
 
-  // Map the cursor position into the captured buffer window
-  const capturedStartRow = Math.max(0, screenHeight - lines.length);
-  const cursorRowInBuffer = cursorPosition.y - capturedStartRow;
+  // Map the cursor position into the captured buffer window using startLine
+  const cursorRowInBuffer = cursorPosition.y - startLine;
 
   // If the last visible screen row is not represented by the captured tail,
   // or does not map to the last captured line, we cannot evaluate reliably.

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -253,7 +253,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
           const startLine = data.start_line ?? 0;
 
           // Perform cursor-aware typing detection
-          const busyStatus = evaluateCursorAwareTypingPrompt(
+          const busyStatus = evaluatePythonCursorAwareTypingPrompt(
             bufferTail,
             cursorPosition,
             screenHeight,
@@ -995,17 +995,7 @@ function resolvePythonProbeScript(override?: string): string {
   );
 }
 
-function runtimeTypingPromptPrefix(runtimeKind: TerminalActivationTarget["runtimeKind"]): string | null {
-  if (runtimeKind === "codex") {
-    return "› ";
-  }
-  if (runtimeKind === "claude_code") {
-    return "❯ ";
-  }
-  return null;
-}
-
-function evaluateCursorAwareTypingPrompt(
+function evaluatePythonCursorAwareTypingPrompt(
   bufferTail: string,
   cursorPosition: { x: number; y: number },
   screenHeight: number,

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -189,8 +189,10 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
     private readonly execAsync: ExecFileAsyncLike = execFileAsync,
     private readonly options: {
       iterm2ApiPath?: string;
+      pythonScriptPath?: string;
       sampleDelayMs?: number;
       sleep?: (ms: number) => Promise<void>;
+      enablePythonProbe?: boolean;
     } = {},
   ) {}
 
@@ -214,6 +216,100 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
       return { presence: "unknown", busy: "unknown" };
     }
 
+    // Try Python API probe first (if enabled)
+    if (this.options.enablePythonProbe !== false) {
+      const pythonResult = await this.tryPythonApiProbe(sessionId, target.runtimeKind);
+      if (pythonResult && pythonResult.presence !== "unknown") {
+        return pythonResult;
+      }
+    }
+
+    // Fallback to command-line tools
+    return this.checkWithCommandLineTools(sessionId);
+  }
+
+  private async tryPythonApiProbe(
+    sessionId: string,
+    runtimeKind: string
+  ): Promise<{ presence: TerminalPresenceStatus; busy: TerminalBusyStatus } | null> {
+    try {
+      const scriptPath = this.options.pythonScriptPath ?? resolvePythonProbeScript();
+      const result = await this.execAsync("python3", [scriptPath, sessionId], {
+        env: { ...process.env, PYTHONIOENCODING: "utf-8" }
+      });
+
+      const data = JSON.parse(result.stdout);
+
+      if (data.status === "gone") {
+        return { presence: "gone", busy: "unknown" };
+      }
+
+      if (data.status === "available") {
+        // If we have cursor and lines data, use cursor-aware detection
+        if (data.cursor && data.lines) {
+          const bufferTail = data.lines.join("\n");
+          const cursorPosition = { x: data.cursor.x, y: data.cursor.y };
+          const screenHeight = data.screen_height;
+
+          // Perform cursor-aware typing detection
+          const busyStatus = evaluateCursorAwareTypingPrompt(
+            bufferTail,
+            cursorPosition,
+            screenHeight,
+            runtimeKind
+          );
+
+          // If cursor-aware detection indicates busy, return immediately
+          if (busyStatus === "busy") {
+            return { presence: "available", busy: "busy" };
+          }
+
+          // If cursor-aware detection is uncertain, fall back to buffer change detection
+          if (busyStatus === "unknown") {
+            await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? DEFAULT_ITERM2_SAMPLE_DELAY_MS);
+            const secondResult = await this.execAsync("python3", [scriptPath, sessionId], {
+              env: { ...process.env, PYTHONIOENCODING: "utf-8" }
+            });
+            const secondData = JSON.parse(secondResult.stdout);
+
+            if (secondData.status === "available" && secondData.lines) {
+              const secondBufferTail = secondData.lines.join("\n");
+              if (bufferTail !== secondBufferTail) {
+                return { presence: "available", busy: "busy" };
+              }
+            }
+          }
+
+          // Check for active buffer markers
+          if (containsActiveBufferMarker(bufferTail)) {
+            return { presence: "available", busy: "busy" };
+          }
+
+          // Check for generic typing prompts as fallback
+          if (hasVisibleTypingPrompt(bufferTail)) {
+            return { presence: "available", busy: "busy" };
+          }
+
+          // Return the cursor-aware detection result
+          return { presence: "available", busy: busyStatus };
+        }
+
+        // If we don't have cursor data, return unknown to trigger fallback
+        return null;
+      }
+
+      // Any other status means we should fall back
+      return null;
+    } catch {
+      // Python API probe failed, fall back to command-line tools
+      return null;
+    }
+  }
+
+  private async checkWithCommandLineTools(sessionId: string): Promise<{
+    presence: TerminalPresenceStatus;
+    busy: TerminalBusyStatus;
+  }> {
     let it2api: string;
     try {
       it2api = resolveIterm2ApiPath(this.options.iterm2ApiPath);
@@ -829,4 +925,77 @@ function parseIterm2SessionIds(stdout: string): string[] {
       return match ? match[1] : null;
     })
     .filter((id): id is string => id !== null);
+}
+
+function resolvePythonProbeScript(override?: string): string {
+  if (override) {
+    return override;
+  }
+  const candidates = [
+    // Check relative to the project root
+    path.join(__dirname, "..", "scripts", "iterm2_cursor_probe.py"),
+    // Check installed location
+    path.join(process.cwd(), "scripts", "iterm2_cursor_probe.py"),
+    // Check development location
+    "/Users/jolestar/opensource/src/github.com/holon-run/agentinbox/scripts/iterm2_cursor_probe.py",
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  // Return the first candidate even if it doesn't exist
+  // This allows tests to mock the script execution
+  return candidates[0];
+}
+
+function runtimeTypingPromptPrefix(runtimeKind: TerminalActivationTarget["runtimeKind"]): string | null {
+  if (runtimeKind === "codex") {
+    return "› ";
+  }
+  if (runtimeKind === "claude_code") {
+    return "❯ ";
+  }
+  return null;
+}
+
+function evaluateCursorAwareTypingPrompt(
+  bufferTail: string,
+  cursorPosition: { x: number; y: number },
+  screenHeight: number,
+  runtimeKind: string
+): TerminalBusyStatus {
+  const lines = bufferTail.split("\n");
+  const lastLineIndex = lines.length - 1;
+
+  // If cursor row is beyond captured buffer, return unknown
+  if (cursorPosition.y > lastLineIndex) {
+    return "unknown";
+  }
+
+  // Check if cursor is on the last visible line
+  if (cursorPosition.y < lastLineIndex) {
+    return "unknown";
+  }
+
+  const lastLine = lines[lastLineIndex] || "";
+  const promptPrefix = runtimeTypingPromptPrefix(runtimeKind as TerminalActivationTarget["runtimeKind"]);
+
+  if (!promptPrefix) {
+    return "unknown";
+  }
+
+  // Check if the last line starts with the runtime-specific prompt prefix
+  if (lastLine.startsWith(promptPrefix)) {
+    // Check if cursor is after the prompt prefix
+    if (cursorPosition.x > promptPrefix.length) {
+      const afterPrompt = lastLine.slice(promptPrefix.length).trim();
+      // If there's content after the prompt, user is typing
+      if (afterPrompt.length > 0) {
+        return "busy";
+      }
+    }
+  }
+
+  return "unknown";
 }

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -290,7 +290,8 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
             return { presence: "available", busy: "idle" };
           }
 
-          // If cursor-aware detection is uncertain, fall back to buffer change detection
+          // If cursor-aware detection is uncertain, fall back to buffer change detection only
+          // Do NOT use generic typing prompts to avoid false positives (see #116)
           if (busyStatus === "unknown") {
             await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? DEFAULT_ITERM2_SAMPLE_DELAY_MS);
             const secondResult = await this.execAsync("python3", [scriptPath, sessionId], {
@@ -310,10 +311,9 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
               return { presence: "available", busy: "busy" };
             }
 
-            // Only apply generic typing prompts as fallback when cursor-aware detection is uncertain
-            if (hasVisibleTypingPrompt(bufferTail)) {
-              return { presence: "available", busy: "busy" };
-            }
+            // Return unknown when cursor-aware detection is uncertain
+            // Do NOT fall back to generic typing prompts to avoid false positives
+            return { presence: "available", busy: "unknown" };
           }
 
           // This should never be reached as all cases are handled above
@@ -365,9 +365,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
     if (containsActiveBufferMarker(second)) {
       return { presence: "available", busy: "busy" };
     }
-    if (hasVisibleTypingPrompt(second)) {
-      return { presence: "available", busy: "busy" };
-    }
+    // Do NOT use generic typing prompts to avoid false positives (see #116)
     return { presence: "available", busy: "unknown" };
   }
 
@@ -448,17 +446,12 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
     if (containsActiveBufferMarker(second)) {
       return { presence: "available", busy: "busy" };
     }
+    // Use cursor-aware detection when available
     const cursorHint = evaluateCursorAwareTypingPrompt(target, paneState, second);
     if (cursorHint === "busy") {
       return { presence: "available", busy: "busy" };
     }
-    if (
-      cursorHint === "unknown" &&
-      paneState.active &&
-      hasVisibleTypingPrompt(second, typingPromptPrefixesForRuntime(target.runtimeKind))
-    ) {
-      return { presence: "available", busy: "busy" };
-    }
+    // Do NOT fall back to generic typing prompts when cursorHint is unknown to avoid false positives (see #116)
     return { presence: "available", busy: "unknown" };
   }
 

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -316,8 +316,8 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
             }
           }
 
-          // Return the cursor-aware detection result
-          return { presence: "available", busy: busyStatus };
+          // This should never be reached as all cases are handled above
+          return { presence: "available", busy: "unknown" };
         }
 
         // If we don't have cursor data, return unknown to trigger fallback

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -523,7 +523,6 @@ test("TmuxTerminalStateProbe reports busy when the stable buffer shows a codex a
   });
 });
 
-<<<<<<< HEAD
 test("TmuxTerminalStateProbe reports busy when the cursor is past a codex prompt prefix on the input row", async () => {
   const probe = new TmuxTerminalStateProbe(async (_file, args) => {
     if (args[0] === "display-message") {
@@ -606,9 +605,11 @@ test("TmuxTerminalStateProbe falls back to prompt heuristics when the cursor row
     sleep: async () => {},
   });
 
+  // After PR #116 tightening, when cursor-aware mapping is uncertain we do not
+  // fall back to generic prompt heuristics, to avoid false positives.
   assert.deepEqual(await probe.check(makeTmuxTarget()), {
     presence: "available",
-    busy: "busy",
+    busy: "unknown",
   });
 });
 

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -808,17 +808,18 @@ test("Iterm2TerminalStateProbe with Python API reports busy when cursor is at pr
   const probe = new Iterm2TerminalStateProbe(
     async (file, args) => {
       if (file === "python3") {
-        // Simulate Python API response with cursor at prompt with input
+        // Simulate Python API response with the cursor on the in-bounds prompt line.
         return {
           stdout: JSON.stringify({
             status: "available",
-            cursor: { x: 10, y: 4 }, // Cursor after "› " (2 chars) + "test" (4 chars) + extra
+            cursor: { x: 10, y: 4 }, // Last line in `lines`; cursor is within the prompt line content.
             screen_height: 5,
+            start_line: 0,
             lines: [
               "line 1",
               "line 2",
               "line 3",
-              "› test input" // Cursor is at position 10, after "test"
+              "› test input" // Cursor is on this prompt line, after the entered input.
             ]
           }),
           stderr: ""
@@ -840,7 +841,7 @@ test("Iterm2TerminalStateProbe with Python API reports busy when cursor is at pr
   assert.equal(result.busy, "busy");
 });
 
-test("Iterm2TerminalStateProbe with Python API reports unknown when cursor is not at prompt line", async () => {
+test("Iterm2TerminalStateProbe with Python API reports idle when cursor is not at prompt line", async () => {
   const probe = new Iterm2TerminalStateProbe(
     async (file, args) => {
       if (file === "python3") {
@@ -850,6 +851,7 @@ test("Iterm2TerminalStateProbe with Python API reports unknown when cursor is no
             status: "available",
             cursor: { x: 5, y: 2 }, // Cursor at line 2, not at last line (4)
             screen_height: 5,
+            start_line: 0,
             lines: [
               "line 1",
               "line 2 with cursor",
@@ -873,7 +875,7 @@ test("Iterm2TerminalStateProbe with Python API reports unknown when cursor is no
   const result = await probe.check(target);
 
   assert.equal(result.presence, "available");
-  assert.equal(result.busy, "unknown");
+  assert.equal(result.busy, "idle");
 });
 
 test("Iterm2TerminalStateProbe with Python API falls back to CLI when Python fails", async () => {
@@ -892,7 +894,7 @@ test("Iterm2TerminalStateProbe with Python API falls back to CLI when Python fai
         }
         if (args[0] === "get-buffer") {
           return {
-            stdout: "› test input\nmore content",
+            stdout: "more content\n› test input",
             stderr: ""
           };
         }
@@ -910,7 +912,7 @@ test("Iterm2TerminalStateProbe with Python API falls back to CLI when Python fai
   const target = makeItermTarget();
   const result = await probe.check(target);
 
-  // Should fall back to CLI which reports busy due to typing prompt
+  // Should fall back to CLI which reports busy due to typing prompt on last line
   assert.equal(result.presence, "available");
   assert.equal(result.busy, "busy");
 });

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -268,7 +268,7 @@ test("Iterm2TerminalStateProbe reports unknown when the buffer is stable and qui
   });
 });
 
-test("Iterm2TerminalStateProbe reports busy when the stable buffer shows visible typed input", async () => {
+test("Iterm2TerminalStateProbe reports unknown when the stable buffer shows visible typed input", async () => {
   const probe = new Iterm2TerminalStateProbe(async (_file, args) => {
     if (args[0] === "list-sessions") {
       return {
@@ -291,9 +291,11 @@ test("Iterm2TerminalStateProbe reports busy when the stable buffer shows visible
     sleep: async () => {},
   });
 
+  // After PR #116 tightening, generic typing prompts are no longer used to avoid false positives
+  // The buffer is stable and shows no active markers, so it returns unknown
   assert.deepEqual(await probe.check(makeItermTarget()), {
     presence: "available",
-    busy: "busy",
+    busy: "unknown",
   });
 });
 
@@ -521,6 +523,7 @@ test("TmuxTerminalStateProbe reports busy when the stable buffer shows a codex a
   });
 });
 
+<<<<<<< HEAD
 test("TmuxTerminalStateProbe reports busy when the cursor is past a codex prompt prefix on the input row", async () => {
   const probe = new TmuxTerminalStateProbe(async (_file, args) => {
     if (args[0] === "display-message") {
@@ -609,7 +612,7 @@ test("TmuxTerminalStateProbe falls back to prompt heuristics when the cursor row
   });
 });
 
-test("TmuxTerminalStateProbe falls back to prompt heuristics when cursor metadata is unavailable", async () => {
+test("TmuxTerminalStateProbe reports unknown when cursor metadata is unavailable and prompt heuristics would apply", async () => {
   const probe = new TmuxTerminalStateProbe(async (_file, args) => {
     if (args[0] === "display-message") {
       return { stdout: "1 0\n", stderr: "" };
@@ -625,9 +628,11 @@ test("TmuxTerminalStateProbe falls back to prompt heuristics when cursor metadat
     sleep: async () => {},
   });
 
+  // After PR #116 tightening, when cursor metadata is unavailable, we do NOT fall back to
+  // generic prompt heuristics to avoid false positives
   assert.deepEqual(await probe.check(makeTmuxTarget()), {
     presence: "available",
-    busy: "busy",
+    busy: "unknown",
   });
 });
 
@@ -914,9 +919,10 @@ test("Iterm2TerminalStateProbe with Python API falls back to CLI when Python fai
   const target = makeItermTarget();
   const result = await probe.check(target);
 
-  // Should fall back to CLI which reports busy due to typing prompt on last line
+  // After PR #116 tightening, CLI fallback no longer uses generic typing prompts to avoid false positives
+  // The buffer is stable and shows no active markers, so it returns unknown
   assert.equal(result.presence, "available");
-  assert.equal(result.busy, "busy");
+  assert.equal(result.busy, "unknown");
 });
 
 test("Iterm2TerminalStateProbe with Python API reports gone when session is gone", async () => {

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -803,3 +803,142 @@ test("Iterm2TerminalStateProbe supports non-claude iTerm2 targets", () => {
   const codexTarget = makeItermTarget(); // This has runtimeKind: "codex"
   assert.equal(probe.supports(codexTarget), true);
 });
+
+test("Iterm2TerminalStateProbe with Python API reports busy when cursor is at prompt with input", async () => {
+  const probe = new Iterm2TerminalStateProbe(
+    async (file, args) => {
+      if (file === "python3") {
+        // Simulate Python API response with cursor at prompt with input
+        return {
+          stdout: JSON.stringify({
+            status: "available",
+            cursor: { x: 10, y: 4 }, // Cursor after "› " (2 chars) + "test" (4 chars) + extra
+            screen_height: 5,
+            lines: [
+              "line 1",
+              "line 2",
+              "line 3",
+              "› test input" // Cursor is at position 10, after "test"
+            ]
+          }),
+          stderr: ""
+        };
+      }
+      throw new Error("Unexpected command: " + file);
+    },
+    {
+      pythonScriptPath: "/tmp/fake-python-probe.py",
+      sampleDelayMs: 0,
+      sleep: async () => {}
+    }
+  );
+
+  const target = makeItermTarget();
+  const result = await probe.check(target);
+
+  assert.equal(result.presence, "available");
+  assert.equal(result.busy, "busy");
+});
+
+test("Iterm2TerminalStateProbe with Python API reports unknown when cursor is not at prompt line", async () => {
+  const probe = new Iterm2TerminalStateProbe(
+    async (file, args) => {
+      if (file === "python3") {
+        // Simulate Python API response with cursor not at last line
+        return {
+          stdout: JSON.stringify({
+            status: "available",
+            cursor: { x: 5, y: 2 }, // Cursor at line 2, not at last line (4)
+            screen_height: 5,
+            lines: [
+              "line 1",
+              "line 2 with cursor",
+              "line 3",
+              "› test input"
+            ]
+          }),
+          stderr: ""
+        };
+      }
+      throw new Error("Unexpected command");
+    },
+    {
+      pythonScriptPath: "/tmp/fake-python-probe.py",
+      sampleDelayMs: 0,
+      sleep: async () => {}
+    }
+  );
+
+  const target = makeItermTarget();
+  const result = await probe.check(target);
+
+  assert.equal(result.presence, "available");
+  assert.equal(result.busy, "unknown");
+});
+
+test("Iterm2TerminalStateProbe with Python API falls back to CLI when Python fails", async () => {
+  const probe = new Iterm2TerminalStateProbe(
+    async (file, args) => {
+      if (file === "python3") {
+        throw new Error("Python not available");
+      }
+      // Fall back to it2api
+      if (file === "/tmp/fake-it2api") {
+        if (args[0] === "list-sessions") {
+          return {
+            stdout: `Session "test" id=4F7A2F18-E5F4-4E27-A391-23953DE1F826 (110 x 30)`,
+            stderr: ""
+          };
+        }
+        if (args[0] === "get-buffer") {
+          return {
+            stdout: "› test input\nmore content",
+            stderr: ""
+          };
+        }
+      }
+      throw new Error("Unexpected command");
+    },
+    {
+      pythonScriptPath: "/tmp/fake-python-probe.py",
+      iterm2ApiPath: "/tmp/fake-it2api",
+      sampleDelayMs: 0,
+      sleep: async () => {}
+    }
+  );
+
+  const target = makeItermTarget();
+  const result = await probe.check(target);
+
+  // Should fall back to CLI which reports busy due to typing prompt
+  assert.equal(result.presence, "available");
+  assert.equal(result.busy, "busy");
+});
+
+test("Iterm2TerminalStateProbe with Python API reports gone when session is gone", async () => {
+  const probe = new Iterm2TerminalStateProbe(
+    async (file, args) => {
+      if (file === "python3") {
+        // Simulate Python API response for gone session
+        return {
+          stdout: JSON.stringify({
+            status: "gone"
+          }),
+          stderr: ""
+        };
+      }
+      throw new Error("Unexpected command");
+    },
+    {
+      pythonScriptPath: "/tmp/fake-python-probe.py",
+      sampleDelayMs: 0,
+      sleep: async () => {}
+    }
+  );
+
+  const target = makeItermTarget();
+  const result = await probe.check(target);
+
+  assert.equal(result.presence, "gone");
+  assert.equal(result.busy, "unknown");
+});

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -812,14 +812,15 @@ test("Iterm2TerminalStateProbe with Python API reports busy when cursor is at pr
         return {
           stdout: JSON.stringify({
             status: "available",
-            cursor: { x: 10, y: 4 }, // Last line in `lines`; cursor is within the prompt line content.
+            cursor: { x: 10, y: 4 }, // Last line (index 4) in 5-line screen; cursor at last line.
             screen_height: 5,
             start_line: 0,
             lines: [
               "line 1",
               "line 2",
               "line 3",
-              "› test input" // Cursor is on this prompt line, after the entered input.
+              "line 4",
+              "› test input" // Cursor is on this prompt line (index 4), after the entered input.
             ]
           }),
           stderr: ""
@@ -856,6 +857,7 @@ test("Iterm2TerminalStateProbe with Python API reports idle when cursor is not a
               "line 1",
               "line 2 with cursor",
               "line 3",
+              "line 4",
               "› test input"
             ]
           }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,4 +24,3 @@
     "test/**/*.ts"
   ]
 }
-# TypeScript test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,3 +24,4 @@
     "test/**/*.ts"
   ]
 }
+# TypeScript test


### PR DESCRIPTION
## Summary
- repick the iTerm2 Python API cursor-aware terminal activity detection work from the broken #119 branch onto current `main`
- preserve the intended Python probe, cursor mapping, packaging, and false-positive tightening changes
- clean up rebase damage that left a stray conflict marker and duplicate helper definitions in the old branch

## Notes
- this supersedes the broken PR #119 branch history
- the code was rebuilt from the known-good commit set on `worktree-iterm2-python-probe`, then verified on top of current `main`

## Testing
- npm install --legacy-peer-deps --no-audit --no-fund
- npm run build
- node --require ts-node/register --test test/runtime_gate.test.ts