### PR TITLE
feat: add handle-scoped delivery operations

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -3,6 +3,8 @@ import {
   AppendSourceEventInput,
   DeliveryAttempt,
   DeliveryRequest,
+  DeliveryHandle,
+  DeliveryOperationDescriptor,
   SubscriptionSource,
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
@@ -14,7 +16,7 @@ import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubDeliveryAdapter } from "./sources/github";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
-import { ExpandedSubscriptionInput, LifecycleSignal, RemoteSourceModuleRegistry } from "./sources/remote_modules";
+import { ExpandedSubscriptionInput, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry } from "./sources/remote_modules";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
 
 export interface SourceAdapter {
@@ -201,9 +203,62 @@ export class AdapterRegistry {
     return this.remoteSource.deriveInlinePreview(source, item);
   }
 
+  async listDeliveryOperations(
+    source: SubscriptionSource | null,
+    handle: DeliveryHandle,
+  ): Promise<DeliveryOperationDescriptor[]> {
+    const module = await this.resolveDeliveryModule(source, handle);
+    if (!module?.listDeliveryOperations) {
+      return [];
+    }
+    return module.listDeliveryOperations({ handle, source });
+  }
+
+  async invokeDeliveryOperation(
+    source: SubscriptionSource | null,
+    handle: DeliveryHandle,
+    operation: string,
+    input: Record<string, unknown>,
+    attempt: DeliveryAttempt,
+  ): Promise<{ status: DeliveryAttempt["status"]; note: string }> {
+    const module = await this.resolveDeliveryModule(source, handle);
+    if (!module?.invokeDeliveryOperation) {
+      throw new Error(`delivery operations are not supported for provider ${handle.provider}`);
+    }
+    return module.invokeDeliveryOperation({ handle, operation, input, attempt, source });
+  }
+
   status(): Record<string, unknown> {
     return {
       remote: this.remoteSource.status?.() ?? {},
     };
   }
+
+  private async resolveDeliveryModule(source: SubscriptionSource | null, handle: DeliveryHandle): Promise<RemoteSourceModule | null> {
+    if (source) {
+      if (source.sourceType === "local_event") {
+        return null;
+      }
+      return this.remoteModuleRegistry.resolve(source, this.homeDir);
+    }
+    if (handle.provider === "github") {
+      return this.remoteModuleRegistry.resolve(syntheticBuiltinSource("github_repo"), this.homeDir);
+    }
+    if (handle.provider === "feishu") {
+      return this.remoteModuleRegistry.resolve(syntheticBuiltinSource("feishu_bot"), this.homeDir);
+    }
+    return null;
+  }
+}
+
+function syntheticBuiltinSource(sourceType: "github_repo" | "feishu_bot"): SubscriptionSource {
+  return {
+    sourceId: `builtin:${sourceType}`,
+    sourceType,
+    sourceKey: sourceType,
+    status: "active",
+    createdAt: "",
+    updatedAt: "",
+    config: {},
+  };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -586,9 +586,10 @@ async function main(): Promise<void> {
     const targetRef = takeFlagValue(normalized, "--target");
     const kind = takeFlagValue(normalized, "--kind") ?? "reply";
     if (!provider || !surface || !targetRef) {
-      throw new Error("usage: agentinbox deliver send --provider PROVIDER --surface SURFACE --target TARGET [--kind KIND] [--payload-json JSON]");
+      throw new Error("usage: agentinbox deliver send --provider PROVIDER --surface SURFACE --target TARGET [--source-id SOURCE_ID] [--kind KIND] [--payload-json JSON]");
     }
     await printRemote(client, "/deliveries/send", {
+      sourceId: takeFlagValue(normalized, "--source-id") ?? undefined,
       provider,
       surface,
       targetRef,
@@ -597,6 +598,67 @@ async function main(): Promise<void> {
       kind,
       payload: parseJsonArg(takeFlagValue(normalized, "--payload-json")),
     });
+    return;
+  }
+
+  if (command === "deliver" && normalized[1] === "actions") {
+    const provider = takeFlagValue(normalized, "--provider");
+    const surface = takeFlagValue(normalized, "--surface");
+    const targetRef = takeFlagValue(normalized, "--target");
+    const handleJson = takeFlagValue(normalized, "--handle-json");
+    if (!handleJson && (!provider || !surface || !targetRef)) {
+      throw new Error("usage: agentinbox deliver actions (--handle-json JSON | --provider PROVIDER --surface SURFACE --target TARGET) [--source-id SOURCE_ID]");
+    }
+    await printRemote(
+      client,
+      "/deliveries/actions",
+      handleJson
+        ? {
+          sourceId: takeFlagValue(normalized, "--source-id") ?? undefined,
+          deliveryHandle: parseJsonArg(handleJson),
+        }
+        : {
+          sourceId: takeFlagValue(normalized, "--source-id") ?? undefined,
+          provider,
+          surface,
+          targetRef,
+          threadRef: takeFlagValue(normalized, "--thread") ?? undefined,
+          replyMode: takeFlagValue(normalized, "--reply-mode") ?? undefined,
+        },
+    );
+    return;
+  }
+
+  if (command === "deliver" && normalized[1] === "invoke") {
+    const provider = takeFlagValue(normalized, "--provider");
+    const surface = takeFlagValue(normalized, "--surface");
+    const targetRef = takeFlagValue(normalized, "--target");
+    const handleJson = takeFlagValue(normalized, "--handle-json");
+    const operation = takeFlagValue(normalized, "--operation");
+    if (!operation || (!handleJson && (!provider || !surface || !targetRef))) {
+      throw new Error("usage: agentinbox deliver invoke (--handle-json JSON | --provider PROVIDER --surface SURFACE --target TARGET) --operation NAME --input-json JSON [--source-id SOURCE_ID]");
+    }
+    await printRemote(
+      client,
+      "/deliveries/invoke",
+      handleJson
+        ? {
+          sourceId: takeFlagValue(normalized, "--source-id") ?? undefined,
+          deliveryHandle: parseJsonArg(handleJson),
+          operation,
+          input: parseJsonArg(takeFlagValue(normalized, "--input-json")),
+        }
+        : {
+          sourceId: takeFlagValue(normalized, "--source-id") ?? undefined,
+          provider,
+          surface,
+          targetRef,
+          threadRef: takeFlagValue(normalized, "--thread") ?? undefined,
+          replyMode: takeFlagValue(normalized, "--reply-mode") ?? undefined,
+          operation,
+          input: parseJsonArg(takeFlagValue(normalized, "--input-json")),
+        },
+    );
     return;
   }
 
@@ -1087,7 +1149,9 @@ Usage:
     deliver: `agentinbox deliver
 
 Usage:
-  agentinbox deliver send --provider PROVIDER --surface SURFACE --target TARGET [--kind KIND] [--payload-json JSON]
+  agentinbox deliver send --provider PROVIDER --surface SURFACE --target TARGET [--source-id SOURCE_ID] [--kind KIND] [--payload-json JSON]
+  agentinbox deliver actions (--handle-json JSON | --provider PROVIDER --surface SURFACE --target TARGET) [--source-id SOURCE_ID]
+  agentinbox deliver invoke (--handle-json JSON | --provider PROVIDER --surface SURFACE --target TARGET) --operation NAME --input-json JSON [--source-id SOURCE_ID]
 `,
     status: `agentinbox status
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -635,7 +635,8 @@ async function main(): Promise<void> {
     const targetRef = takeFlagValue(normalized, "--target");
     const handleJson = takeFlagValue(normalized, "--handle-json");
     const operation = takeFlagValue(normalized, "--operation");
-    if (!operation || (!handleJson && (!provider || !surface || !targetRef))) {
+    const inputJson = takeFlagValue(normalized, "--input-json");
+    if (!operation || !inputJson || (!handleJson && (!provider || !surface || !targetRef))) {
       throw new Error("usage: agentinbox deliver invoke (--handle-json JSON | --provider PROVIDER --surface SURFACE --target TARGET) --operation NAME --input-json JSON [--source-id SOURCE_ID]");
     }
     await printRemote(
@@ -646,7 +647,7 @@ async function main(): Promise<void> {
           sourceId: takeFlagValue(normalized, "--source-id") ?? undefined,
           deliveryHandle: parseJsonArg(handleJson),
           operation,
-          input: parseJsonArg(takeFlagValue(normalized, "--input-json")),
+          input: parseJsonArg(inputJson, "--input-json"),
         }
         : {
           sourceId: takeFlagValue(normalized, "--source-id") ?? undefined,
@@ -656,7 +657,7 @@ async function main(): Promise<void> {
           threadRef: takeFlagValue(normalized, "--thread") ?? undefined,
           replyMode: takeFlagValue(normalized, "--reply-mode") ?? undefined,
           operation,
-          input: parseJsonArg(takeFlagValue(normalized, "--input-json")),
+          input: parseJsonArg(inputJson, "--input-json"),
         },
     );
     return;

--- a/src/http.ts
+++ b/src/http.ts
@@ -1414,11 +1414,13 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("sources/events requires") ||
     message.startsWith("source remove requires") ||
     message.startsWith("delivery requires") ||
+    message.startsWith("deliver send is not supported") ||
     message.startsWith("deliveryHandle requires") ||
     message.startsWith("delivery operations are not supported") ||
     message.startsWith("unknown GitHub delivery operation") ||
     message.startsWith("unknown Feishu delivery operation") ||
     message.startsWith("invalid GitHub targetRef") ||
+    message.includes("requires input.text") ||
     message.includes("requires input.body") ||
     message.startsWith("subscriptions/reset requires") ||
     message.startsWith("agents requires") ||

--- a/src/http.ts
+++ b/src/http.ts
@@ -42,6 +42,30 @@ const deliveryHandleSchema = {
   },
 } as const;
 
+const deliveryTargetByHandleSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["deliveryHandle"],
+  properties: {
+    sourceId: { type: "string", minLength: 1 },
+    deliveryHandle: deliveryHandleSchema,
+  },
+} as const;
+
+const deliveryTargetByFieldsSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["provider", "surface", "targetRef"],
+  properties: {
+    sourceId: { type: "string", minLength: 1 },
+    provider: { type: "string", minLength: 1 },
+    surface: { type: "string", minLength: 1 },
+    targetRef: { type: "string", minLength: 1 },
+    threadRef: { type: "string" },
+    replyMode: { type: "string" },
+  },
+} as const;
+
 function buildFastifyServer(service: AgentInboxService) {
   const app = Fastify({
     logger: false,
@@ -1217,6 +1241,7 @@ function buildFastifyServer(service: AgentInboxService) {
             additionalProperties: false,
             required: ["kind", "payload", "deliveryHandle"],
             properties: {
+              sourceId: { type: "string", minLength: 1 },
               kind: { type: "string", minLength: 1 },
               payload: jsonObjectSchema,
               deliveryHandle: deliveryHandleSchema,
@@ -1227,6 +1252,7 @@ function buildFastifyServer(service: AgentInboxService) {
             additionalProperties: false,
             required: ["kind", "payload", "provider", "surface", "targetRef"],
             properties: {
+              sourceId: { type: "string", minLength: 1 },
               kind: { type: "string", minLength: 1 },
               payload: jsonObjectSchema,
               provider: { type: "string", minLength: 1 },
@@ -1244,6 +1270,59 @@ function buildFastifyServer(service: AgentInboxService) {
       },
     },
   }, async (request) => service.sendDelivery(request.body as never));
+
+  app.post("/deliveries/actions", {
+    schema: {
+      tags: ["deliveries"],
+      body: {
+        oneOf: [deliveryTargetByHandleSchema, deliveryTargetByFieldsSchema],
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => service.listDeliveryActions(request.body as never));
+
+  app.post("/deliveries/invoke", {
+    schema: {
+      tags: ["deliveries"],
+      body: {
+        oneOf: [
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["deliveryHandle", "operation", "input"],
+            properties: {
+              sourceId: { type: "string", minLength: 1 },
+              deliveryHandle: deliveryHandleSchema,
+              operation: { type: "string", minLength: 1 },
+              input: jsonObjectSchema,
+            },
+          },
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["provider", "surface", "targetRef", "operation", "input"],
+            properties: {
+              sourceId: { type: "string", minLength: 1 },
+              provider: { type: "string", minLength: 1 },
+              surface: { type: "string", minLength: 1 },
+              targetRef: { type: "string", minLength: 1 },
+              threadRef: { type: "string" },
+              replyMode: { type: "string" },
+              operation: { type: "string", minLength: 1 },
+              input: jsonObjectSchema,
+            },
+          },
+        ],
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => service.invokeDelivery(request.body as never));
 
   app.setNotFoundHandler((_request, reply) => {
     void reply.code(404).send({ error: "not found" });
@@ -1334,7 +1413,13 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("manual append is not supported") ||
     message.startsWith("sources/events requires") ||
     message.startsWith("source remove requires") ||
+    message.startsWith("delivery requires") ||
     message.startsWith("deliveryHandle requires") ||
+    message.startsWith("delivery operations are not supported") ||
+    message.startsWith("unknown GitHub delivery operation") ||
+    message.startsWith("unknown Feishu delivery operation") ||
+    message.startsWith("invalid GitHub targetRef") ||
+    message.includes("requires input.body") ||
     message.startsWith("subscriptions/reset requires") ||
     message.startsWith("agents requires") ||
     message.startsWith("agents/targets requires") ||
@@ -1359,6 +1444,8 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("remote_source requires") ||
     message.startsWith("remote_source profile") ||
     message.startsWith("remote_source module") ||
+    message.startsWith("reply_in_review_thread requires") ||
+    message.includes("does not match delivery provider") ||
     message.includes("requires tmuxPaneId") ||
     message.includes("requires iTerm2 session identity") ||
     message.includes("requires a supported terminal context") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -356,6 +356,7 @@ export interface AppendSourceEventResult {
 
 export interface DeliveryRequest {
   agentId?: string;
+  sourceId?: string;
   deliveryHandle?: DeliveryHandle | null;
   provider?: string;
   surface?: string;
@@ -364,6 +365,35 @@ export interface DeliveryRequest {
   replyMode?: string | null;
   kind: string;
   payload: Record<string, unknown>;
+}
+
+export interface DeliveryOperationDescriptor {
+  name: string;
+  title: string;
+  inputSchema: Record<string, unknown>;
+  canonicalTextAlias?: boolean;
+}
+
+export interface DeliveryActionsRequest {
+  sourceId?: string;
+  deliveryHandle?: DeliveryHandle | null;
+  provider?: string;
+  surface?: string;
+  targetRef?: string;
+  threadRef?: string | null;
+  replyMode?: string | null;
+}
+
+export interface DeliveryInvokeRequest {
+  sourceId?: string;
+  deliveryHandle?: DeliveryHandle | null;
+  provider?: string;
+  surface?: string;
+  targetRef?: string;
+  threadRef?: string | null;
+  replyMode?: string | null;
+  operation: string;
+  input: Record<string, unknown>;
 }
 
 export interface MatchResult {

--- a/src/service.ts
+++ b/src/service.ts
@@ -10,7 +10,10 @@ import {
   AppendSourceEventInput,
   AppendSourceEventResult,
   DeliveryAttempt,
+  DeliveryActionsRequest,
   DeliveryHandle,
+  DeliveryInvokeRequest,
+  DeliveryOperationDescriptor,
   DeliveryRequest,
   Inbox,
   InboxItem,
@@ -1353,6 +1356,42 @@ export class AgentInboxService {
     return { ...storedAttempt, note: result.note };
   }
 
+  async listDeliveryActions(
+    request: DeliveryActionsRequest,
+  ): Promise<{ sourceId: string | null; handle: DeliveryHandle; operations: DeliveryOperationDescriptor[] }> {
+    const handle = resolveDeliveryHandle(request);
+    const source = resolveDeliverySource(this.store, request.sourceId, handle);
+    const operations = await this.adapters.listDeliveryOperations(source, handle);
+    return {
+      sourceId: source?.sourceId ?? null,
+      handle,
+      operations,
+    };
+  }
+
+  async invokeDelivery(
+    request: DeliveryInvokeRequest,
+  ): Promise<DeliveryAttempt & { note: string; operation: string }> {
+    const handle = resolveDeliveryHandle(request);
+    const source = resolveDeliverySource(this.store, request.sourceId, handle);
+    const attempt: DeliveryAttempt = {
+      deliveryId: generateId("dlv"),
+      provider: handle.provider,
+      surface: handle.surface,
+      targetRef: handle.targetRef,
+      threadRef: handle.threadRef ?? null,
+      replyMode: handle.replyMode ?? null,
+      kind: request.operation,
+      payload: request.input,
+      status: "accepted",
+      createdAt: nowIso(),
+    };
+    const result = await this.adapters.invokeDeliveryOperation(source, handle, request.operation, request.input, attempt);
+    const storedAttempt = { ...attempt, status: result.status };
+    this.store.insertDelivery(storedAttempt);
+    return { ...storedAttempt, note: result.note, operation: request.operation };
+  }
+
   status(): Record<string, unknown> {
     return {
       retention: {
@@ -2624,7 +2663,9 @@ function retentionCutoffIso(retentionMs: number): string {
   return new Date(Date.now() - retentionMs).toISOString();
 }
 
-function resolveDeliveryHandle(request: DeliveryRequest): DeliveryHandle {
+function resolveDeliveryHandle(
+  request: DeliveryRequest | DeliveryActionsRequest | DeliveryInvokeRequest,
+): DeliveryHandle {
   if (request.deliveryHandle) {
     return request.deliveryHandle;
   }
@@ -2638,6 +2679,35 @@ function resolveDeliveryHandle(request: DeliveryRequest): DeliveryHandle {
     threadRef: request.threadRef ?? null,
     replyMode: request.replyMode ?? null,
   };
+}
+
+function resolveDeliverySource(
+  store: AgentInboxStore,
+  sourceId: string | undefined,
+  handle: DeliveryHandle,
+): SubscriptionSource | null {
+  if (!sourceId) {
+    return null;
+  }
+  const source = store.getSource(sourceId);
+  if (!source) {
+    throw new Error(`unknown source: ${sourceId}`);
+  }
+  const expectedProvider = providerForSourceType(source.sourceType);
+  if (expectedProvider && expectedProvider !== handle.provider) {
+    throw new Error(`source ${sourceId} does not match delivery provider ${handle.provider}`);
+  }
+  return source;
+}
+
+function providerForSourceType(sourceType: SubscriptionSource["sourceType"]): string | null {
+  if (sourceType === "github_repo") {
+    return "github";
+  }
+  if (sourceType === "feishu_bot") {
+    return "feishu";
+  }
+  return null;
 }
 
 export class ActivationDispatcher {

--- a/src/service.ts
+++ b/src/service.ts
@@ -1337,6 +1337,7 @@ export class AgentInboxService {
 
   async sendDelivery(request: DeliveryRequest): Promise<DeliveryAttempt & { note: string }> {
     const handle = resolveDeliveryHandle(request);
+    const source = resolveDeliverySource(this.store, request.sourceId, handle);
     const attempt: DeliveryAttempt = {
       deliveryId: generateId("dlv"),
       provider: handle.provider,
@@ -1349,8 +1350,9 @@ export class AgentInboxService {
       status: "accepted",
       createdAt: nowIso(),
     };
-    const adapter = this.adapters.deliveryAdapterFor(handle.provider);
-    const result = await adapter.send(request, attempt);
+    const result = source
+      ? await this.sendCanonicalDeliveryViaModule(source, handle, request.payload, attempt)
+      : await this.adapters.deliveryAdapterFor(handle.provider).send(request, attempt);
     const storedAttempt = { ...attempt, status: result.status };
     this.store.insertDelivery(storedAttempt);
     return { ...storedAttempt, note: result.note };
@@ -1390,6 +1392,21 @@ export class AgentInboxService {
     const storedAttempt = { ...attempt, status: result.status };
     this.store.insertDelivery(storedAttempt);
     return { ...storedAttempt, note: result.note, operation: request.operation };
+  }
+
+  private async sendCanonicalDeliveryViaModule(
+    source: SubscriptionSource,
+    handle: DeliveryHandle,
+    payload: Record<string, unknown>,
+    attempt: DeliveryAttempt,
+  ): Promise<{ status: DeliveryAttempt["status"]; note: string }> {
+    const operations = await this.adapters.listDeliveryOperations(source, handle);
+    const canonicalOperation = operations.find((operation) => operation.canonicalTextAlias);
+    if (!canonicalOperation) {
+      throw new Error(`deliver send is not supported for ${handle.provider}/${handle.surface}; use deliver invoke`);
+    }
+    const input = payload.text != null ? { ...payload, body: String(payload.text) } : payload;
+    return this.adapters.invokeDeliveryOperation(source, handle, canonicalOperation.name, input, attempt);
   }
 
   status(): Record<string, unknown> {

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -112,6 +112,14 @@ export function feishuDeliveryOperationsForHandle(handle: DeliveryHandle): Deliv
       required: ["text"],
       properties: {
         text: { type: "string", minLength: 1 },
+        endpoint: { type: "string", minLength: 1 },
+        schemaUrl: { type: "string", minLength: 1 },
+        schema_url: { type: "string", minLength: 1 },
+        uxcAuth: { type: "string", minLength: 1 },
+        auth: { type: "string", minLength: 1 },
+        replyInThread: { type: "boolean" },
+        reply_in_thread: { type: "boolean" },
+        uuid: { type: "string", minLength: 1 },
       },
     },
     canonicalTextAlias: true,
@@ -127,8 +135,12 @@ export async function invokeFeishuDeliveryOperation(
   if (operation !== "send_text") {
     throw new Error(`unknown Feishu delivery operation: ${operation}`);
   }
+  const text = asString(input.text);
+  if (!text || text.trim().length === 0) {
+    throw new Error("send_text requires input.text");
+  }
   const config = parseDeliveryConfig(input);
-  const message = normalizeDeliveryMessage(input);
+  const message = normalizeDeliveryMessage({ text });
 
   if (handle.surface === "message_reply") {
     await client.replyToMessage({

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -2,6 +2,8 @@ import { UxcDaemonClient } from "@holon-run/uxc-daemon-client";
 import {
   AppendSourceEventInput,
   DeliveryAttempt,
+  DeliveryHandle,
+  DeliveryOperationDescriptor,
   DeliveryRequest,
   SubscriptionSource,
 } from "../model";
@@ -93,38 +95,69 @@ export class FeishuDeliveryAdapter {
   }
 
   async send(request: DeliveryRequest, attempt: DeliveryAttempt): Promise<{ status: "sent"; note: string }> {
-    const config = parseDeliveryConfig(request.payload);
-    const message = normalizeDeliveryMessage(request.payload);
-
-    if (attempt.surface === "message_reply") {
-      await this.client.replyToMessage({
-        endpoint: config.endpoint,
-        schemaUrl: config.schemaUrl,
-        auth: config.auth,
-        messageId: attempt.targetRef,
-        msgType: message.msgType,
-        content: message.content,
-        replyInThread: config.replyInThread,
-        uuid: config.uuid,
-      });
-      return { status: "sent", note: "sent Feishu message reply" };
-    }
-
-    if (attempt.surface === "chat_message") {
-      await this.client.sendChatMessage({
-        endpoint: config.endpoint,
-        schemaUrl: config.schemaUrl,
-        auth: config.auth,
-        chatId: attempt.targetRef,
-        msgType: message.msgType,
-        content: message.content,
-        uuid: config.uuid,
-      });
-      return { status: "sent", note: "sent Feishu chat message" };
-    }
-
-    throw new Error(`unsupported Feishu surface: ${attempt.surface}`);
+    return invokeFeishuDeliveryOperation(attempt, "send_text", request.payload, this.client);
   }
+}
+
+export function feishuDeliveryOperationsForHandle(handle: DeliveryHandle): DeliveryOperationDescriptor[] {
+  if (handle.surface !== "message_reply" && handle.surface !== "chat_message") {
+    return [];
+  }
+  return [{
+    name: "send_text",
+    title: handle.surface === "message_reply" ? "Reply With Text" : "Send Text Message",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["text"],
+      properties: {
+        text: { type: "string", minLength: 1 },
+      },
+    },
+    canonicalTextAlias: true,
+  }];
+}
+
+export async function invokeFeishuDeliveryOperation(
+  handle: DeliveryHandle,
+  operation: string,
+  input: Record<string, unknown>,
+  client: FeishuUxcClient = new FeishuUxcClient(),
+): Promise<{ status: "sent"; note: string }> {
+  if (operation !== "send_text") {
+    throw new Error(`unknown Feishu delivery operation: ${operation}`);
+  }
+  const config = parseDeliveryConfig(input);
+  const message = normalizeDeliveryMessage(input);
+
+  if (handle.surface === "message_reply") {
+    await client.replyToMessage({
+      endpoint: config.endpoint,
+      schemaUrl: config.schemaUrl,
+      auth: config.auth,
+      messageId: handle.targetRef,
+      msgType: message.msgType,
+      content: message.content,
+      replyInThread: config.replyInThread,
+      uuid: config.uuid,
+    });
+    return { status: "sent", note: "sent Feishu message reply" };
+  }
+
+  if (handle.surface === "chat_message") {
+    await client.sendChatMessage({
+      endpoint: config.endpoint,
+      schemaUrl: config.schemaUrl,
+      auth: config.auth,
+      chatId: handle.targetRef,
+      msgType: message.msgType,
+      content: message.content,
+      uuid: config.uuid,
+    });
+    return { status: "sent", note: "sent Feishu chat message" };
+  }
+
+  throw new Error(`deliver send only supports canonical Feishu text surfaces; use deliver invoke for ${handle.surface}`);
 }
 
 export function normalizeFeishuBotEvent(

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -3,6 +3,7 @@ import {
   AppendSourceEventInput,
   DeliveryAttempt,
   DeliveryHandle,
+  DeliveryOperationDescriptor,
   DeliveryRequest,
   SourceSchemaField,
   SubscriptionFilter,
@@ -67,6 +68,50 @@ export class GithubUxcClient {
       options: { auth: input.auth },
     });
   }
+
+  async updateIssueState(input: {
+    owner: string;
+    repo: string;
+    issueNumber: number;
+    state: "open" | "closed";
+    auth?: string;
+  }): Promise<void> {
+    await this.client.call({
+      endpoint: GITHUB_ENDPOINT,
+      operation: "patch:/repos/{owner}/{repo}/issues/{issue_number}",
+      payload: {
+        owner: input.owner,
+        repo: input.repo,
+        issue_number: input.issueNumber,
+        state: input.state,
+      },
+      options: { auth: input.auth },
+    });
+  }
+
+  async mergePullRequest(input: {
+    owner: string;
+    repo: string;
+    pullNumber: number;
+    mergeMethod?: "merge" | "squash" | "rebase";
+    commitTitle?: string;
+    commitMessage?: string;
+    auth?: string;
+  }): Promise<void> {
+    await this.client.call({
+      endpoint: GITHUB_ENDPOINT,
+      operation: "put:/repos/{owner}/{repo}/pulls/{pull_number}/merge",
+      payload: {
+        owner: input.owner,
+        repo: input.repo,
+        pull_number: input.pullNumber,
+        merge_method: input.mergeMethod ?? null,
+        commit_title: input.commitTitle ?? null,
+        commit_message: input.commitMessage ?? null,
+      },
+      options: { auth: input.auth },
+    });
+  }
 }
 
 export class GithubDeliveryAdapter {
@@ -78,31 +123,136 @@ export class GithubDeliveryAdapter {
 
   async send(request: DeliveryRequest, attempt: DeliveryAttempt): Promise<{ status: "sent"; note: string }> {
     const payloadText = stringifyDeliveryPayload(request.payload);
-    const target = parseTargetRef(attempt.targetRef);
-    if (attempt.surface === "issue_comment" || attempt.surface === "pull_request_comment") {
-      await this.client.createIssueComment({
-        owner: target.owner,
-        repo: target.repo,
-        issueNumber: target.number,
-        body: payloadText,
-      });
-      return { status: "sent", note: "sent GitHub issue comment" };
-    }
-    if (attempt.surface === "review_comment") {
-      if (!attempt.threadRef || !attempt.threadRef.startsWith("review_comment:")) {
-        throw new Error("review_comment delivery requires threadRef=review_comment:<id>");
-      }
-      await this.client.replyToReviewComment({
-        owner: target.owner,
-        repo: target.repo,
-        pullNumber: target.number,
-        commentId: Number(attempt.threadRef.slice("review_comment:".length)),
-        body: payloadText,
-      });
-      return { status: "sent", note: "sent GitHub review comment reply" };
-    }
-    throw new Error(`unsupported GitHub surface: ${attempt.surface}`);
+    return invokeGithubDeliveryOperation(attempt, canonicalGithubOperationForSurface(attempt.surface), { body: payloadText }, this.client);
   }
+}
+
+export function githubDeliveryOperationsForHandle(handle: DeliveryHandle): DeliveryOperationDescriptor[] {
+  if (handle.surface === "review_comment") {
+    return [{
+      name: "reply_in_review_thread",
+      title: "Reply In Review Thread",
+      inputSchema: deliveryBodySchema(),
+      canonicalTextAlias: true,
+    }];
+  }
+  if (handle.surface === "issue_comment") {
+    return [
+      {
+        name: "add_comment",
+        title: "Add Comment",
+        inputSchema: deliveryBodySchema(),
+        canonicalTextAlias: true,
+      },
+      {
+        name: "close_issue",
+        title: "Close Issue",
+        inputSchema: emptyObjectSchema(),
+      },
+      {
+        name: "reopen_issue",
+        title: "Reopen Issue",
+        inputSchema: emptyObjectSchema(),
+      },
+    ];
+  }
+  if (handle.surface === "pull_request_comment") {
+    return [
+      {
+        name: "add_comment",
+        title: "Add Comment",
+        inputSchema: deliveryBodySchema(),
+        canonicalTextAlias: true,
+      },
+      {
+        name: "close_issue",
+        title: "Close Pull Request",
+        inputSchema: emptyObjectSchema(),
+      },
+      {
+        name: "reopen_issue",
+        title: "Reopen Pull Request",
+        inputSchema: emptyObjectSchema(),
+      },
+      {
+        name: "merge_pull_request",
+        title: "Merge Pull Request",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            mergeMethod: { type: "string", enum: ["merge", "squash", "rebase"] },
+            commitTitle: { type: "string" },
+            commitMessage: { type: "string" },
+          },
+        },
+      },
+    ];
+  }
+  return [];
+}
+
+export async function invokeGithubDeliveryOperation(
+  handle: DeliveryHandle,
+  operation: string,
+  input: Record<string, unknown>,
+  client: GithubUxcClient = new GithubUxcClient(),
+): Promise<{ status: "sent"; note: string }> {
+  const target = parseTargetRef(handle.targetRef);
+  if (operation === "add_comment") {
+    const body = requireDeliveryBody(input, operation);
+    await client.createIssueComment({
+      owner: target.owner,
+      repo: target.repo,
+      issueNumber: target.number,
+      body,
+    });
+    return { status: "sent", note: "sent GitHub issue comment" };
+  }
+  if (operation === "reply_in_review_thread") {
+    const body = requireDeliveryBody(input, operation);
+    if (!handle.threadRef || !handle.threadRef.startsWith("review_comment:")) {
+      throw new Error("reply_in_review_thread requires threadRef=review_comment:<id>");
+    }
+    await client.replyToReviewComment({
+      owner: target.owner,
+      repo: target.repo,
+      pullNumber: target.number,
+      commentId: Number(handle.threadRef.slice("review_comment:".length)),
+      body,
+    });
+    return { status: "sent", note: "sent GitHub review comment reply" };
+  }
+  if (operation === "close_issue") {
+    await client.updateIssueState({
+      owner: target.owner,
+      repo: target.repo,
+      issueNumber: target.number,
+      state: "closed",
+    });
+    return { status: "sent", note: "closed GitHub issue" };
+  }
+  if (operation === "reopen_issue") {
+    await client.updateIssueState({
+      owner: target.owner,
+      repo: target.repo,
+      issueNumber: target.number,
+      state: "open",
+    });
+    return { status: "sent", note: "reopened GitHub issue" };
+  }
+  if (operation === "merge_pull_request") {
+    await client.mergePullRequest({
+      owner: target.owner,
+      repo: target.repo,
+      pullNumber: target.number,
+      mergeMethod: asMergeMethod(input.mergeMethod),
+      commitTitle: asString(input.commitTitle) ?? undefined,
+      commitMessage: asString(input.commitMessage) ?? undefined,
+    });
+    return { status: "sent", note: "merged GitHub pull request" };
+  }
+  throw new Error(`unknown GitHub delivery operation: ${operation}`);
 }
 
 export function normalizeGithubRepoEvent(
@@ -359,6 +509,47 @@ function stringifyDeliveryPayload(payload: Record<string, unknown>): string {
     return payload.text;
   }
   return JSON.stringify(payload, null, 2);
+}
+
+function canonicalGithubOperationForSurface(surface: string): string {
+  if (surface === "issue_comment" || surface === "pull_request_comment") {
+    return "add_comment";
+  }
+  if (surface === "review_comment") {
+    return "reply_in_review_thread";
+  }
+  throw new Error(`deliver send only supports canonical GitHub text surfaces; use deliver invoke for ${surface}`);
+}
+
+function deliveryBodySchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: ["body"],
+    properties: {
+      body: { type: "string", minLength: 1 },
+    },
+  };
+}
+
+function emptyObjectSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  };
+}
+
+function requireDeliveryBody(input: Record<string, unknown>, operation: string): string {
+  const body = asString(input.body);
+  if (!body || body.trim().length === 0) {
+    throw new Error(`${operation} requires input.body`);
+  }
+  return body;
+}
+
+function asMergeMethod(value: unknown): "merge" | "squash" | "rebase" | undefined {
+  return value === "merge" || value === "squash" || value === "rebase" ? value : undefined;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -2,12 +2,24 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { PollSubscriptionConfig, RuntimeInvokeOptions } from "@holon-run/uxc-daemon-client";
-import { ActivationItem, AppendSourceEventInput, CleanupPolicy, SourceSchemaField, SubscriptionFilter, SubscriptionSource } from "../model";
+import {
+  ActivationItem,
+  AppendSourceEventInput,
+  CleanupPolicy,
+  DeliveryAttempt,
+  DeliveryHandle,
+  DeliveryOperationDescriptor,
+  SourceSchemaField,
+  SubscriptionFilter,
+  SubscriptionSource,
+} from "../model";
 import {
   deriveGithubTrackedResource,
   expandGithubSubscriptionShortcut,
   GITHUB_ENDPOINT,
+  githubDeliveryOperationsForHandle,
   githubSubscriptionShortcutSpec,
+  invokeGithubDeliveryOperation,
   normalizeGithubRepoEvent,
   parseGithubSourceConfig,
   projectGithubLifecycleSignal,
@@ -21,6 +33,8 @@ import {
 } from "./github_ci";
 import {
   FEISHU_OPENAPI_ENDPOINT,
+  feishuDeliveryOperationsForHandle,
+  invokeFeishuDeliveryOperation,
   normalizeFeishuBotEvent,
   parseFeishuSourceConfig,
 } from "./feishu";
@@ -83,6 +97,19 @@ export interface LifecycleSignal {
   occurredAt?: string;
 }
 
+export interface ListDeliveryOperationsInput {
+  handle: DeliveryHandle;
+  source?: SubscriptionSource | null;
+}
+
+export interface InvokeDeliveryOperationInput {
+  handle: DeliveryHandle;
+  operation: string;
+  input: Record<string, unknown>;
+  attempt: DeliveryAttempt;
+  source?: SubscriptionSource | null;
+}
+
 export interface RemoteSourceModule {
   id: string;
   validateConfig(source: SubscriptionSource): void;
@@ -95,6 +122,8 @@ export interface RemoteSourceModule {
   deriveTrackedResource?(filter: SubscriptionFilter, source: SubscriptionSource): { ref: string } | null;
   projectLifecycleSignal?(rawPayload: Record<string, unknown>, source: SubscriptionSource): LifecycleSignal | null;
   deriveInlinePreview?(item: ActivationItem, source: SubscriptionSource): string | null;
+  listDeliveryOperations?(input: ListDeliveryOperationsInput): DeliveryOperationDescriptor[];
+  invokeDeliveryOperation?(input: InvokeDeliveryOperationInput): Promise<{ status: DeliveryAttempt["status"]; note: string }>;
 }
 
 const REMOTE_USER_MODULE_ROOT_DIR = "source-profiles";
@@ -188,6 +217,8 @@ function validateModuleContract(module: RemoteSourceModule, sourcePath: string):
   validateOptionalHook(module.deriveTrackedResource, "deriveTrackedResource", sourcePath);
   validateOptionalHook(module.projectLifecycleSignal, "projectLifecycleSignal", sourcePath);
   validateOptionalHook(module.deriveInlinePreview, "deriveInlinePreview", sourcePath);
+  validateOptionalHook(module.listDeliveryOperations, "listDeliveryOperations", sourcePath);
+  validateOptionalHook(module.invokeDeliveryOperation, "invokeDeliveryOperation", sourcePath);
 }
 
 function validateOptionalHook(value: unknown, name: string, sourcePath: string): void {
@@ -229,6 +260,12 @@ function asNonEmptyString(value: unknown): string | null {
 
 const GITHUB_REPO_MODULE: RemoteSourceModule = {
   id: "builtin.github_repo",
+  listDeliveryOperations(input: ListDeliveryOperationsInput): DeliveryOperationDescriptor[] {
+    return githubDeliveryOperationsForHandle(input.handle);
+  },
+  async invokeDeliveryOperation(input: InvokeDeliveryOperationInput): Promise<{ status: DeliveryAttempt["status"]; note: string }> {
+    return invokeGithubDeliveryOperation(input.handle, input.operation, input.input);
+  },
   describeCapabilities(source: SubscriptionSource): RemoteSourceCapabilityDescription {
     const config = parseGithubSourceConfig(source);
     return {
@@ -451,6 +488,12 @@ const GITHUB_REPO_CI_MODULE: RemoteSourceModule = {
 
 const FEISHU_BOT_MODULE: RemoteSourceModule = {
   id: "builtin.feishu_bot",
+  listDeliveryOperations(input: ListDeliveryOperationsInput): DeliveryOperationDescriptor[] {
+    return feishuDeliveryOperationsForHandle(input.handle);
+  },
+  async invokeDeliveryOperation(input: InvokeDeliveryOperationInput): Promise<{ status: DeliveryAttempt["status"]; note: string }> {
+    return invokeFeishuDeliveryOperation(input.handle, input.operation, input.input);
+  },
   describeCapabilities(): RemoteSourceCapabilityDescription {
     return {
       sourceKind: "feishu_bot",

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -389,6 +389,17 @@ test("control plane validates sources/events occurredAt and deliveries/send requ
       });
       assert.equal(invalidDelivery.statusCode, 400);
       assert.equal(typeof invalidDelivery.data.error, "string");
+
+      const mismatchedSend = await client.request<{ error: string }>("/deliveries/send", {
+        sourceId: sourceResponse.data.sourceId,
+        provider: "github",
+        surface: "issue_comment",
+        targetRef: "holon-run/agentinbox#111",
+        kind: "comment",
+        payload: { text: "hello" },
+      });
+      assert.equal(mismatchedSend.statusCode, 400);
+      assert.match(mismatchedSend.data.error, /deliver send is not supported/);
     } finally {
       await started.close();
     }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -400,6 +400,110 @@ test("control plane validates sources/events occurredAt and deliveries/send requ
   }
 });
 
+test("control plane exposes delivery actions and invoke for remote modules", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-delivery-ops-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const profileDir = path.join(homeDir, "source-profiles");
+  fs.mkdirSync(profileDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(profileDir, "delivery-hook.mjs"),
+    `export default {
+  id: "demo.delivery-hook",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() {
+    return null;
+  },
+  listDeliveryOperations() {
+    return [{
+      name: "ack_remote_event",
+      title: "Ack Remote Event",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["body"],
+        properties: { body: { type: "string" } }
+      }
+    }];
+  },
+  async invokeDeliveryOperation(input) {
+    return { status: "sent", note: "invoked " + input.operation + " for " + input.handle.targetRef };
+  }
+};`,
+    "utf8",
+  );
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    await adapters.start();
+    await service.start();
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const sourceResponse = await client.request<{ sourceId: string }>("/sources", {
+        sourceType: "remote_source",
+        sourceKey: "demo-delivery",
+        config: {
+          profilePath: "delivery-hook.mjs",
+          profileConfig: {},
+        },
+      } satisfies RegisterSourceInput);
+      assert.equal(sourceResponse.statusCode, 200);
+
+      const actions = await client.request<{ operations: Array<{ name: string }> }>("/deliveries/actions", {
+        sourceId: sourceResponse.data.sourceId,
+        provider: "demo",
+        surface: "ticket",
+        targetRef: "ticket:42",
+      });
+      assert.equal(actions.statusCode, 200);
+      assert.deepEqual(actions.data.operations.map((operation) => operation.name), ["ack_remote_event"]);
+
+      const invoke = await client.request<{ status: string; note: string; operation: string }>("/deliveries/invoke", {
+        sourceId: sourceResponse.data.sourceId,
+        provider: "demo",
+        surface: "ticket",
+        targetRef: "ticket:42",
+        operation: "ack_remote_event",
+        input: { body: "acked" },
+      });
+      assert.equal(invoke.statusCode, 200);
+      assert.equal(invoke.data.status, "sent");
+      assert.equal(invoke.data.operation, "ack_remote_event");
+      assert.match(invoke.data.note, /invoked ack_remote_event/);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("control plane GET /agents can include activation target summaries", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-agents-"));
   const socketPath = path.join(homeDir, "agentinbox.sock");
@@ -869,6 +973,41 @@ test("cli inbox send writes a direct text message into the target inbox", () => 
       message: "Review PR #51 CI failure and push a fix.",
       sender: "local-script",
     });
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli deliver actions exposes handle-scoped delivery operations", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-deliver-actions-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%9631",
+    CODEX_THREAD_ID: "thread-deliver-actions",
+  };
+
+  try {
+    const result = runCli([
+      "deliver",
+      "actions",
+      "--provider",
+      "github",
+      "--surface",
+      "pull_request_comment",
+      "--target",
+      "holon-run/agentinbox#111",
+    ], env);
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout) as { operations: Array<{ name: string }> };
+    assert.deepEqual(
+      payload.operations.map((operation) => operation.name),
+      ["add_comment", "close_issue", "reopen_issue", "merge_pull_request"],
+    );
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1025,6 +1025,42 @@ test("cli deliver actions exposes handle-scoped delivery operations", () => {
   }
 });
 
+test("cli deliver invoke requires input-json", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-deliver-invoke-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%9632",
+    CODEX_THREAD_ID: "thread-deliver-invoke",
+  };
+
+  try {
+    const result = runCli([
+      "deliver",
+      "invoke",
+      "--provider",
+      "github",
+      "--surface",
+      "pull_request_comment",
+      "--target",
+      "holon-run/agentinbox#111",
+      "--operation",
+      "add_comment",
+    ], env);
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stderr,
+      /usage: agentinbox deliver invoke \(\-\-handle-json JSON \| \-\-provider PROVIDER \-\-surface SURFACE \-\-target TARGET\) \-\-operation NAME \-\-input-json JSON \[\-\-source-id SOURCE_ID\]/,
+    );
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli agent resume and target resume commands are available", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-agent-resume-"));
   const env = {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -2,8 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { DeliveryAttempt, SubscriptionSource } from "../src/model";
 import {
+  feishuDeliveryOperationsForHandle,
   FeishuDeliveryAdapter,
   FeishuUxcClient,
+  invokeFeishuDeliveryOperation,
   type FeishuCallClient,
   normalizeFeishuBotEvent,
 } from "../src/sources/feishu";
@@ -98,4 +100,26 @@ test("feishu delivery adapter maps message replies and chat sends to uxc calls",
   assert.equal(fake.calls[1]?.operation, "post:/im/v1/messages");
   assert.equal((fake.calls[1]?.payload as Record<string, unknown>)?.receive_id_type, "chat_id");
   assert.equal((fake.calls[1]?.options as Record<string, unknown>)?.schema_url, FEISHU_IM_SCHEMA_URL);
+});
+
+test("feishu delivery operations expose a canonical send_text action", () => {
+  assert.deepEqual(
+    feishuDeliveryOperationsForHandle({
+      provider: "feishu",
+      surface: "message_reply",
+      targetRef: "om_reply",
+    }).map((operation) => operation.name),
+    ["send_text"],
+  );
+});
+
+test("feishu delivery invoke maps send_text to the canonical outbound path", async () => {
+  const fake = new FakeFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  await invokeFeishuDeliveryOperation({
+    provider: "feishu",
+    surface: "chat_message",
+    targetRef: "oc_chat",
+  }, "send_text", { text: "team update" }, client);
+  assert.equal(fake.calls[0]?.operation, "post:/im/v1/messages");
 });

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -5,7 +5,9 @@ import {
   GithubDeliveryAdapter,
   GithubUxcClient,
   githubSubscriptionShortcutSpec,
+  githubDeliveryOperationsForHandle,
   expandGithubSubscriptionShortcut,
+  invokeGithubDeliveryOperation,
   normalizeGithubRepoEvent,
   projectGithubLifecycleSignal,
   type GithubCallClient,
@@ -239,4 +241,45 @@ test("github delivery adapter maps issue comments and review replies to uxc call
   };
   await adapter.send({ kind: "reply", payload: { text: "review" } } as never, reviewAttempt);
   assert.equal(fake.calls[1]?.operation, "post:/repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies");
+});
+
+test("github delivery operations expose handle-specific actions", () => {
+  assert.deepEqual(
+    githubDeliveryOperationsForHandle({
+      provider: "github",
+      surface: "pull_request_comment",
+      targetRef: "holon-run/agentinbox#34",
+    }).map((operation) => operation.name),
+    ["add_comment", "close_issue", "reopen_issue", "merge_pull_request"],
+  );
+  assert.deepEqual(
+    githubDeliveryOperationsForHandle({
+      provider: "github",
+      surface: "review_comment",
+      targetRef: "holon-run/agentinbox#34",
+      threadRef: "review_comment:88",
+    }).map((operation) => operation.name),
+    ["reply_in_review_thread"],
+  );
+});
+
+test("github delivery invoke maps issue state and merge operations to uxc calls", async () => {
+  const fake = new FakeUxcClient();
+  const client = new GithubUxcClient(fake);
+
+  await invokeGithubDeliveryOperation({
+    provider: "github",
+    surface: "issue_comment",
+    targetRef: "holon-run/agentinbox#12",
+  }, "close_issue", {}, client);
+  assert.equal(fake.calls[0]?.operation, "patch:/repos/{owner}/{repo}/issues/{issue_number}");
+  assert.equal((fake.calls[0]?.payload as Record<string, unknown>)?.state, "closed");
+
+  await invokeGithubDeliveryOperation({
+    provider: "github",
+    surface: "pull_request_comment",
+    targetRef: "holon-run/agentinbox#34",
+  }, "merge_pull_request", { mergeMethod: "squash", commitTitle: "Ship it" }, client);
+  assert.equal(fake.calls[1]?.operation, "put:/repos/{owner}/{repo}/pulls/{pull_number}/merge");
+  assert.equal((fake.calls[1]?.payload as Record<string, unknown>)?.merge_method, "squash");
 });

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -708,6 +708,103 @@ test("RemoteSourceRuntime still honors deprecated profileRegistry option", async
   }
 });
 
+test("user-defined remote_source modules can expose delivery actions and invoke them", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const profileDir = path.join(dir, "source-profiles");
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, "delivery-hook.mjs"),
+      `globalThis.__deliveryCalls = globalThis.__deliveryCalls ?? [];
+export default {
+  id: "demo.delivery-hook",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent(raw) {
+    return raw?.id ? {
+      sourceNativeId: String(raw.id),
+      eventVariant: "demo.created",
+      metadata: {},
+      rawPayload: raw
+    } : null;
+  },
+  listDeliveryOperations() {
+    return [{
+      name: "ack_remote_event",
+      title: "Ack Remote Event",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["body"],
+        properties: { body: { type: "string" } }
+      }
+    }];
+  },
+  async invokeDeliveryOperation(input) {
+    globalThis.__deliveryCalls.push({
+      operation: input.operation,
+      input: input.input,
+      targetRef: input.handle.targetRef
+    });
+    return { status: "sent", note: "sent custom remote delivery" };
+  }
+};`,
+      "utf8",
+    );
+
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "demo-delivery",
+      config: {
+        profilePath: "delivery-hook.mjs",
+        profileConfig: {},
+      },
+    });
+
+    const listed = await service.listDeliveryActions({
+      sourceId: source.sourceId,
+      provider: "demo",
+      surface: "ticket",
+      targetRef: "ticket:42",
+    });
+    assert.deepEqual(listed.operations.map((operation) => operation.name), ["ack_remote_event"]);
+
+    const invoked = await service.invokeDelivery({
+      sourceId: source.sourceId,
+      provider: "demo",
+      surface: "ticket",
+      targetRef: "ticket:42",
+      operation: "ack_remote_event",
+      input: { body: "acked" },
+    });
+    assert.equal(invoked.status, "sent");
+    assert.equal(invoked.note, "sent custom remote delivery");
+
+    const calls = ((globalThis as { __deliveryCalls?: Array<Record<string, unknown>> }).__deliveryCalls ?? []);
+    assert.deepEqual(calls, [{
+      operation: "ack_remote_event",
+      input: { body: "acked" },
+      targetRef: "ticket:42",
+    }]);
+  } finally {
+    delete (globalThis as { __deliveryCalls?: unknown }).__deliveryCalls;
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function checkpointKeyForPayload(
   payload: unknown,
   strategy: NonNullable<ManagedSourceSpec["poll_config"]>["checkpoint_strategy"],


### PR DESCRIPTION
## Summary
- add handle-scoped delivery operation discovery and invocation surfaces
- route extensible outbound operations through RemoteSourceModule hooks
- keep deliver send as the canonical text convenience path

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "github delivery|feishu delivery|user-defined remote_source modules can expose delivery actions and invoke them|control plane exposes delivery actions and invoke for remote modules|cli deliver actions exposes handle-scoped delivery operations" test/github.test.ts test/feishu.test.ts test/remote_source.test.ts test/control_plane.test.ts