### PR TITLE
feat: add daemon log levels and gate tracing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,8 +5,9 @@ import { AdapterRegistry } from "./adapters";
 import { AgentInboxClient } from "./client";
 import { startControlServer } from "./control_server";
 import { AgentWithTargets, annotateAgents, BindingKind, resolveCurrentAgent } from "./current_agent";
-import { daemonStatus, ensureDaemonForClient, removePidFile, startDaemon, stopDaemon, writePidFile } from "./daemon";
+import { daemonStatus, ensureDaemonForClient, removePidFile, resolveDaemonLogLevel, startDaemon, stopDaemon, writeDaemonMetadata, writePidFile } from "./daemon";
 import { createServer } from "./http";
+import { JsonLogger, parseLogLevel } from "./logging";
 import { resolveDaemonPaths, resolveServeConfig } from "./paths";
 import { AgentInboxService } from "./service";
 import { AgentInboxStore } from "./store";
@@ -619,28 +620,38 @@ async function main(): Promise<void> {
 
 async function runServe(args: string[]): Promise<void> {
   const port = parseOptionalNumber(takeFlagValue(args, "--port"));
+  const homeOverride = takeFlagValue(args, "--home");
   const serveConfig = resolveServeConfig({
     env: process.env,
-    homeDirOverride: takeFlagValue(args, "--home"),
+    homeDirOverride: homeOverride,
     statePathOverride: takeFlagValue(args, "--state"),
     socketPathOverride: takeFlagValue(args, "--socket"),
     portOverride: port,
   });
+  const daemonPaths = resolveDaemonPaths(process.env, homeOverride);
+  const logLevel = parseLogLevel(takeFlagValue(args, "--log-level") ?? process.env.AGENTINBOX_LOG_LEVEL);
+  const logger = new JsonLogger(logLevel, "agentinbox");
 
   const store = await AgentInboxStore.open(serveConfig.dbPath);
   let service: AgentInboxService;
   const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
     homeDir: serveConfig.homeDir,
   });
-  service = new AgentInboxService(store, adapters);
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, undefined, undefined, logger.child("service"));
   const server = createServer(service);
   await adapters.start();
   await service.start();
   const controlServer = await startControlServer(server, serveConfig.transport);
-  const daemonPaths = resolveDaemonPaths(process.env, takeFlagValue(args, "--home"));
   if (serveConfig.transport.kind === "socket") {
     writePidFile(daemonPaths.pidPath, process.pid);
   }
