### PR TITLE
refactor: align remote source module naming

### DIFF
--- a/docs/site/reference/source-types.md
+++ b/docs/site/reference/source-types.md
@@ -14,7 +14,7 @@ without building a provider-specific adapter first.
 
 `remote_source` is the generic external-source runtime surface.
 
-It uses a local profile module to define:
+It uses a local module to define:
 
 - managed source spec (`source.ensure`)
 - raw event mapping (`stream.read` payload -> AgentInbox event)
@@ -32,7 +32,7 @@ instance schema discovery:
 Configuration fields:
 
 - `profilePath` (required): path under `$AGENTINBOX_HOME/source-profiles`
-- `profileConfig` (optional): profile-specific config object
+- `profileConfig` (optional): module-specific config object
 
 ## `github_repo`
 

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -14,7 +14,7 @@ import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubDeliveryAdapter } from "./sources/github";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
-import { ExpandedSubscriptionInput, LifecycleSignal, RemoteSourceProfileRegistry } from "./sources/remote_profiles";
+import { ExpandedSubscriptionInput, LifecycleSignal, RemoteSourceModuleRegistry } from "./sources/remote_modules";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
 
 export interface SourceAdapter {
@@ -70,7 +70,7 @@ export class AdapterRegistry {
   private readonly feishuDelivery = new FeishuDeliveryAdapter();
   private readonly githubDelivery = new GithubDeliveryAdapter();
   private readonly homeDir: string;
-  private readonly remoteProfileRegistry: RemoteSourceProfileRegistry;
+  private readonly remoteModuleRegistry: RemoteSourceModuleRegistry;
 
   constructor(
     store: AgentInboxStore,
@@ -78,15 +78,15 @@ export class AdapterRegistry {
     options?: {
       homeDir?: string;
       remoteSourceClient?: UxcRemoteSourceClient;
-      remoteProfileRegistry?: RemoteSourceProfileRegistry;
+      remoteModuleRegistry?: RemoteSourceModuleRegistry;
     },
   ) {
     this.homeDir = options?.homeDir ?? resolveAgentInboxHome(process.env);
-    this.remoteProfileRegistry = options?.remoteProfileRegistry ?? new RemoteSourceProfileRegistry();
+    this.remoteModuleRegistry = options?.remoteModuleRegistry ?? new RemoteSourceModuleRegistry();
     this.remoteSource = new RemoteSourceRuntime(store, appendSourceEvent, {
       homeDir: this.homeDir,
       client: options?.remoteSourceClient,
-      profileRegistry: this.remoteProfileRegistry,
+      moduleRegistry: this.remoteModuleRegistry,
     });
   }
 
@@ -166,14 +166,14 @@ export class AdapterRegistry {
   async resolveSourceIdentity(source: SubscriptionSource): Promise<ResolvedSourceIdentity> {
     return resolveSourceIdentity(source, {
       homeDir: this.homeDir,
-      profileRegistry: this.remoteProfileRegistry,
+      moduleRegistry: this.remoteModuleRegistry,
     });
   }
 
   async resolveSourceSchema(source: SubscriptionSource): Promise<ResolvedSourceSchema> {
     return resolveSourceSchema(source, {
       homeDir: this.homeDir,
-      profileRegistry: this.remoteProfileRegistry,
+      moduleRegistry: this.remoteModuleRegistry,
     });
   }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -1358,6 +1358,7 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("invalid webhook activation target") ||
     message.startsWith("remote_source requires") ||
     message.startsWith("remote_source profile") ||
+    message.startsWith("remote_source module") ||
     message.includes("requires tmuxPaneId") ||
     message.includes("requires iTerm2 session identity") ||
     message.includes("requires a supported terminal context") ||

--- a/src/service.ts
+++ b/src/service.ts
@@ -60,7 +60,7 @@ import {
   renderAgentPrompt,
   TerminalDispatcher,
 } from "./terminal";
-import { LifecycleSignal } from "./sources/remote_profiles";
+import { LifecycleSignal } from "./sources/remote_modules";
 import { ActivationGate, DefaultActivationGate } from "./runtime_gate";
 
 const DEFAULT_SUBSCRIPTION_POLL_LIMIT = 100;

--- a/src/source_resolution.ts
+++ b/src/source_resolution.ts
@@ -1,11 +1,11 @@
 import { resolveAgentInboxHome } from "./paths";
 import { ResolvedSourceIdentity, ResolvedSourceSchema, SourceSchema, SubscriptionSource } from "./model";
-import { RemoteSourceProfile, RemoteSourceProfileRegistry, builtInProfileIdForSourceType, profileConfigForSource } from "./sources/remote_profiles";
+import { RemoteSourceModule, RemoteSourceModuleRegistry, builtInModuleIdForSourceType, moduleConfigForSource } from "./sources/remote_modules";
 import { getSourceSchema } from "./source_schema";
 
 export interface ResolveSourceContext {
   homeDir?: string;
-  profileRegistry?: RemoteSourceProfileRegistry;
+  moduleRegistry?: RemoteSourceModuleRegistry;
 }
 
 export async function resolveSourceIdentity(
@@ -20,7 +20,7 @@ export async function resolveSourceIdentity(
     };
   }
 
-  const builtinImplementationId = builtInProfileIdForSourceType(source.sourceType);
+  const builtinImplementationId = builtInModuleIdForSourceType(source.sourceType);
   if (builtinImplementationId) {
     return {
       hostType: "remote_source",
@@ -33,16 +33,16 @@ export async function resolveSourceIdentity(
     throw new Error(`unsupported source type for source resolution: ${source.sourceType}`);
   }
 
-  const profileRegistry = context.profileRegistry ?? new RemoteSourceProfileRegistry();
+  const moduleRegistry = context.moduleRegistry ?? new RemoteSourceModuleRegistry();
   const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
-  const profile = await profileRegistry.resolve(source, homeDir);
-  const capabilityDescription = typeof profile.describeCapabilities === "function"
-    ? profile.describeCapabilities(profileInputSource(source))
+  const module = await moduleRegistry.resolve(source, homeDir);
+  const capabilityDescription = typeof module.describeCapabilities === "function"
+    ? module.describeCapabilities(moduleInputSource(source))
     : undefined;
   return {
     hostType: "remote_source",
-    sourceKind: capabilityDescription?.sourceKind?.trim() || `remote:${profile.id}`,
-    implementationId: profile.id,
+    sourceKind: capabilityDescription?.sourceKind?.trim() || `remote:${module.id}`,
+    implementationId: module.id,
   };
 }
 
@@ -50,17 +50,17 @@ export async function resolveSourceSchema(
   source: SubscriptionSource,
   context: ResolveSourceContext = {},
 ): Promise<ResolvedSourceSchema> {
-  const profileRegistry = context.profileRegistry ?? new RemoteSourceProfileRegistry();
+  const moduleRegistry = context.moduleRegistry ?? new RemoteSourceModuleRegistry();
   const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
-  const resolvedContext: ResolveSourceContext = { ...context, profileRegistry, homeDir };
+  const resolvedContext: ResolveSourceContext = { ...context, moduleRegistry, homeDir };
   const identity = await resolveSourceIdentity(source, resolvedContext);
   const staticSchema = getSourceSchema(source.sourceType);
-  let capabilityDescription: ReturnType<NonNullable<RemoteSourceProfile["describeCapabilities"]>> | undefined;
-  let profile: RemoteSourceProfile | null = null;
+  let capabilityDescription: ReturnType<NonNullable<RemoteSourceModule["describeCapabilities"]>> | undefined;
+  let module: RemoteSourceModule | null = null;
   if (identity.hostType === "remote_source") {
-    profile = await profileRegistry.resolve(source, homeDir);
-    capabilityDescription = typeof profile.describeCapabilities === "function"
-      ? profile.describeCapabilities(profileInputSource(source))
+    module = await moduleRegistry.resolve(source, homeDir);
+    capabilityDescription = typeof module.describeCapabilities === "function"
+      ? module.describeCapabilities(moduleInputSource(source))
       : undefined;
   }
   return withResolvedIdentity(
@@ -76,10 +76,10 @@ export async function resolveSourceSchema(
     identity.hostType === "remote_source"
       ? {
           aliases: capabilityDescription?.aliases,
-          supportsTrackedResourceRef: typeof profile?.deriveTrackedResource === "function",
-          supportsLifecycleSignals: typeof profile?.projectLifecycleSignal === "function",
-          shortcuts: typeof profile?.listSubscriptionShortcuts === "function"
-            ? profile.listSubscriptionShortcuts(profileInputSource(source))
+          supportsTrackedResourceRef: typeof module?.deriveTrackedResource === "function",
+          supportsLifecycleSignals: typeof module?.projectLifecycleSignal === "function",
+          shortcuts: typeof module?.listSubscriptionShortcuts === "function"
+            ? module.listSubscriptionShortcuts(moduleInputSource(source))
             : [],
         }
       : undefined,
@@ -122,12 +122,12 @@ export function withResolvedIdentity(
   };
 }
 
-function profileInputSource(source: SubscriptionSource): SubscriptionSource {
+function moduleInputSource(source: SubscriptionSource): SubscriptionSource {
   if (source.sourceType !== "remote_source") {
     return source;
   }
   return {
     ...source,
-    config: profileConfigForSource(source),
+    config: moduleConfigForSource(source),
   };
 }

--- a/src/source_schema.ts
+++ b/src/source_schema.ts
@@ -19,7 +19,7 @@ const SOURCE_SCHEMAS: Record<SourceType, SourceSchema> = {
     payloadExamples: [],
     eventVariantExamples: [],
     configFields: [
-      { name: "profilePath", type: "string", required: true, description: "Local profile module path under $AGENTINBOX_HOME/source-profiles." },
+      { name: "profilePath", type: "string", required: true, description: "Local module path under $AGENTINBOX_HOME/source-profiles." },
       { name: "profileConfig", type: "object", required: false, description: "Profile-specific configuration passed to validate/spec/map hooks." },
     ],
   },

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -3,7 +3,7 @@ import { ActivationItem, AppendSourceEventInput, SourcePollResult, SubscriptionS
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
 import { nowIso } from "../util";
-import { ExpandedSubscriptionInput, LifecycleSignal, ManagedSourceSpec, RemoteSourceProfileRegistry } from "./remote_profiles";
+import { ExpandedSubscriptionInput, LifecycleSignal, ManagedSourceSpec, RemoteSourceModuleRegistry } from "./remote_modules";
 
 const REMOTE_SOURCE_TYPES = new Set<SubscriptionSource["sourceType"]>([
   "remote_source",
@@ -84,7 +84,7 @@ export class RpcUxcRemoteSourceClient implements UxcRemoteSourceClient {
 }
 
 export class RemoteSourceRuntime {
-  private readonly profileRegistry: RemoteSourceProfileRegistry;
+  private readonly moduleRegistry: RemoteSourceModuleRegistry;
   private readonly client: UxcRemoteSourceClient;
   private interval: NodeJS.Timeout | null = null;
   private readonly inFlight = new Set<string>();
@@ -96,12 +96,12 @@ export class RemoteSourceRuntime {
     private readonly store: AgentInboxStore,
     private readonly appendSourceEvent: (input: AppendSourceEventInput) => Promise<{ appended: number; deduped: number }>,
     options?: {
-      profileRegistry?: RemoteSourceProfileRegistry;
+      moduleRegistry?: RemoteSourceModuleRegistry;
       client?: UxcRemoteSourceClient;
       homeDir?: string;
     },
   ) {
-    this.profileRegistry = options?.profileRegistry ?? new RemoteSourceProfileRegistry();
+    this.moduleRegistry = options?.moduleRegistry ?? new RemoteSourceModuleRegistry();
     this.client = options?.client ?? new RpcUxcRemoteSourceClient();
     this.homeDir = options?.homeDir ?? resolveAgentInboxHome(process.env);
   }
@@ -117,10 +117,10 @@ export class RemoteSourceRuntime {
     if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
       return;
     }
-    const profile = await this.profileRegistry.resolve(source, this.homeDir);
-    const profileSource = profileInputSource(source);
-    profile.validateConfig(profileSource);
-    profile.buildManagedSourceSpec(profileSource);
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    const moduleSource = moduleInputSource(source);
+    module.validateConfig(moduleSource);
+    module.buildManagedSourceSpec(moduleSource);
   }
 
   async start(): Promise<void> {
@@ -216,11 +216,11 @@ export class RemoteSourceRuntime {
     if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
       return null;
     }
-    const profile = await this.profileRegistry.resolve(source, this.homeDir);
-    if (typeof profile.projectLifecycleSignal !== "function") {
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    if (typeof module.projectLifecycleSignal !== "function") {
       return null;
     }
-    return profile.projectLifecycleSignal(rawPayload, profileInputSource(source));
+    return module.projectLifecycleSignal(rawPayload, moduleInputSource(source));
   }
 
   async expandSubscriptionShortcut(
@@ -230,14 +230,14 @@ export class RemoteSourceRuntime {
     if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
       return null;
     }
-    const profile = await this.profileRegistry.resolve(source, this.homeDir);
-    if (typeof profile.expandSubscriptionShortcut !== "function") {
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    if (typeof module.expandSubscriptionShortcut !== "function") {
       return null;
     }
-    return profile.expandSubscriptionShortcut({
+    return module.expandSubscriptionShortcut({
       name: input.name,
       args: input.args,
-      source: profileInputSource(source),
+      source: moduleInputSource(source),
     });
   }
 
@@ -245,11 +245,11 @@ export class RemoteSourceRuntime {
     if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
       return null;
     }
-    const profile = await this.profileRegistry.resolve(source, this.homeDir);
-    if (typeof profile.deriveInlinePreview !== "function") {
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    if (typeof module.deriveInlinePreview !== "function") {
       return null;
     }
-    return profile.deriveInlinePreview(item, profileInputSource(source));
+    return module.deriveInlinePreview(item, moduleInputSource(source));
   }
 
   private async syncAll(): Promise<void> {
@@ -307,10 +307,10 @@ export class RemoteSourceRuntime {
         }
       }
 
-      const profile = await this.profileRegistry.resolve(source, this.homeDir);
-      const profileSource = profileInputSource(source);
-      profile.validateConfig(profileSource);
-      const spec = profile.buildManagedSourceSpec(profileSource);
+      const module = await this.moduleRegistry.resolve(source, this.homeDir);
+      const moduleSource = moduleInputSource(source);
+      module.validateConfig(moduleSource);
+      const spec = module.buildManagedSourceSpec(moduleSource);
       const binding = managedBindingForSource(source);
       const ensured = await this.client.sourceEnsure({
         namespace: binding.namespace,
@@ -333,7 +333,7 @@ export class RemoteSourceRuntime {
         if (Object.keys(rawPayload).length === 0) {
           continue;
         }
-        const mapped = profile.mapRawEvent(rawPayload, profileSource);
+        const mapped = module.mapRawEvent(rawPayload, moduleSource);
         if (!mapped) {
           continue;
         }
@@ -402,7 +402,7 @@ export class RemoteSourceRuntime {
   }
 }
 
-function profileInputSource(source: SubscriptionSource): SubscriptionSource {
+function moduleInputSource(source: SubscriptionSource): SubscriptionSource {
   if (source.sourceType !== "remote_source") {
     return source;
   }

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -83,7 +83,7 @@ export interface LifecycleSignal {
   occurredAt?: string;
 }
 
-export interface RemoteSourceProfile {
+export interface RemoteSourceModule {
   id: string;
   validateConfig(source: SubscriptionSource): void;
   buildManagedSourceSpec(source: SubscriptionSource): ManagedSourceSpec;
@@ -97,54 +97,54 @@ export interface RemoteSourceProfile {
   deriveInlinePreview?(item: ActivationItem, source: SubscriptionSource): string | null;
 }
 
-const REMOTE_USER_PROFILE_ROOT_DIR = "source-profiles";
-const BUILTIN_PROFILE_IDS = new Set(["builtin.github_repo", "builtin.github_repo_ci", "builtin.feishu_bot"]);
+const REMOTE_USER_MODULE_ROOT_DIR = "source-profiles";
+const BUILTIN_MODULE_IDS = new Set(["builtin.github_repo", "builtin.github_repo_ci", "builtin.feishu_bot"]);
 
-export class RemoteSourceProfileRegistry {
-  private readonly profileCache = new Map<string, RemoteSourceProfile>();
+export class RemoteSourceModuleRegistry {
+  private readonly moduleCache = new Map<string, RemoteSourceModule>();
 
-  resolve(source: SubscriptionSource, homeDir: string): Promise<RemoteSourceProfile> {
+  resolve(source: SubscriptionSource, homeDir: string): Promise<RemoteSourceModule> {
     if (source.sourceType === "github_repo") {
-      return Promise.resolve(GITHUB_REPO_PROFILE);
+      return Promise.resolve(GITHUB_REPO_MODULE);
     }
     if (source.sourceType === "github_repo_ci") {
-      return Promise.resolve(GITHUB_REPO_CI_PROFILE);
+      return Promise.resolve(GITHUB_REPO_CI_MODULE);
     }
     if (source.sourceType === "feishu_bot") {
-      return Promise.resolve(FEISHU_BOT_PROFILE);
+      return Promise.resolve(FEISHU_BOT_MODULE);
     }
     if (source.sourceType !== "remote_source") {
-      throw new Error(`unsupported source type for remote profile: ${source.sourceType}`);
+      throw new Error(`unsupported source type for remote module: ${source.sourceType}`);
     }
-    return this.loadUserProfile(source, homeDir);
+    return this.loadUserModule(source, homeDir);
   }
 
-  private async loadUserProfile(source: SubscriptionSource, homeDir: string): Promise<RemoteSourceProfile> {
+  private async loadUserModule(source: SubscriptionSource, homeDir: string): Promise<RemoteSourceModule> {
     const config = source.config ?? {};
     const profilePath = asNonEmptyString(config.profilePath);
     if (!profilePath) {
-      throw new Error("remote_source requires config.profilePath");
+      throw new Error("remote_source requires config.profilePath (module path)");
     }
 
-    const profileRoot = path.resolve(homeDir, REMOTE_USER_PROFILE_ROOT_DIR);
-    const resolvedPath = resolveAndValidateProfilePath(profileRoot, profilePath);
+    const moduleRoot = path.resolve(homeDir, REMOTE_USER_MODULE_ROOT_DIR);
+    const resolvedPath = resolveAndValidateModulePath(moduleRoot, profilePath);
     const cacheKey = `${resolvedPath}:${source.sourceKey}`;
-    const cached = this.profileCache.get(cacheKey);
+    const cached = this.moduleCache.get(cacheKey);
     if (cached) {
       return cached;
     }
     if (!fs.existsSync(resolvedPath)) {
-      throw new Error(`remote_source profile not found: ${resolvedPath}`);
+      throw new Error(`remote_source module not found: ${resolvedPath}`);
     }
 
     const imported = await dynamicImportModule(pathToFileURL(resolvedPath).href);
-    const profile = ((imported.default ?? imported) as RemoteSourceProfile | undefined);
-    if (!profile || typeof profile !== "object") {
-      throw new Error(`remote_source profile must export default object: ${resolvedPath}`);
+    const module = ((imported.default ?? imported) as RemoteSourceModule | undefined);
+    if (!module || typeof module !== "object") {
+      throw new Error(`remote_source module must export default object: ${resolvedPath}`);
     }
-    validateProfileContract(profile, resolvedPath);
-    this.profileCache.set(cacheKey, profile);
-    return profile;
+    validateModuleContract(module, resolvedPath);
+    this.moduleCache.set(cacheKey, module);
+    return module;
   }
 }
 
@@ -153,7 +153,7 @@ async function dynamicImportModule(moduleUrl: string): Promise<Record<string, un
   return importer(moduleUrl);
 }
 
-export function builtInProfileIdForSourceType(sourceType: SubscriptionSource["sourceType"]): string | null {
+export function builtInModuleIdForSourceType(sourceType: SubscriptionSource["sourceType"]): string | null {
   if (sourceType === "github_repo") {
     return "builtin.github_repo";
   }
@@ -166,44 +166,44 @@ export function builtInProfileIdForSourceType(sourceType: SubscriptionSource["so
   return null;
 }
 
-function validateProfileContract(profile: RemoteSourceProfile, sourcePath: string): void {
-  if (!profile.id || typeof profile.id !== "string") {
-    throw new Error(`remote_source profile id must be a non-empty string: ${sourcePath}`);
+function validateModuleContract(module: RemoteSourceModule, sourcePath: string): void {
+  if (!module.id || typeof module.id !== "string") {
+    throw new Error(`remote_source module id must be a non-empty string: ${sourcePath}`);
   }
-  if (BUILTIN_PROFILE_IDS.has(profile.id)) {
-    throw new Error(`remote_source profile id is reserved: ${profile.id}`);
+  if (BUILTIN_MODULE_IDS.has(module.id)) {
+    throw new Error(`remote_source module id is reserved: ${module.id}`);
   }
-  if (typeof profile.validateConfig !== "function") {
-    throw new Error(`remote_source profile missing validateConfig(): ${sourcePath}`);
+  if (typeof module.validateConfig !== "function") {
+    throw new Error(`remote_source module missing validateConfig(): ${sourcePath}`);
   }
-  if (typeof profile.buildManagedSourceSpec !== "function") {
-    throw new Error(`remote_source profile missing buildManagedSourceSpec(): ${sourcePath}`);
+  if (typeof module.buildManagedSourceSpec !== "function") {
+    throw new Error(`remote_source module missing buildManagedSourceSpec(): ${sourcePath}`);
   }
-  if (typeof profile.mapRawEvent !== "function") {
-    throw new Error(`remote_source profile missing mapRawEvent(): ${sourcePath}`);
+  if (typeof module.mapRawEvent !== "function") {
+    throw new Error(`remote_source module missing mapRawEvent(): ${sourcePath}`);
   }
-  validateOptionalHook(profile.describeCapabilities, "describeCapabilities", sourcePath);
-  validateOptionalHook(profile.listSubscriptionShortcuts, "listSubscriptionShortcuts", sourcePath);
-  validateOptionalHook(profile.expandSubscriptionShortcut, "expandSubscriptionShortcut", sourcePath);
-  validateOptionalHook(profile.deriveTrackedResource, "deriveTrackedResource", sourcePath);
-  validateOptionalHook(profile.projectLifecycleSignal, "projectLifecycleSignal", sourcePath);
-  validateOptionalHook(profile.deriveInlinePreview, "deriveInlinePreview", sourcePath);
+  validateOptionalHook(module.describeCapabilities, "describeCapabilities", sourcePath);
+  validateOptionalHook(module.listSubscriptionShortcuts, "listSubscriptionShortcuts", sourcePath);
+  validateOptionalHook(module.expandSubscriptionShortcut, "expandSubscriptionShortcut", sourcePath);
+  validateOptionalHook(module.deriveTrackedResource, "deriveTrackedResource", sourcePath);
+  validateOptionalHook(module.projectLifecycleSignal, "projectLifecycleSignal", sourcePath);
+  validateOptionalHook(module.deriveInlinePreview, "deriveInlinePreview", sourcePath);
 }
 
 function validateOptionalHook(value: unknown, name: string, sourcePath: string): void {
   if (value !== undefined && typeof value !== "function") {
-    throw new Error(`remote_source profile ${name} must be a function when provided: ${sourcePath}`);
+    throw new Error(`remote_source module ${name} must be a function when provided: ${sourcePath}`);
   }
 }
 
-function resolveAndValidateProfilePath(profileRoot: string, profilePath: string): string {
+function resolveAndValidateModulePath(moduleRoot: string, profilePath: string): string {
   const resolved = path.isAbsolute(profilePath)
     ? path.resolve(profilePath)
-    : path.resolve(profileRoot, profilePath);
-  const normalizedRoot = ensureTrailingSep(path.resolve(profileRoot));
+    : path.resolve(moduleRoot, profilePath);
+  const normalizedRoot = ensureTrailingSep(path.resolve(moduleRoot));
   const normalizedResolved = path.resolve(resolved);
-  if (!normalizedResolved.startsWith(normalizedRoot) && normalizedResolved !== path.resolve(profileRoot)) {
-    throw new Error(`remote_source profilePath must stay under ${profileRoot}`);
+  if (!normalizedResolved.startsWith(normalizedRoot) && normalizedResolved !== path.resolve(moduleRoot)) {
+    throw new Error(`remote_source profilePath must stay under ${moduleRoot}`);
   }
   return normalizedResolved;
 }
@@ -227,7 +227,7 @@ function asNonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-const GITHUB_REPO_PROFILE: RemoteSourceProfile = {
+const GITHUB_REPO_MODULE: RemoteSourceModule = {
   id: "builtin.github_repo",
   describeCapabilities(source: SubscriptionSource): RemoteSourceCapabilityDescription {
     const config = parseGithubSourceConfig(source);
@@ -337,7 +337,7 @@ const GITHUB_REPO_PROFILE: RemoteSourceProfile = {
   },
 };
 
-const GITHUB_REPO_CI_PROFILE: RemoteSourceProfile = {
+const GITHUB_REPO_CI_MODULE: RemoteSourceModule = {
   id: "builtin.github_repo_ci",
   describeCapabilities(): RemoteSourceCapabilityDescription {
     return {
@@ -449,7 +449,7 @@ const GITHUB_REPO_CI_PROFILE: RemoteSourceProfile = {
   },
 };
 
-const FEISHU_BOT_PROFILE: RemoteSourceProfile = {
+const FEISHU_BOT_MODULE: RemoteSourceModule = {
   id: "builtin.feishu_bot",
   describeCapabilities(): RemoteSourceCapabilityDescription {
     return {
@@ -510,7 +510,7 @@ const FEISHU_BOT_PROFILE: RemoteSourceProfile = {
   },
 };
 
-export function profileConfigForSource(source: SubscriptionSource): Record<string, unknown> {
+export function moduleConfigForSource(source: SubscriptionSource): Record<string, unknown> {
   const config = asRecord(source.config);
   if (source.sourceType === "remote_source") {
     return asRecord(config.profileConfig);

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -885,7 +885,7 @@ test("source details keep a wrapped fallback schema when non-identity capability
   }
 });
 
-test("subscription add can expand a remote profile shortcut into standard subscription fields", async () => {
+test("subscription add can expand a remote module shortcut into standard subscription fields", async () => {
   const { store, service, dir } = await makeService();
   try {
     const profileDir = path.join(dir, "source-profiles");
@@ -963,7 +963,7 @@ test("subscription add can expand a remote profile shortcut into standard subscr
   }
 });
 
-test("remote_source profile contract rejects non-function optional hooks", async () => {
+test("remote_source module contract rejects non-function optional hooks", async () => {
   const { store, service, dir } = await makeService();
   try {
     const profileDir = path.join(dir, "source-profiles");

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -2542,12 +2542,12 @@ test("control plane source details degrade when remote_source resolution fails b
       assert.equal(details.statusCode, 200);
       assert.equal(details.data.source.sourceId, sourceId);
       assert.equal(details.data.resolvedIdentity, null);
-      assert.match(details.data.resolutionError, /remote_source profile not found/);
+      assert.match(details.data.resolutionError, /remote_source module not found/);
       assert.equal(details.data.schema.sourceType, "remote_source");
 
       const schema = await client.request<{ error: string }>(`/sources/${encodeURIComponent(sourceId)}/schema`, undefined, "GET");
       assert.equal(schema.statusCode, 400);
-      assert.match(schema.data.error, /remote_source profile not found/);
+      assert.match(schema.data.error, /remote_source module not found/);
     } finally {
       await started.close();
     }

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -7,7 +7,7 @@ import { AdapterRegistry } from "../src/adapters";
 import { AppendSourceEventInput } from "../src/model";
 import { AgentInboxService } from "../src/service";
 import { UxcRemoteSourceClient } from "../src/sources/remote";
-import { ManagedSourceSpec } from "../src/sources/remote_profiles";
+import { ManagedSourceSpec } from "../src/sources/remote_modules";
 import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
 import { nowIso } from "../src/util";
@@ -137,7 +137,7 @@ async function makeService(fake: FakeRemoteSourceClient): Promise<{
   return { dir, store, service, adapters };
 }
 
-test("remote_source with local profile ingests stream events", async () => {
+test("remote_source with local module ingests stream events", async () => {
   const fake = new FakeRemoteSourceClient();
   const { dir, store, service } = await makeService(fake);
   try {
@@ -234,7 +234,7 @@ test("remote_source profilePath must stay under source-profiles root", async () 
   }
 });
 
-test("github_repo source uses remote runtime builtin profile mapping", async () => {
+test("github_repo source uses remote runtime builtin module mapping", async () => {
   const fake = new FakeRemoteSourceClient();
   const { dir, store, service } = await makeService(fake);
   try {
@@ -417,7 +417,7 @@ test("github_repo pull request subscriptions retire through the generic lifecycl
   }
 });
 
-test("github_repo_ci builtin profile emits status transitions for one workflow run id", async () => {
+test("github_repo_ci builtin module emits status transitions for one workflow run id", async () => {
   const fake = new FakeRemoteSourceClient();
   const { dir, store, service } = await makeService(fake);
   try {


### PR DESCRIPTION
## Summary\n- rename the remote source contract and registry symbols from profile to module\n- rename the runtime/source-resolution plumbing to use module terminology\n- keep  and  as compatibility shims while aligning docs/tests to the RFC wording\n\n## Testing\n- npm run build\n- node --require ts-node/register --test --test-force-exit --test-name-pattern "control plane source details degrade|remote_source|module contract|shortcut|source schema" test/remote_source.test.ts test/agentinbox.test.ts test/control_plane.test.ts