### PR TITLE
fix: restore remote profile compatibility shims

### DIFF
--- a/src/source_resolution.ts
+++ b/src/source_resolution.ts
@@ -6,6 +6,8 @@ import { getSourceSchema } from "./source_schema";
 export interface ResolveSourceContext {
   homeDir?: string;
   moduleRegistry?: RemoteSourceModuleRegistry;
+  // Deprecated compatibility alias for callers that still pass the old option name.
+  profileRegistry?: RemoteSourceModuleRegistry;
 }
 
 export async function resolveSourceIdentity(
@@ -33,7 +35,7 @@ export async function resolveSourceIdentity(
     throw new Error(`unsupported source type for source resolution: ${source.sourceType}`);
   }
 
-  const moduleRegistry = context.moduleRegistry ?? new RemoteSourceModuleRegistry();
+  const moduleRegistry = context.moduleRegistry ?? context.profileRegistry ?? new RemoteSourceModuleRegistry();
   const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
   const module = await moduleRegistry.resolve(source, homeDir);
   const capabilityDescription = typeof module.describeCapabilities === "function"
@@ -50,7 +52,7 @@ export async function resolveSourceSchema(
   source: SubscriptionSource,
   context: ResolveSourceContext = {},
 ): Promise<ResolvedSourceSchema> {
-  const moduleRegistry = context.moduleRegistry ?? new RemoteSourceModuleRegistry();
+  const moduleRegistry = context.moduleRegistry ?? context.profileRegistry ?? new RemoteSourceModuleRegistry();
   const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
   const resolvedContext: ResolveSourceContext = { ...context, moduleRegistry, homeDir };
   const identity = await resolveSourceIdentity(source, resolvedContext);

--- a/src/sources/remote_profiles.ts
+++ b/src/sources/remote_profiles.ts
@@ -1,0 +1,23 @@
+export {
+  type ExpandedSubscriptionInput,
+  type ExpandSubscriptionShortcutInput,
+  type LifecycleSignal,
+  type ManagedSourceSpec,
+  type MappedRemoteEvent,
+  type RemoteSourceCapabilityDescription,
+  type RemoteSourceModule,
+  type SubscriptionShortcutSpec,
+  RemoteSourceModuleRegistry,
+  builtInModuleIdForSourceType,
+  moduleConfigForSource,
+} from "./remote_modules";
+
+import { RemoteSourceModuleRegistry, builtInModuleIdForSourceType, moduleConfigForSource } from "./remote_modules";
+
+// Deprecated compatibility aliases kept for downstream imports during the profile->module rename transition.
+export type RemoteSourceProfile = import("./remote_modules").RemoteSourceModule;
+
+export class RemoteSourceProfileRegistry extends RemoteSourceModuleRegistry {}
+
+export const builtInProfileIdForSourceType = builtInModuleIdForSourceType;
+export const profileConfigForSource = moduleConfigForSource;

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -6,8 +6,10 @@ import assert from "node:assert/strict";
 import { AdapterRegistry } from "../src/adapters";
 import { AppendSourceEventInput } from "../src/model";
 import { AgentInboxService } from "../src/service";
+import { resolveSourceIdentity } from "../src/source_resolution";
 import { UxcRemoteSourceClient } from "../src/sources/remote";
 import { ManagedSourceSpec } from "../src/sources/remote_modules";
+import { RemoteSourceProfileRegistry, builtInProfileIdForSourceType, profileConfigForSource } from "../src/sources/remote_profiles";
 import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
 import { nowIso } from "../src/util";
@@ -597,6 +599,67 @@ test("remote_source remove --with-subscriptions stops remote binding and deletes
     await service.stop();
     store.close();
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("deprecated remote profile exports still alias the module contract", async () => {
+  const registry = new RemoteSourceProfileRegistry();
+  assert.ok(registry instanceof RemoteSourceProfileRegistry);
+  assert.equal(builtInProfileIdForSourceType("github_repo"), "builtin.github_repo");
+  assert.deepEqual(
+    profileConfigForSource({
+      sourceId: "src_compat",
+      sourceType: "remote_source",
+      sourceKey: "compat",
+      configRef: null,
+      config: { profileConfig: { answer: 42 } },
+      status: "active",
+      checkpoint: null,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    }),
+    { answer: 42 },
+  );
+});
+
+test("resolveSourceIdentity still honors deprecated profileRegistry context", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-remote-source-compat-"));
+  try {
+    const profileDir = path.join(homeDir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    const modulePath = path.join(profileDir, "compat.mjs");
+    fs.writeFileSync(modulePath, `
+      export default {
+        id: "demo.compat",
+        validateConfig() {},
+        buildManagedSourceSpec() { return { endpoint: "https://example.invalid", mode: "poll" }; },
+        mapRawEvent() { return null; },
+        describeCapabilities() { return { sourceKind: "remote:compat-demo" }; },
+      };
+    `);
+
+    const identity = await resolveSourceIdentity({
+      sourceId: "src_compat_identity",
+      sourceType: "remote_source",
+      sourceKey: "compat-demo",
+      configRef: null,
+      config: { profilePath: "compat.mjs" },
+      status: "active",
+      checkpoint: null,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    }, {
+      homeDir,
+      profileRegistry: new RemoteSourceProfileRegistry(),
+    });
+
+    assert.deepEqual(identity, {
+      hostType: "remote_source",
+      sourceKind: "remote:compat-demo",
+      implementationId: "demo.compat",
+    });
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- restore deprecated `remote_profiles` exports as aliases over the new module contract
- continue honoring `ResolveSourceContext.profileRegistry` while the rename settles
- add regression coverage for both compatibility shims

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "deprecated remote profile exports still alias the module contract|resolveSourceIdentity still honors deprecated profileRegistry context|remote_source" test/remote_source.test.ts