+  writeDaemonMetadata(daemonPaths.metadataPath, { logLevel });
+  logger.info("daemon.ready", {
+    homeDir: serveConfig.homeDir,
+    dbPath: serveConfig.dbPath,
+    transport: controlServer.info,
+    logLevel,
+  });
   console.log(jsonResponse({
     ok: true,
     homeDir: serveConfig.homeDir,
@@ -656,6 +667,7 @@ async function runServe(args: string[]): Promise<void> {
       if (serveConfig.transport.kind === "socket") {
         removePidFile(daemonPaths.pidPath);
       }
+      removePidFile(daemonPaths.metadataPath);
       process.exit(0);
     });
   };
@@ -670,6 +682,7 @@ async function runDaemon(args: string[]): Promise<void> {
     homeDirOverride: takeFlagValue(args, "--home"),
     socketPathOverride: takeFlagValue(args, "--socket"),
     baseUrlOverride: takeFlagValue(args, "--url"),
+    logLevelOverride: parseLogLevel(takeFlagValue(args, "--log-level") ?? process.env.AGENTINBOX_LOG_LEVEL),
   };
 
   if (action === "start") {
@@ -1001,13 +1014,13 @@ Commands:
     serve: `agentinbox serve
 
 Usage:
-  agentinbox serve [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
+  agentinbox serve [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock] [--log-level error|warn|info|debug|trace]
   agentinbox serve --port 4747 [--state ~/.agentinbox/agentinbox.sqlite]
 `,
     daemon: `agentinbox daemon
 
 Usage:
-  agentinbox daemon start [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
+  agentinbox daemon start [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock] [--log-level error|warn|info|debug|trace]
   agentinbox daemon stop [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
   agentinbox daemon status [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
 `,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,18 +3,21 @@ import path from "node:path";
 import { execFileSync, spawn } from "node:child_process";
 import { AgentInboxClient } from "./client";
 import { resolveAgentInboxHome, resolveDaemonPaths, type ClientTransport } from "./paths";
+import { defaultLogLevel, isLogLevel, LogLevel, parseLogLevel } from "./logging";
 
 export interface DaemonCliOptions {
   env?: NodeJS.ProcessEnv;
   homeDirOverride?: string;
   socketPathOverride?: string;
   baseUrlOverride?: string;
+  logLevelOverride?: LogLevel;
   noAutoStart?: boolean;
 }
 
 export interface DaemonStartResult {
   started: boolean;
   pid: number;
+  logLevel: LogLevel;
   pidPath: string;
   logPath: string;
   transport: ClientTransport;
@@ -23,6 +26,7 @@ export interface DaemonStartResult {
 export interface DaemonStatusResult {
   running: boolean;
   pid: number | null;
+  logLevel: LogLevel | null;
   version: string | null;
   startedAt: string | null;
   command: string | null;
@@ -53,6 +57,7 @@ export async function ensureDaemonForClient(options: DaemonCliOptions = {}): Pro
 export async function startDaemon(options: DaemonCliOptions = {}): Promise<DaemonStartResult> {
   const env = options.env ?? process.env;
   const transport = requireSocketTransport(resolveDaemonClientTransport(options), "daemon start");
+  const logLevel = resolveDaemonLogLevel(env, options.logLevelOverride);
 
   const homeDir = resolveAgentInboxHome(env, options.homeDirOverride);
   const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
@@ -64,6 +69,7 @@ export async function startDaemon(options: DaemonCliOptions = {}): Promise<Daemo
     return {
       started: false,
       pid: pid ?? -1,
+      logLevel,
       pidPath,
       logPath,
       transport,
@@ -80,6 +86,7 @@ export async function startDaemon(options: DaemonCliOptions = {}): Promise<Daemo
         AGENTINBOX_HOME: homeDir,
         AGENTINBOX_SOCKET: transport.socketPath,
         AGENTINBOX_URL: "",
+        AGENTINBOX_LOG_LEVEL: logLevel,
       },
       detached: true,
       stdio: ["ignore", logFd, logFd],
@@ -92,6 +99,7 @@ export async function startDaemon(options: DaemonCliOptions = {}): Promise<Daemo
   return {
     started: true,
     pid: child.pid ?? -1,
+    logLevel,
     pidPath,
     logPath,
     transport,
@@ -101,7 +109,7 @@ export async function startDaemon(options: DaemonCliOptions = {}): Promise<Daemo
 export async function stopDaemon(options: DaemonCliOptions = {}): Promise<DaemonStatusResult> {
   const env = options.env ?? process.env;
   const transport = requireSocketTransport(resolveDaemonClientTransport(options), "daemon stop");
-  const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
+  const { pidPath, logPath, metadataPath } = resolveDaemonPaths(env, options.homeDirOverride);
 
   const pid = readPidFile(pidPath);
   if (pid != null && isProcessAlive(pid)) {
@@ -111,6 +119,7 @@ export async function stopDaemon(options: DaemonCliOptions = {}): Promise<Daemon
 
   cleanupStalePidFile(pidPath, true);
   cleanupFile(transport.socketPath);
+  cleanupFile(metadataPath);
 
   return daemonStatus(options);
 }
@@ -118,14 +127,16 @@ export async function stopDaemon(options: DaemonCliOptions = {}): Promise<Daemon
 export async function daemonStatus(options: DaemonCliOptions = {}): Promise<DaemonStatusResult> {
   const env = options.env ?? process.env;
   const transport = requireSocketTransport(resolveDaemonClientTransport(options), "daemon status");
-  const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
+  const { pidPath, logPath, metadataPath } = resolveDaemonPaths(env, options.homeDirOverride);
   const pid = readPidFile(pidPath);
   if (pid != null && !isProcessAlive(pid)) {
     cleanupStalePidFile(pidPath, true);
     cleanupFile(transport.socketPath);
+    cleanupFile(metadataPath);
     return {
       running: false,
       pid: null,
+      logLevel: null,
       version: null,
       startedAt: null,
       command: null,
@@ -137,9 +148,11 @@ export async function daemonStatus(options: DaemonCliOptions = {}): Promise<Daem
   }
 
   const processInfo = pid == null ? null : readProcessMetadata(pid);
+  const daemonMetadata = readDaemonMetadata(metadataPath);
   return {
     running: await canReachHealthz(transport),
     pid,
+    logLevel: daemonMetadata?.logLevel ?? null,
     version: pid == null ? null : PACKAGE_VERSION,
     startedAt: processInfo?.startedAt ?? null,
     command: processInfo?.command ?? null,
@@ -280,6 +293,36 @@ function cleanupStalePidFile(pidPath: string, force = false): void {
   }
   if (force || !isProcessAlive(pid)) {
     cleanupFile(pidPath);
+  }
+}
+
+export function resolveDaemonLogLevel(
+  env: NodeJS.ProcessEnv = process.env,
+  override?: LogLevel,
+): LogLevel {
+  if (override) {
+    return override;
+  }
+  return parseLogLevel(env.AGENTINBOX_LOG_LEVEL, defaultLogLevel());
+}
+
+export function writeDaemonMetadata(
+  metadataPath: string,
+  metadata: { logLevel: LogLevel },
+): void {
+  fs.mkdirSync(path.dirname(metadataPath), { recursive: true });
+  fs.writeFileSync(metadataPath, JSON.stringify(metadata), "utf8");
+}
+
+function readDaemonMetadata(metadataPath: string): { logLevel: LogLevel } | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(metadataPath, "utf8")) as { logLevel?: unknown };
+    if (isLogLevel(parsed.logLevel)) {
+      return { logLevel: parsed.logLevel };
+    }
+    return null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,134 @@
+export type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
+
+const LOG_LEVEL_RANK: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+  trace: 4,
+};
+
+const LOG_LEVELS = new Set<LogLevel>(["error", "warn", "info", "debug", "trace"]);
+const DEFAULT_LOG_LEVEL: LogLevel = "info";
+
+export interface Logger {
+  level: LogLevel;
+  enabled(level: LogLevel): boolean;
+  child(component: string): Logger;
+  error(event: string, fields?: Record<string, unknown>): void;
+  warn(event: string, fields?: Record<string, unknown>): void;
+  info(event: string, fields?: Record<string, unknown>): void;
+  debug(event: string, fields?: Record<string, unknown>): void;
+  trace(event: string, fields?: Record<string, unknown>): void;
+}
+
+export class NoopLogger implements Logger {
+  constructor(public readonly level: LogLevel = DEFAULT_LOG_LEVEL) {}
+
+  enabled(_level: LogLevel): boolean {
+    return false;
+  }
+
+  child(_component: string): Logger {
+    return this;
+  }
+
+  error(_event: string, _fields?: Record<string, unknown>): void {}
+  warn(_event: string, _fields?: Record<string, unknown>): void {}
+  info(_event: string, _fields?: Record<string, unknown>): void {}
+  debug(_event: string, _fields?: Record<string, unknown>): void {}
+  trace(_event: string, _fields?: Record<string, unknown>): void {}
+}
+
+export class JsonLogger implements Logger {
+  constructor(
+    public readonly level: LogLevel,
+    private readonly component: string,
+    private readonly writeLine: (line: string) => void = (line) => process.stdout.write(`${line}\n`),
+  ) {}
+
+  enabled(level: LogLevel): boolean {
+    return LOG_LEVEL_RANK[level] <= LOG_LEVEL_RANK[this.level];
+  }
+
+  child(component: string): Logger {
+    return new JsonLogger(this.level, `${this.component}.${component}`, this.writeLine);
+  }
+
+  error(event: string, fields?: Record<string, unknown>): void {
+    this.log("error", event, fields);
+  }
+
+  warn(event: string, fields?: Record<string, unknown>): void {
+    this.log("warn", event, fields);
+  }
+
+  info(event: string, fields?: Record<string, unknown>): void {
+    this.log("info", event, fields);
+  }
+
+  debug(event: string, fields?: Record<string, unknown>): void {
+    this.log("debug", event, fields);
+  }
+
+  trace(event: string, fields?: Record<string, unknown>): void {
+    this.log("trace", event, fields);
+  }
+
+  private log(level: LogLevel, event: string, fields?: Record<string, unknown>): void {
+    if (!this.enabled(level)) {
+      return;
+    }
+    this.writeLine(JSON.stringify({
+      ts: new Date().toISOString(),
+      level,
+      component: this.component,
+      event,
+      ...(fields ? serializeFields(fields) : {}),
+    }));
+  }
+}
+
+export function parseLogLevel(value: unknown, fallback: LogLevel = DEFAULT_LOG_LEVEL): LogLevel {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (LOG_LEVELS.has(normalized as LogLevel)) {
+    return normalized as LogLevel;
+  }
+  return fallback;
+}
+
+export function isLogLevel(value: unknown): value is LogLevel {
+  return typeof value === "string" && LOG_LEVELS.has(value as LogLevel);
+}
+
+export function defaultLogLevel(): LogLevel {
+  return DEFAULT_LOG_LEVEL;
+}
+
+function serializeFields(fields: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(fields).map(([key, value]) => [key, serializeValue(value)]),
+  );
+}
+
+function serializeValue(value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => serializeValue(entry));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) => [key, serializeValue(nested)]),
+    );
+  }
+  return value;
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -37,6 +37,7 @@ export interface ResolvedServeConfig {
 export interface DaemonPaths {
   pidPath: string;
   logPath: string;
+  metadataPath: string;
 }
 
 export function resolveAgentInboxHome(
@@ -110,6 +111,7 @@ export function resolveDaemonPaths(
   return {
     pidPath: path.join(homeDir, "agentinbox.pid"),
     logPath: path.join(homeDir, "agentinbox.log"),
+    metadataPath: path.join(homeDir, "agentinbox.daemon.json"),
   };
 }
 

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { TerminalActivationTarget } from "./model";
+import { Logger, NoopLogger } from "./logging";
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_ITERM2_SAMPLE_DELAY_MS = 900;
@@ -51,18 +52,27 @@ export interface ActivationGate {
 }
 
 export class DefaultActivationGate implements ActivationGate {
+  private readonly runtimeProbes: RuntimePresenceProbe[];
+  private readonly terminalProbes: TerminalStateProbe[];
+  private readonly logger: Logger;
+
   constructor(
-    private readonly runtimeProbes: RuntimePresenceProbe[] = [
-      new CodexRuntimePresenceProbe(),
-      new ClaudeCodeRuntimePresenceProbe(),
-    ],
-    private readonly terminalProbes: TerminalStateProbe[] = [
-      new CodexTerminalStateProbe(),
-      new Iterm2TerminalStateProbe(),
-      new ClaudeCodeTerminalStateProbe(),
-      new TmuxTerminalStateProbe(),
-    ],
-  ) {}
+    runtimeProbes?: RuntimePresenceProbe[],
+    terminalProbes?: TerminalStateProbe[],
+    logger: Logger = new NoopLogger(),
+  ) {
+    this.logger = logger.child("activation_gate");
+    this.runtimeProbes = runtimeProbes ?? [
+      new CodexRuntimePresenceProbe(undefined, undefined, this.logger.child("codex_runtime")),
+      new ClaudeCodeRuntimePresenceProbe(undefined, undefined, this.logger.child("claude_runtime")),
+    ];
+    this.terminalProbes = terminalProbes ?? [
+      new CodexTerminalStateProbe(undefined, undefined, undefined, undefined, undefined, this.logger.child("codex_terminal")),
+      new Iterm2TerminalStateProbe(undefined, {}, this.logger.child("iterm2_terminal")),
+      new ClaudeCodeTerminalStateProbe(undefined, undefined, undefined, this.logger.child("claude_terminal")),
+      new TmuxTerminalStateProbe(undefined, {}, this.logger.child("tmux_terminal")),
+    ];
+  }
 
   async evaluate(target: TerminalActivationTarget): Promise<{
     outcome: "inject" | "defer" | "offline";
@@ -71,6 +81,18 @@ export class DefaultActivationGate implements ActivationGate {
     const runtimeProbe = this.runtimeProbes.find((probe) => probe.supports(target));
     const runtimePresence = runtimeProbe ? await runtimeProbe.check(target) : "unknown";
     if (runtimePresence === "gone") {
+      this.logger.debug("gate_decision", {
+        targetId: target.targetId,
+        runtimeKind: target.runtimeKind,
+        backend: target.backend,
+        runtimeProbe: runtimeProbe?.constructor?.name ?? null,
+        runtimePresence,
+        terminalProbe: null,
+        terminalPresence: null,
+        terminalBusy: null,
+        outcome: "offline",
+        reason: "runtime_gone",
+      });
       return { outcome: "offline", reason: "runtime_gone" };
     }
     const terminalProbe = this.terminalProbes.find((probe) => probe.supports(target));
@@ -79,14 +101,62 @@ export class DefaultActivationGate implements ActivationGate {
       : { presence: "unknown" as const, busy: "unknown" as const };
 
     if (terminalState.presence === "gone") {
+      this.logger.debug("gate_decision", {
+        targetId: target.targetId,
+        runtimeKind: target.runtimeKind,
+        backend: target.backend,
+        runtimeProbe: runtimeProbe?.constructor?.name ?? null,
+        runtimePresence,
+        terminalProbe: terminalProbe?.constructor?.name ?? null,
+        terminalPresence: terminalState.presence,
+        terminalBusy: terminalState.busy,
+        outcome: "offline",
+        reason: "terminal_gone",
+      });
       return { outcome: "offline", reason: "terminal_gone" };
     }
     if (terminalState.busy === "busy") {
+      this.logger.debug("gate_decision", {
+        targetId: target.targetId,
+        runtimeKind: target.runtimeKind,
+        backend: target.backend,
+        runtimeProbe: runtimeProbe?.constructor?.name ?? null,
+        runtimePresence,
+        terminalProbe: terminalProbe?.constructor?.name ?? null,
+        terminalPresence: terminalState.presence,
+        terminalBusy: terminalState.busy,
+        outcome: "defer",
+        reason: "terminal_busy",
+      });
       return { outcome: "defer", reason: "terminal_busy" };
     }
     if (target.runtimeKind === "codex" && terminalState.busy === "idle") {
+      this.logger.debug("gate_decision", {
+        targetId: target.targetId,
+        runtimeKind: target.runtimeKind,
+        backend: target.backend,
+        runtimeProbe: runtimeProbe?.constructor?.name ?? null,
+        runtimePresence,
+        terminalProbe: terminalProbe?.constructor?.name ?? null,
+        terminalPresence: terminalState.presence,
+        terminalBusy: terminalState.busy,
+        outcome: "defer",
+        reason: "terminal_recently_active",
+      });
       return { outcome: "defer", reason: "terminal_recently_active" };
     }
+    this.logger.debug("gate_decision", {
+      targetId: target.targetId,
+      runtimeKind: target.runtimeKind,
+      backend: target.backend,
+      runtimeProbe: runtimeProbe?.constructor?.name ?? null,
+      runtimePresence,
+      terminalProbe: terminalProbe?.constructor?.name ?? null,
+      terminalPresence: terminalState.presence,
+      terminalBusy: terminalState.busy,
+      outcome: "inject",
+      reason: "gate_unknown_or_idle",
+    });
     return { outcome: "inject", reason: "gate_unknown_or_idle" };
   }
 }
@@ -95,6 +165,7 @@ export class CodexRuntimePresenceProbe implements RuntimePresenceProbe {
   constructor(
     private readonly killFn: (pid: number, signal: number) => void = (pid, signal) => process.kill(pid, signal),
     private readonly sessionFileReader?: (sessionId: string) => Promise<CodexSessionLookupResult>,
+    private readonly logger: Logger = new NoopLogger(),
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -103,26 +174,33 @@ export class CodexRuntimePresenceProbe implements RuntimePresenceProbe {
 
   async check(target: TerminalActivationTarget): Promise<RuntimePresenceStatus> {
     if (!Number.isInteger(target.runtimePid)) {
+      this.logger.trace("probe_result", { targetId: target.targetId, result: "unknown", reason: "missing_runtime_pid" });
       return "unknown";
     }
     try {
       this.killFn(target.runtimePid!, 0);
       if (!target.runtimeSessionId) {
+        this.logger.trace("probe_result", { targetId: target.targetId, result: "unknown", reason: "missing_runtime_session_id" });
         return "unknown";
       }
       const sessionInfo = await (this.sessionFileReader ?? defaultCodexSessionFileReader)(target.runtimeSessionId);
       if (sessionInfo === "unknown") {
+        this.logger.trace("probe_result", { targetId: target.targetId, result: "unknown", reason: "session_file_unknown" });
         return "unknown";
       }
       if (!sessionInfo || sessionInfo.sessionId !== target.runtimeSessionId) {
+        this.logger.trace("probe_result", { targetId: target.targetId, result: "gone", reason: "session_file_mismatch" });
         return "gone";
       }
+      this.logger.trace("probe_result", { targetId: target.targetId, result: "alive" });
       return "alive";
     } catch (error) {
       const code = error instanceof Error && "code" in error ? String((error as NodeJS.ErrnoException).code ?? "") : "";
       if (code === "ESRCH") {
+        this.logger.trace("probe_result", { targetId: target.targetId, result: "gone", reason: "process_missing" });
         return "gone";
       }
+      this.logger.debug("probe_error", { targetId: target.targetId, error, result: "unknown" });
       return "unknown";
     }
   }
@@ -135,6 +213,7 @@ export class CodexTerminalStateProbe implements TerminalStateProbe {
     private readonly sessionFileReader?: (sessionId: string) => Promise<CodexSessionLookupResult>,
     private readonly statReader?: (filePath: string) => Promise<{ mtimeMs: number } | null>,
     private readonly nowFn: () => number = () => Date.now(),
+    private readonly logger: Logger = new NoopLogger(),
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -147,26 +226,66 @@ export class CodexTerminalStateProbe implements TerminalStateProbe {
   }> {
     const terminalState = await this.readTerminalState(target);
     if (!target.runtimeSessionId) {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result: terminalState,
+        reason: "missing_runtime_session_id",
+      });
       return terminalState;
     }
     const sessionInfo = await (this.sessionFileReader ?? defaultCodexSessionFileReader)(target.runtimeSessionId);
     if (sessionInfo === "unknown" || !sessionInfo || sessionInfo.sessionId !== target.runtimeSessionId) {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result: terminalState,
+        reason: "session_file_unavailable",
+      });
       return terminalState;
     }
     const stat = await (this.statReader ?? defaultFileStatReader)(sessionInfo.filePath);
     if (!stat) {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result: terminalState,
+        reason: "session_file_stat_missing",
+      });
       return terminalState;
     }
     if (terminalState.busy === "busy" || terminalState.presence === "gone") {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result: terminalState,
+        reason: "terminal_probe_decisive",
+      });
       return terminalState;
     }
     const ageMs = this.nowFn() - stat.mtimeMs;
     if (ageMs < 5000) {
-      return { presence: terminalState.presence, busy: "busy" };
+      const result = { presence: terminalState.presence, busy: "busy" as const };
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result,
+        reason: "session_file_recent_activity",
+        ageMs,
+      });
+      return result;
     }
     if (ageMs < 30000) {
-      return { presence: terminalState.presence, busy: "idle" };
+      const result = { presence: terminalState.presence, busy: "idle" as const };
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result,
+        reason: "session_file_recently_active",
+        ageMs,
+      });
+      return result;
     }
