### PR TITLE
fix: align iterm python probe semantics

### DIFF
--- a/scripts/iterm2_cursor_probe.py
+++ b/scripts/iterm2_cursor_probe.py
@@ -8,6 +8,9 @@ import sys
 import json
 import asyncio
 
+# Keep this value in sync with the TypeScript probe normalization constant
+# `NORMALIZED_BUFFER_TAIL_LINES`, since both are intended to mirror the same
+# CLI/probe tail window.
 CAPTURE_TAIL_LINES = 20
 
 

--- a/scripts/iterm2_cursor_probe.py
+++ b/scripts/iterm2_cursor_probe.py
@@ -8,6 +8,8 @@ import sys
 import json
 import asyncio
 
+CAPTURE_TAIL_LINES = 20
+
 
 def probe_session(connection, session_id):
     """Probe iTerm2 session state and return cursor position with buffer contents."""
@@ -25,9 +27,9 @@ def probe_session(connection, session_id):
                 screen = await session.async_get_screen_contents()
                 cursor = screen.cursor_coord
 
-                # Get the last few lines of content
+                # Capture a tail comparable to the CLI probe window.
                 lines = []
-                start_line = max(0, screen.number_of_lines - 5)
+                start_line = max(0, screen.number_of_lines - CAPTURE_TAIL_LINES)
                 for i in range(start_line, screen.number_of_lines):
                     try:
                         line = screen.line(i)

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -781,7 +781,7 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
 
   private async readBufferTail(paneId: string): Promise<string | null> {
     try {
-      const result = await this.execAsync("tmux", ["capture-pane", "-p", "-t", paneId, "-S", "-20"]);
+      const result = await this.execAsync("tmux", ["capture-pane", "-p", "-t", paneId, "-S", `-${NORMALIZED_BUFFER_TAIL_LINES}`]);
       return normalizeBufferTail(result.stdout);
     } catch {
       return null;

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -9,6 +9,7 @@ import { Logger, NoopLogger } from "./logging";
 const execFileAsync = promisify(execFile);
 const DEFAULT_ITERM2_SAMPLE_DELAY_MS = 900;
 const DEFAULT_TMUX_SAMPLE_DELAY_MS = 900;
+const NORMALIZED_BUFFER_TAIL_LINES = 20;
 const ACTIVE_BUFFER_MARKERS = [
   "esc to interrupt",
   "Working (",
@@ -393,8 +394,16 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
 
       if (data.status === "available") {
         // If we have cursor and lines data, use cursor-aware detection
-        if (data.cursor && data.lines) {
-          const bufferTail = data.lines.join("\n");
+        if (data.cursor && Array.isArray(data.lines)) {
+          const bufferTail = normalizeProbeTailFromLines(data.lines);
+          if (!bufferTail) {
+            this.logger.trace("probe_python_result", {
+              sessionId,
+              result: { presence: "available", busy: "unknown" },
+              reason: "empty_normalized_buffer",
+            });
+            return { presence: "available", busy: "unknown" };
+          }
           const cursorPosition = { x: data.cursor.x, y: data.cursor.y };
           const screenHeight = data.screen_height;
           const startLine = data.start_line ?? 0;
@@ -427,35 +436,35 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
             });
             const secondData = JSON.parse(secondResult.stdout);
 
-            if (secondData.status === "available" && secondData.lines) {
-              const secondBufferTail = secondData.lines.join("\n");
-            if (bufferTail !== secondBufferTail) {
+            if (secondData.status === "available" && Array.isArray(secondData.lines)) {
+              const secondBufferTail = normalizeProbeTailFromLines(secondData.lines);
+              if (secondBufferTail && bufferTail !== secondBufferTail) {
                 this.logger.trace("probe_python_result", {
                   sessionId,
                   result: { presence: "available", busy: "busy" },
                   reason: "buffer_changed",
                 });
+                return { presence: "available", busy: "busy" };
+              }
+            }
+
+            // Check for active buffer markers
+            if (containsActiveBufferMarker(bufferTail)) {
+              this.logger.trace("probe_python_result", {
+                sessionId,
+                result: { presence: "available", busy: "busy" },
+                reason: "active_buffer_marker",
+              });
               return { presence: "available", busy: "busy" };
             }
-          }
 
-          // Check for active buffer markers
-          if (containsActiveBufferMarker(bufferTail)) {
             this.logger.trace("probe_python_result", {
               sessionId,
-              result: { presence: "available", busy: "busy" },
-              reason: "active_buffer_marker",
+              result: { presence: "available", busy: "unknown" },
+              reason: "cursor_aware_not_busy",
             });
-            return { presence: "available", busy: "busy" };
+            return { presence: "available", busy: "unknown" };
           }
-
-          this.logger.trace("probe_python_result", {
-            sessionId,
-            result: { presence: "available", busy: "idle" },
-            reason: "cursor_aware_not_busy",
-          });
-          return { presence: "available", busy: "idle" };
-        }
 
           // If cursor-aware detection is uncertain, fall back to buffer change detection only
           // Do NOT use generic typing prompts to avoid false positives (see #116)
@@ -466,27 +475,27 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
             });
             const secondData = JSON.parse(secondResult.stdout);
 
-            if (secondData.status === "available" && secondData.lines) {
-              const secondBufferTail = secondData.lines.join("\n");
-            if (bufferTail !== secondBufferTail) {
+            if (secondData.status === "available" && Array.isArray(secondData.lines)) {
+              const secondBufferTail = normalizeProbeTailFromLines(secondData.lines);
+              if (secondBufferTail && bufferTail !== secondBufferTail) {
                 this.logger.trace("probe_python_result", {
                   sessionId,
                   result: { presence: "available", busy: "busy" },
                   reason: "buffer_changed_after_unknown_cursor_state",
                 });
-              return { presence: "available", busy: "busy" };
+                return { presence: "available", busy: "busy" };
+              }
             }
-          }
 
             // Check for active buffer markers
-          if (containsActiveBufferMarker(bufferTail)) {
-            this.logger.trace("probe_python_result", {
-              sessionId,
-              result: { presence: "available", busy: "busy" },
-              reason: "active_buffer_marker_after_unknown_cursor_state",
-            });
-            return { presence: "available", busy: "busy" };
-          }
+            if (containsActiveBufferMarker(bufferTail)) {
+              this.logger.trace("probe_python_result", {
+                sessionId,
+                result: { presence: "available", busy: "busy" },
+                reason: "active_buffer_marker_after_unknown_cursor_state",
+              });
+              return { presence: "available", busy: "busy" };
+            }
 
             // Return unknown when cursor-aware detection is uncertain
             // Do NOT fall back to generic typing prompts to avoid false positives
@@ -868,10 +877,14 @@ function normalizeBufferTail(buffer: string): string | null {
     .replace(/\r/g, "")
     .split("\n")
     .map((line) => line.trimEnd())
-    .slice(-20)
+    .slice(-NORMALIZED_BUFFER_TAIL_LINES)
     .join("\n")
     .trim();
   return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeProbeTailFromLines(lines: readonly string[]): string | null {
+  return normalizeBufferTail(lines.join("\n"));
 }
 
 function resolveIterm2ApiPath(override?: string): string {

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -928,7 +928,7 @@ test("Iterm2TerminalStateProbe with Python API reports busy when cursor is at pr
   assert.equal(result.busy, "busy");
 });
 
-test("Iterm2TerminalStateProbe with Python API reports idle when cursor is not at prompt line", async () => {
+test("Iterm2TerminalStateProbe with Python API reports unknown when cursor is not at prompt line", async () => {
   const probe = new Iterm2TerminalStateProbe(
     async (file, args) => {
       if (file === "python3") {
@@ -963,7 +963,93 @@ test("Iterm2TerminalStateProbe with Python API reports idle when cursor is not a
   const result = await probe.check(target);
 
   assert.equal(result.presence, "available");
-  assert.equal(result.busy, "idle");
+  assert.equal(result.busy, "unknown");
+});
+
+test("Iterm2TerminalStateProbe with Python API normalizes tail whitespace before diffing snapshots", async () => {
+  const snapshots = [
+    {
+      status: "available",
+      cursor: { x: 5, y: 2 },
+      screen_height: 5,
+      start_line: 0,
+      lines: [
+        "line 1   ",
+        "line 2 with cursor\r",
+        "line 3",
+        "line 4   ",
+        "› test input   ",
+      ],
+    },
+    {
+      status: "available",
+      cursor: { x: 5, y: 2 },
+      screen_height: 5,
+      start_line: 0,
+      lines: [
+        "line 1",
+        "line 2 with cursor",
+        "line 3",
+        "line 4",
+        "› test input",
+      ],
+    },
+  ];
+
+  const probe = new Iterm2TerminalStateProbe(
+    async (file) => {
+      if (file === "python3") {
+        return {
+          stdout: JSON.stringify(snapshots.shift()),
+          stderr: "",
+        };
+      }
+      throw new Error("Unexpected command");
+    },
+    {
+      pythonScriptPath: "/tmp/fake-python-probe.py",
+      sampleDelayMs: 0,
+      sleep: async () => {},
+    }
+  );
+
+  const result = await probe.check(makeItermTarget());
+  assert.equal(result.presence, "available");
+  assert.equal(result.busy, "unknown");
+});
+
+test("Iterm2TerminalStateProbe with Python API sees active markers above the old 5-line tail", async () => {
+  const probe = new Iterm2TerminalStateProbe(
+    async (file) => {
+      if (file === "python3") {
+        return {
+          stdout: JSON.stringify({
+            status: "available",
+            cursor: { x: 0, y: 19 },
+            screen_height: 20,
+            start_line: 0,
+            lines: [
+              "workspace",
+              "build logs",
+              "• Working (1m 23s • esc to interrupt)",
+              ...Array.from({ length: 17 }, (_, index) => `line ${index + 4}`),
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      throw new Error("Unexpected command");
+    },
+    {
+      pythonScriptPath: "/tmp/fake-python-probe.py",
+      sampleDelayMs: 0,
+      sleep: async () => {},
+    }
+  );
+
+  const result = await probe.check(makeItermTarget());
+  assert.equal(result.presence, "available");
+  assert.equal(result.busy, "busy");
 });
 
 test("Iterm2TerminalStateProbe with Python API falls back to CLI when Python fails", async () => {


### PR DESCRIPTION
## Summary
- normalize Python-probe tails with the same rules as the CLI path
- expand the Python capture window and avoid over-deferring quiet Codex prompts
- add regression coverage for whitespace-only diffs, larger sampled tails, and quiet prompt semantics

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit test/runtime_gate.test.ts