### PR TITLE
fix: restore remote runtime profile alias

### DIFF
--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -97,11 +97,12 @@ export class RemoteSourceRuntime {
     private readonly appendSourceEvent: (input: AppendSourceEventInput) => Promise<{ appended: number; deduped: number }>,
     options?: {
       moduleRegistry?: RemoteSourceModuleRegistry;
+      profileRegistry?: RemoteSourceModuleRegistry;
       client?: UxcRemoteSourceClient;
       homeDir?: string;
     },
   ) {
-    this.moduleRegistry = options?.moduleRegistry ?? new RemoteSourceModuleRegistry();
+    this.moduleRegistry = options?.moduleRegistry ?? options?.profileRegistry ?? new RemoteSourceModuleRegistry();
     this.client = options?.client ?? new RpcUxcRemoteSourceClient();
     this.homeDir = options?.homeDir ?? resolveAgentInboxHome(process.env);
   }

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -7,7 +7,7 @@ import { AdapterRegistry } from "../src/adapters";
 import { AppendSourceEventInput } from "../src/model";
 import { AgentInboxService } from "../src/service";
 import { resolveSourceIdentity } from "../src/source_resolution";
-import { UxcRemoteSourceClient } from "../src/sources/remote";
+import { RemoteSourceRuntime, UxcRemoteSourceClient } from "../src/sources/remote";
 import { ManagedSourceSpec } from "../src/sources/remote_modules";
 import { RemoteSourceProfileRegistry, builtInProfileIdForSourceType, profileConfigForSource } from "../src/sources/remote_profiles";
 import { AgentInboxStore } from "../src/store";
@@ -659,6 +659,51 @@ test("resolveSourceIdentity still honors deprecated profileRegistry context", as
       implementationId: "demo.compat",
     });
   } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("RemoteSourceRuntime still honors deprecated profileRegistry option", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-remote-runtime-compat-"));
+  const store = await AgentInboxStore.open(path.join(homeDir, "agentinbox.sqlite"));
+  try {
+    const profileDir = path.join(homeDir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(path.join(profileDir, "compat-runtime.mjs"), `
+      export default {
+        id: "demo.compat.runtime",
+        validateConfig(source) {
+          if (!source.config?.tenant) throw new Error("tenant required");
+        },
+        buildManagedSourceSpec(source) {
+          return { endpoint: "https://example.invalid", mode: "poll", args: { tenant: source.config.tenant } };
+        },
+        mapRawEvent() { return null; },
+      };
+    `);
+
+    const runtime = new RemoteSourceRuntime(store, async () => ({ appended: 0, deduped: 0 }), {
+      homeDir,
+      client: new FakeRemoteSourceClient(),
+      profileRegistry: new RemoteSourceProfileRegistry(),
+    });
+
+    await assert.doesNotReject(runtime.validateSource({
+      sourceId: "src_runtime_compat",
+      sourceType: "remote_source",
+      sourceKey: "compat-runtime",
+      configRef: null,
+      config: {
+        profilePath: "compat-runtime.mjs",
+        profileConfig: { tenant: "team-a" },
+      },
+      status: "active",
+      checkpoint: null,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    }));
+  } finally {
+    store.close();
     fs.rmSync(homeDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- restore the deprecated profileRegistry constructor alias on RemoteSourceRuntime
- keep moduleRegistry as the preferred option while honoring the old name during the transition
- add regression coverage for direct callers using the deprecated option

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "deprecated remote profile exports still alias the module contract|resolveSourceIdentity still honors deprecated profileRegistry context|RemoteSourceRuntime still honors deprecated profileRegistry option" test/remote_source.test.ts