+    this.logger.trace("probe_result", {
+      targetId: target.targetId,
+      result: terminalState,
+      reason: "session_file_stale",
+      ageMs,
+    });
     return terminalState;
   }
 
@@ -194,6 +313,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
       sleep?: (ms: number) => Promise<void>;
       enablePythonProbe?: boolean;
     } = {},
+    private readonly logger: Logger = new NoopLogger(),
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -213,6 +333,11 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
   }> {
     const sessionId = target.itermSessionId?.trim();
     if (!sessionId) {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result: { presence: "unknown", busy: "unknown" },
+        reason: "missing_iterm_session_id",
+      });
       return { presence: "unknown", busy: "unknown" };
     }
 
@@ -220,12 +345,29 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
     if (this.options.enablePythonProbe !== false) {
       const pythonResult = await this.tryPythonApiProbe(sessionId, target.runtimeKind);
       if (pythonResult && pythonResult.presence !== "unknown") {
+        this.logger.debug("probe_result", {
+          targetId: target.targetId,
+          path: "python",
+          result: pythonResult,
+        });
         return pythonResult;
       }
+      this.logger.trace("probe_fallback", {
+        targetId: target.targetId,
+        from: "python",
+        to: "cli",
+        reason: pythonResult ? "python_presence_unknown" : "python_probe_unavailable",
+      });
     }
 
     // Fallback to command-line tools
-    return this.checkWithCommandLineTools(sessionId);
+    const result = await this.checkWithCommandLineTools(sessionId, target.targetId);
+    this.logger.debug("probe_result", {
+      targetId: target.targetId,
+      path: "cli",
+      result,
+    });
+    return result;
   }
 
   private async tryPythonApiProbe(
@@ -241,6 +383,11 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
       const data = JSON.parse(result.stdout);
 
       if (data.status === "gone") {
+        this.logger.trace("probe_python_result", {
+          sessionId,
+          result: { presence: "gone", busy: "unknown" },
+          reason: "session_gone",
+        });
         return { presence: "gone", busy: "unknown" };
       }
 
@@ -263,6 +410,11 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
 
           // If cursor-aware detection indicates busy, return immediately
           if (busyStatus === "busy") {
+            this.logger.trace("probe_python_result", {
+              sessionId,
+              result: { presence: "available", busy: "busy" },
+              reason: "cursor_aware_busy",
+            });
             return { presence: "available", busy: "busy" };
           }
 
@@ -277,18 +429,33 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
 
             if (secondData.status === "available" && secondData.lines) {
               const secondBufferTail = secondData.lines.join("\n");
-              if (bufferTail !== secondBufferTail) {
-                return { presence: "available", busy: "busy" };
-              }
-            }
-
-            // Check for active buffer markers
-            if (containsActiveBufferMarker(bufferTail)) {
+            if (bufferTail !== secondBufferTail) {
+                this.logger.trace("probe_python_result", {
+                  sessionId,
+                  result: { presence: "available", busy: "busy" },
+                  reason: "buffer_changed",
+                });
               return { presence: "available", busy: "busy" };
             }
-
-            return { presence: "available", busy: "idle" };
           }
+
+          // Check for active buffer markers
+          if (containsActiveBufferMarker(bufferTail)) {
+            this.logger.trace("probe_python_result", {
+              sessionId,
+              result: { presence: "available", busy: "busy" },
+              reason: "active_buffer_marker",
+            });
+            return { presence: "available", busy: "busy" };
+          }
+
+          this.logger.trace("probe_python_result", {
+            sessionId,
+            result: { presence: "available", busy: "idle" },
+            reason: "cursor_aware_not_busy",
+          });
+          return { presence: "available", busy: "idle" };
+        }
 
           // If cursor-aware detection is uncertain, fall back to buffer change detection only
           // Do NOT use generic typing prompts to avoid false positives (see #116)
@@ -301,45 +468,90 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
 
             if (secondData.status === "available" && secondData.lines) {
               const secondBufferTail = secondData.lines.join("\n");
-              if (bufferTail !== secondBufferTail) {
-                return { presence: "available", busy: "busy" };
-              }
-            }
-
-            // Check for active buffer markers
-            if (containsActiveBufferMarker(bufferTail)) {
+            if (bufferTail !== secondBufferTail) {
+                this.logger.trace("probe_python_result", {
+                  sessionId,
+                  result: { presence: "available", busy: "busy" },
+                  reason: "buffer_changed_after_unknown_cursor_state",
+                });
               return { presence: "available", busy: "busy" };
             }
+          }
+
+            // Check for active buffer markers
+          if (containsActiveBufferMarker(bufferTail)) {
+            this.logger.trace("probe_python_result", {
+              sessionId,
+              result: { presence: "available", busy: "busy" },
+              reason: "active_buffer_marker_after_unknown_cursor_state",
+            });
+            return { presence: "available", busy: "busy" };
+          }
 
             // Return unknown when cursor-aware detection is uncertain
             // Do NOT fall back to generic typing prompts to avoid false positives
+            this.logger.trace("probe_python_result", {
+              sessionId,
+              result: { presence: "available", busy: "unknown" },
+              reason: "cursor_aware_unknown",
+            });
             return { presence: "available", busy: "unknown" };
           }
 
           // This should never be reached as all cases are handled above
+          this.logger.trace("probe_python_result", {
+            sessionId,
+            result: { presence: "available", busy: "unknown" },
+            reason: "cursor_probe_fell_through",
+          });
           return { presence: "available", busy: "unknown" };
         }
 
         // If we don't have cursor data, return unknown to trigger fallback
+        this.logger.trace("probe_python_result", {
+          sessionId,
+          result: null,
+          reason: "missing_cursor_data",
+        });
         return null;
       }
 
       // Any other status means we should fall back
+      this.logger.trace("probe_python_result", {
+        sessionId,
+        result: null,
+        reason: "unexpected_python_status",
+        status: data.status,
+      });
       return null;
-    } catch {
+    } catch (error) {
       // Python API probe failed, fall back to command-line tools
+      this.logger.trace("probe_fallback", {
+        sessionId,
+        from: "python",
+        to: "cli",
+        reason: "python_probe_error",
+        error,
+      });
       return null;
     }
   }
 
-  private async checkWithCommandLineTools(sessionId: string): Promise<{
+  private async checkWithCommandLineTools(sessionId: string, targetId?: string): Promise<{
     presence: TerminalPresenceStatus;
     busy: TerminalBusyStatus;
   }> {
     let it2api: string;
     try {
       it2api = resolveIterm2ApiPath(this.options.iterm2ApiPath);
-    } catch {
+    } catch (error) {
+      this.logger.trace("probe_fallback", {
+        targetId,
+        from: "cli",
+        to: null,
+        reason: "it2api_unavailable",
+        error,
+      });
       return { presence: "unknown", busy: "unknown" };
     }
 
@@ -360,12 +572,27 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
     }
 
     if (first !== second) {
+      this.logger.trace("probe_cli_result", {
+        sessionId,
+        result: { presence: "available", busy: "busy" },
+        reason: "buffer_changed",
+      });
       return { presence: "available", busy: "busy" };
     }
     if (containsActiveBufferMarker(second)) {
+      this.logger.trace("probe_cli_result", {
+        sessionId,
+        result: { presence: "available", busy: "busy" },
+        reason: "active_buffer_marker",
+      });
       return { presence: "available", busy: "busy" };
     }
     // Do NOT use generic typing prompts to avoid false positives (see #116)
+    this.logger.trace("probe_cli_result", {
+      sessionId,
+      result: { presence: "available", busy: "unknown" },
+      reason: "stable_quiet_buffer",
+    });
     return { presence: "available", busy: "unknown" };
   }
 
@@ -374,7 +601,13 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
       const result = await this.execAsync(it2api, ["list-sessions"]);
       const sessionIds = parseIterm2SessionIds(result.stdout);
       return sessionIds.includes(sessionId) ? "available" : "gone";
-    } catch {
+    } catch (error) {
+      this.logger.trace("probe_error", {
+        sessionId,
+        step: "list_sessions",
+        error,
+        result: "unknown",
+      });
       return "unknown";
     }
   }
@@ -404,6 +637,7 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
       sampleDelayMs?: number;
       sleep?: (ms: number) => Promise<void>;
     } = {},
+    private readonly logger: Logger = new NoopLogger(),
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -416,17 +650,40 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
   }> {
     const paneId = target.tmuxPaneId?.trim();
     if (!paneId) {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result: { presence: "unknown", busy: "unknown" },
+        reason: "missing_tmux_pane_id",
+      });
       return { presence: "unknown", busy: "unknown" };
     }
 
     const paneState = await this.readPaneState(paneId);
     if (paneState === "missing") {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        paneId,
+        result: { presence: "gone", busy: "unknown" },
+        reason: "pane_missing",
+      });
       return { presence: "gone", busy: "unknown" };
     }
     if (paneState === "unknown") {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        paneId,
+        result: { presence: "unknown", busy: "unknown" },
+        reason: "pane_state_unknown",
+      });
       return { presence: "unknown", busy: "unknown" };
     }
     if (paneState.dead) {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        paneId,
+        result: { presence: "gone", busy: "unknown" },
+        reason: "pane_dead",
+      });
       return { presence: "gone", busy: "unknown" };
     }
 
@@ -441,17 +698,41 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
     }
 
     if (first !== second) {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        paneId,
+        result: { presence: "available", busy: "busy" },
+        reason: "buffer_changed",
+      });
       return { presence: "available", busy: "busy" };
     }
     if (containsActiveBufferMarker(second)) {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        paneId,
+        result: { presence: "available", busy: "busy" },
+        reason: "active_buffer_marker",
+      });
       return { presence: "available", busy: "busy" };
     }
     // Use cursor-aware detection when available
     const cursorHint = evaluateCursorAwareTypingPrompt(target, paneState, second);
     if (cursorHint === "busy") {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        paneId,
+        result: { presence: "available", busy: "busy" },
+        reason: "cursor_aware_busy",
+      });
       return { presence: "available", busy: "busy" };
     }
     // Do NOT fall back to generic typing prompts when cursorHint is unknown to avoid false positives (see #116)
+    this.logger.trace("probe_result", {
+      targetId: target.targetId,
+      paneId,
+      result: { presence: "available", busy: "unknown" },
+      reason: cursorHint === "not_busy" ? "cursor_aware_not_busy" : "cursor_aware_unknown",
+    });
     return { presence: "available", busy: "unknown" };
   }
 
@@ -746,6 +1027,7 @@ export class ClaudeCodeRuntimePresenceProbe implements RuntimePresenceProbe {
   constructor(
     private readonly killFn: (pid: number, signal: number) => void = (pid, signal) => process.kill(pid, signal),
     private readonly sessionFileReader?: (pid: number) => Promise<{ sessionId: string; cwd: string } | null>,
+    private readonly logger: Logger = new NoopLogger(),
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -754,6 +1036,7 @@ export class ClaudeCodeRuntimePresenceProbe implements RuntimePresenceProbe {
 
   async check(target: TerminalActivationTarget): Promise<RuntimePresenceStatus> {
     if (!Number.isInteger(target.runtimePid)) {
+      this.logger.trace("probe_result", { targetId: target.targetId, result: "unknown", reason: "missing_runtime_pid" });
       return "unknown";
     }
 
@@ -764,20 +1047,25 @@ export class ClaudeCodeRuntimePresenceProbe implements RuntimePresenceProbe {
       // 2. Verify session file exists and is valid
       const sessionInfo = await (this.sessionFileReader ?? this.defaultSessionFileReader)(target.runtimePid!);
       if (!sessionInfo) {
+        this.logger.trace("probe_result", { targetId: target.targetId, result: "gone", reason: "session_file_missing" });
         return "gone"; // Process exists but session file is invalid/missing
       }
 
       // 3. Verify session ID matches (prevent PID reuse)
       if (target.runtimeSessionId && sessionInfo.sessionId !== target.runtimeSessionId) {
+        this.logger.trace("probe_result", { targetId: target.targetId, result: "gone", reason: "session_id_mismatch" });
         return "gone";
       }
 
+      this.logger.trace("probe_result", { targetId: target.targetId, result: "alive" });
       return "alive";
     } catch (error) {
       const code = error instanceof Error && "code" in error ? String((error as NodeJS.ErrnoException).code ?? "") : "";
       if (code === "ESRCH") {
+        this.logger.trace("probe_result", { targetId: target.targetId, result: "gone", reason: "process_missing" });
         return "gone"; // Process doesn't exist
       }
+      this.logger.debug("probe_error", { targetId: target.targetId, error, result: "unknown" });
       return "unknown";
     }
   }
@@ -810,6 +1098,7 @@ export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
     private readonly sessionFileReader?: (pid: number) => Promise<{ sessionId: string; cwd: string } | null>,
     private readonly logFileStatReader?: (path: string) => Promise<{ mtimeMs: number } | null>,
     private readonly sleepFn: (ms: number) => Promise<void> = sleep,
+    private readonly logger: Logger = new NoopLogger(),
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -821,6 +1110,11 @@ export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
     busy: TerminalBusyStatus;
   }> {
     if (!target.runtimePid || !target.runtimeSessionId) {
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result: { presence: "unknown", busy: "unknown" },
+        reason: "missing_runtime_identity",
+      });
       return { presence: "unknown", busy: "unknown" };
     }
 
@@ -828,11 +1122,21 @@ export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
       // 1. Read session file to get cwd
       const sessionData = await (this.sessionFileReader ?? this.defaultSessionFileReader)(target.runtimePid);
       if (!sessionData) {
+        this.logger.trace("probe_result", {
+          targetId: target.targetId,
+          result: { presence: "gone", busy: "unknown" },
+          reason: "session_file_missing",
+        });
         return { presence: "gone", busy: "unknown" };
       }
 
       // 2. Verify session ID matches
       if (sessionData.sessionId !== target.runtimeSessionId) {
+        this.logger.trace("probe_result", {
+          targetId: target.targetId,
+          result: { presence: "gone", busy: "unknown" },
+          reason: "session_id_mismatch",
+        });
         return { presence: "gone", busy: "unknown" };
       }
 
@@ -848,10 +1152,18 @@ export class ClaudeCodeTerminalStateProbe implements TerminalStateProbe {
         ? await this.checkIterm2Presence(target.itermSessionId)
         : "available";
 
+      this.logger.trace("probe_result", {
+        targetId: target.targetId,
+        result: { presence, busy },
+      });
       return { presence, busy };
 
     } catch (error) {
-      console.warn('Claude Code state check failed:', error);
+      this.logger.debug("probe_error", {
+        targetId: target.targetId,
+        error,
+        result: { presence: "unknown", busy: "unknown" },
+      });
       return { presence: "unknown", busy: "unknown" };
     }
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -62,6 +62,7 @@ import {
 } from "./terminal";
 import { LifecycleSignal } from "./sources/remote_modules";
 import { ActivationGate, DefaultActivationGate } from "./runtime_gate";
+import { Logger, NoopLogger } from "./logging";
 
 const DEFAULT_SUBSCRIPTION_POLL_LIMIT = 100;
 const DEFAULT_ACTIVATION_WINDOW_MS = 3_000;
@@ -154,7 +155,8 @@ export class AgentInboxService {
     backend?: EventBusBackend,
     activationPolicy?: ActivationPolicy,
     terminalDispatcher: TerminalDispatcher = new TerminalDispatcher(),
-    activationGate: ActivationGate = new DefaultActivationGate(),
+    activationGate?: ActivationGate,
+    logger: Logger = new NoopLogger(),
   ) {
     this.activationDispatcher = activationDispatcher;
     this.backend = backend ?? new SqliteEventBusBackend(store);
@@ -162,12 +164,14 @@ export class AgentInboxService {
     this.activationMaxItems = activationPolicy?.maxItems ?? DEFAULT_ACTIVATION_MAX_ITEMS;
     this.ackedRetentionMs = DEFAULT_ACKED_RETENTION_MS;
     this.terminalDispatcher = terminalDispatcher;
-    this.activationGate = activationGate;
+    this.logger = logger;
+    this.activationGate = activationGate ?? new DefaultActivationGate(undefined, undefined, this.logger.child("gate"));
   }
 
   private readonly activationDispatcher: ActivationDispatcher;
   private readonly terminalDispatcher: TerminalDispatcher;
   private readonly activationGate: ActivationGate;
+  private readonly logger: Logger;
 
   async start(): Promise<void> {
     if (this.syncInterval) {
@@ -1834,12 +1838,32 @@ export class AgentInboxService {
     try {
       if (target.kind === "terminal") {
         const gate = await this.activationGate.evaluate(target);
+        this.logger.debug("activation.gate_decision", {
+          agentId: input.agentId,
+          targetId: target.targetId,
+          runtimeKind: target.runtimeKind,
+          backend: target.backend,
+          outcome: gate.outcome,
+          reason: gate.reason,
+        });
         if (gate.outcome === "offline") {
+          this.logger.info("activation.target_offline", {
+            agentId: input.agentId,
+            targetId: target.targetId,
+            reason: gate.reason,
+            transition: "runtime_gate",
+          });
           this.markActivationTargetOffline(target.targetId, `runtime gate: ${gate.reason}`);
           this.reconcileAgentStatus(target.agentId);
           return "offline";
         }
         if (gate.outcome === "defer") {
+          this.logger.debug("activation.dispatch_deferred", {
+            agentId: input.agentId,
+            targetId: target.targetId,
+            reason: gate.reason,
+            retryMs: DEFAULT_NOTIFY_RETRY_MS,
+          });
           this.store.upsertActivationDispatchState({
             agentId: input.agentId,
             targetId: input.targetId,
@@ -1877,6 +1901,11 @@ export class AgentInboxService {
         terminalPrompt = prompt;
         const promptFingerprint = terminalReminderFingerprint(prompt, input.items);
         if (state?.status === "dirty" && state.lastNotifiedFingerprint === promptFingerprint) {
+          this.logger.debug("activation.dispatch_suppressed", {
+            agentId: input.agentId,
+            targetId: target.targetId,
+            reason: "unchanged_terminal_prompt",
+          });
           this.store.upsertActivationDispatchState({
             agentId: input.agentId,
             targetId: input.targetId,
@@ -1891,7 +1920,19 @@ export class AgentInboxService {
           });
           return "suppressed";
         }
+        this.logger.debug("activation.terminal_dispatch_start", {
+          agentId: input.agentId,
+          targetId: target.targetId,
+          totalUnackedCount,
+          newItemCount: input.newItemCount,
+          sourceIds: input.sourceIds,
+          subscriptionIds: input.subscriptionIds,
+        });
         await this.terminalDispatcher.dispatch(target, prompt);
+        this.logger.debug("activation.terminal_dispatch_succeeded", {
+          agentId: input.agentId,
+          targetId: target.targetId,
+        });
       } else {
         const activation: Activation = {
           kind: "agentinbox.activation",
@@ -1931,11 +1972,28 @@ export class AgentInboxService {
       });
       return "dispatched";
     } catch (error) {
-      console.warn(`activation target dispatch failed for ${target.targetId}:`, error);
       const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn("activation.dispatch_failed", {
+        agentId: input.agentId,
+        targetId: target.targetId,
+        targetKind: target.kind,
+        error,
+        message,
+      });
       if (target.kind === "terminal") {
         const exists = await this.terminalDispatcher.probe(target);
+        this.logger.debug("activation.terminal_probe_after_failure", {
+          agentId: input.agentId,
+          targetId: target.targetId,
+          exists,
+        });
         if (!exists) {
+          this.logger.info("activation.target_offline", {
+            agentId: input.agentId,
+            targetId: target.targetId,
+            reason: message,
+            transition: "dispatch_probe",
+          });
           this.markActivationTargetOffline(target.targetId, message);
           this.reconcileAgentStatus(target.agentId);
           return "offline";

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -133,6 +133,7 @@ test("resolveDaemonPaths derives pid and log files from AGENTINBOX_HOME", () => 
   assert.deepEqual(paths, {
     pidPath: path.join(homeDir, "agentinbox.pid"),
     logPath: path.join(homeDir, "agentinbox.log"),
+    metadataPath: path.join(homeDir, "agentinbox.daemon.json"),
   });
 });
 
@@ -182,6 +183,7 @@ test("daemonStatus removes stale pid files", async () => {
     });
     assert.equal(status.running, false);
     assert.equal(status.pid, null);
+    assert.equal(status.logLevel, null);
     assert.equal(fs.existsSync(pidPath), false);
   } finally {
     fs.rmSync(homeDir, { recursive: true, force: true });
@@ -217,6 +219,7 @@ test("cli auto-starts the daemon for normal commands and daemon stop shuts it do
     const parsedDaemon = JSON.parse(daemonState.stdout) as {
       running: boolean;
       pid: number | null;
+      logLevel: string | null;
       version: string | null;
       startedAt: string | null;
       command: string | null;
@@ -226,6 +229,7 @@ test("cli auto-starts the daemon for normal commands and daemon stop shuts it do
     };
     assert.equal(parsedDaemon.running, true);
     assert.ok(parsedDaemon.pid && parsedDaemon.pid > 0);
+    assert.equal(parsedDaemon.logLevel, "info");
     assert.equal(parsedDaemon.version, packageVersion.version);
     assert.equal(typeof parsedDaemon.command, "string");
     assert.ok(parsedDaemon.command && parsedDaemon.command.includes("serve"));
@@ -243,6 +247,45 @@ test("cli auto-starts the daemon for normal commands and daemon stop shuts it do
     assert.equal(stopped.status, 0, stopped.stderr);
     const parsedStopped = JSON.parse(stopped.stdout) as { running: boolean };
     assert.equal(parsedStopped.running, false);
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("daemon status surfaces the configured log level", () => {
+  const repoDir = path.resolve(__dirname, "..");
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-daemon-log-level-home-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+  };
+  try {
+    const started = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "daemon", "start", "--log-level", "debug"], {
+      cwd: repoDir,
+      env,
+      encoding: "utf8",
+      timeout: 25_000,
+    });
+    assert.equal(started.status, 0, started.stderr);
+
+    const daemonState = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "daemon", "status"], {
+      cwd: repoDir,
+      env,
+      encoding: "utf8",
+      timeout: 25_000,
+    });
+    assert.equal(daemonState.status, 0, daemonState.stderr);
+    const parsedDaemon = JSON.parse(daemonState.stdout) as { running: boolean; logLevel: string | null };
+    assert.equal(parsedDaemon.running, true);
+    assert.equal(parsedDaemon.logLevel, "debug");
+
+    const stopped = spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", "daemon", "stop"], {
+      cwd: repoDir,
+      env,
+      encoding: "utf8",
+      timeout: 25_000,
+    });
+    assert.equal(stopped.status, 0, stopped.stderr);
   } finally {
     fs.rmSync(homeDir, { recursive: true, force: true });
   }

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -14,6 +14,48 @@ import { TerminalActivationTarget } from "../src/model";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Logger, LogLevel } from "../src/logging";
+
+class RecordingLogger implements Logger {
+  constructor(
+    public readonly level: LogLevel = "trace",
+    private readonly component = "test",
+    public readonly records: Array<{ level: LogLevel; event: string; fields?: Record<string, unknown>; component: string }> = [],
+  ) {}
+
+  enabled(_level: LogLevel): boolean {
+    return true;
+  }
+
+  child(component: string): Logger {
+    return new RecordingLogger(this.level, `${this.component}.${component}`, this.records);
+  }
+
+  error(event: string, fields?: Record<string, unknown>): void {
+    this.push("error", event, fields);
+  }
+
+  warn(event: string, fields?: Record<string, unknown>): void {
+    this.push("warn", event, fields);
+  }
+
+  info(event: string, fields?: Record<string, unknown>): void {
+    this.push("info", event, fields);
+  }
+
+  debug(event: string, fields?: Record<string, unknown>): void {
+    this.push("debug", event, fields);
+  }
+
+  trace(event: string, fields?: Record<string, unknown>): void {
+    this.push("trace", event, fields);
+  }
+
+  private push(level: LogLevel, event: string, fields?: Record<string, unknown>): void {
+    const record = { level, event, fields, component: this.component };
+    this.records.push(record);
+  }
+}
 
 function makeItermTarget(): TerminalActivationTarget {
   return {
@@ -376,6 +418,44 @@ test("DefaultActivationGate short-circuits terminal probes when runtime is alrea
     reason: "runtime_gone",
   });
   assert.equal(terminalChecked, false);
+});
+
+test("DefaultActivationGate emits a structured gate decision log", async () => {
+  const logger = new RecordingLogger();
+  const gate = new DefaultActivationGate(
+    [new CodexRuntimePresenceProbe(
+      () => {},
+      async () => ({
+        sessionId: "thread-1",
+        filePath: "/tmp/codex-thread-1.jsonl",
+      }),
+    )],
+    [{
+      supports: () => true,
+      async check() {
+        return {
+          presence: "available" as const,
+          busy: "busy" as const,
+        };
+      },
+    }],
+    logger,
+  );
+
+  const decision = await gate.evaluate(makeItermTarget());
+  assert.deepEqual(decision, {
+    outcome: "defer",
+    reason: "terminal_busy",
+  });
+
+  const logRecord = logger.records.find((record) => record.event === "gate_decision");
+  assert.ok(logRecord);
+  assert.equal(logRecord.level, "debug");
+  assert.equal(logRecord.fields?.runtimePresence, "alive");
+  assert.equal(logRecord.fields?.terminalPresence, "available");
+  assert.equal(logRecord.fields?.terminalBusy, "busy");
+  assert.equal(logRecord.fields?.outcome, "defer");
+  assert.equal(logRecord.fields?.reason, "terminal_busy");
 });
 
 test("CodexTerminalStateProbe reports busy when the Codex session file was updated recently", async () => {


### PR DESCRIPTION
## Summary
- add configurable daemon log levels and surface the active level in daemon status
- add structured activation gate and probe tracing, including fallback and offline/defer decisions
- cover the new daemon status and gate logging behavior with regression tests

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit test/runtime_gate.test.ts
- node --require ts-node/register --test --test-force-exit --test-name-pattern "resolveDaemonPaths|daemonStatus removes stale pid files|cli auto-starts the daemon for normal commands and daemon stop shuts it down|daemon status surfaces the configured log level" test/control_plane.test.ts