### PR TITLE
feat: add source host and stream model

### DIFF
--- a/drizzle/migrations/0009_source_hosts_and_streams.sql
+++ b/drizzle/migrations/0009_source_hosts_and_streams.sql
@@ -1,0 +1,131 @@
+create table if not exists source_hosts (
+  host_id text primary key,
+  host_type text not null,
+  host_key text not null,
+  config_ref text,
+  config_json text not null,
+  status text not null,
+  created_at text not null,
+  updated_at text not null
+);
+
+create unique index if not exists idx_source_hosts_type_key
+  on source_hosts(host_type, host_key);
+
+alter table sources add column host_id text;
+alter table sources add column stream_kind text;
+alter table sources add column stream_key text;
+alter table sources add column compat_source_type text;
+
+update sources
+set compat_source_type = source_type
+where compat_source_type is null;
+
+update sources
+set stream_kind = case source_type
+  when 'github_repo' then 'repo_events'
+  when 'github_repo_ci' then 'ci_runs'
+  when 'feishu_bot' then 'message_events'
+  when 'local_event' then 'events'
+  else 'default'
+end
+where stream_kind is null;
+
+update sources
+set stream_key = source_key
+where stream_key is null;
+
+insert or ignore into source_hosts (
+  host_id,
+  host_type,
+  host_key,
+  config_ref,
+  config_json,
+  status,
+  created_at,
+  updated_at
+)
+select
+  case
+    when host_type = 'github' then
+      'hst_github_' || replace(lower(hex(host_key)), ' ', '')
+    when host_type = 'feishu' then
+      'hst_feishu_' || replace(lower(hex(host_key)), ' ', '')
+    when host_type = 'local_event' then
+      'hst_local_event_' || replace(lower(hex(host_key)), ' ', '')
+    else
+      'hst_remote_source_' || replace(lower(hex(host_key)), ' ', '')
+  end as host_id,
+  host_type,
+  host_key,
+  config_ref,
+  config_json,
+  status,
+  created_at,
+  updated_at
+from (
+  select distinct
+    case
+      when source_type in ('github_repo', 'github_repo_ci') then 'github'
+      when source_type = 'feishu_bot' then 'feishu'
+      when source_type = 'local_event' then 'local_event'
+      else 'remote_source'
+    end as host_type,
+    case
+      when source_type in ('github_repo', 'github_repo_ci') then
+        'uxcAuth:' || coalesce(json_extract(config_json, '$.uxcAuth'), config_ref, 'default')
+      when source_type = 'feishu_bot' then
+        'app:' || coalesce(json_extract(config_json, '$.appId'), config_ref, source_id)
+      when source_type = 'local_event' then
+        source_key
+      else
+        source_id
+    end as host_key,
+    config_ref,
+    case
+      when source_type in ('github_repo', 'github_repo_ci') then
+        json_object('uxcAuth', json_extract(config_json, '$.uxcAuth'))
+      when source_type = 'feishu_bot' then
+        json_object(
+          'appId', json_extract(config_json, '$.appId'),
+          'appSecret', json_extract(config_json, '$.appSecret'),
+          'schemaUrl', coalesce(json_extract(config_json, '$.schemaUrl'), json_extract(config_json, '$.schema_url')),
+          'replyInThread', coalesce(json_extract(config_json, '$.replyInThread'), json_extract(config_json, '$.reply_in_thread')),
+          'uxcAuth', json_extract(config_json, '$.uxcAuth')
+        )
+      when source_type = 'local_event' then
+        json('{}')
+      else
+        config_json
+    end as config_json,
+    status,
+    created_at,
+    updated_at
+  from sources
+);
+
+update sources
+set host_id = (
+  select host_id
+  from source_hosts
+  where source_hosts.host_type = case
+    when sources.source_type in ('github_repo', 'github_repo_ci') then 'github'
+    when sources.source_type = 'feishu_bot' then 'feishu'
+    when sources.source_type = 'local_event' then 'local_event'
+    else 'remote_source'
+  end
+    and source_hosts.host_key = case
+      when sources.source_type in ('github_repo', 'github_repo_ci') then
+        'uxcAuth:' || coalesce(json_extract(sources.config_json, '$.uxcAuth'), sources.config_ref, 'default')
+      when sources.source_type = 'feishu_bot' then
+        'app:' || coalesce(json_extract(sources.config_json, '$.appId'), sources.config_ref, sources.source_id)
+      when sources.source_type = 'local_event' then
+        sources.source_key
+      else
+        sources.source_id
+    end
+)
+where host_id is null;
+
+create unique index if not exists idx_sources_host_stream_key
+  on sources(host_id, stream_kind, stream_key);

--- a/drizzle/migrations/0009_source_hosts_and_streams.sql
+++ b/drizzle/migrations/0009_source_hosts_and_streams.sql
@@ -79,7 +79,7 @@ from (
       when source_type = 'local_event' then
         source_key
       else
-        source_id
+        source_key
     end as host_key,
     config_ref,
     case
@@ -122,10 +122,43 @@ set host_id = (
       when sources.source_type = 'local_event' then
         sources.source_key
       else
-        sources.source_id
+        sources.source_key
     end
 )
 where host_id is null;
+
+create table if not exists sources__new (
+  source_id text primary key,
+  host_id text not null,
+  stream_kind text not null,
+  stream_key text not null,
+  compat_source_type text,
+  source_type text not null,
+  source_key text not null,
+  config_ref text,
+  config_json text not null,
+  status text not null,
+  checkpoint text,
+  created_at text not null,
+  updated_at text not null
+);
+
+insert into sources__new (
+  source_id, host_id, stream_kind, stream_key, compat_source_type,
+  source_type, source_key, config_ref, config_json,
+  status, checkpoint, created_at, updated_at
+)
+select
+  source_id, host_id, stream_kind, stream_key, compat_source_type,
+  source_type, source_key, config_ref, config_json,
+  status, checkpoint, created_at, updated_at
+from sources;
+
+drop table sources;
+alter table sources__new rename to sources;
+
+create index if not exists idx_sources_type_key
+  on sources(source_type, source_key);
 
 create unique index if not exists idx_sources_host_stream_key
   on sources(host_id, stream_kind, stream_key);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,7 +1,24 @@
 import { index, integer, primaryKey, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
+export const sourceHosts = sqliteTable("source_hosts", {
+  hostId: text("host_id").primaryKey(),
+  hostType: text("host_type").notNull(),
+  hostKey: text("host_key").notNull(),
+  configRef: text("config_ref"),
+  configJson: text("config_json").notNull(),
+  status: text("status").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+}, (table) => ({
+  hostTypeKey: uniqueIndex("idx_source_hosts_type_key").on(table.hostType, table.hostKey),
+}));
+
 export const sources = sqliteTable("sources", {
   sourceId: text("source_id").primaryKey(),
+  hostId: text("host_id").notNull(),
+  streamKind: text("stream_kind").notNull(),
+  streamKey: text("stream_key").notNull(),
+  compatSourceType: text("compat_source_type"),
   sourceType: text("source_type").notNull(),
   sourceKey: text("source_key").notNull(),
   configRef: text("config_ref"),
@@ -12,6 +29,7 @@ export const sources = sqliteTable("sources", {
   updatedAt: text("updated_at").notNull(),
 }, (table) => ({
   sourceTypeKey: uniqueIndex("idx_sources_type_key").on(table.sourceType, table.sourceKey),
+  hostStreamKey: uniqueIndex("idx_sources_host_stream_key").on(table.hostId, table.streamKind, table.streamKey),
 }));
 
 export const sourceIdleStates = sqliteTable("source_idle_states", {

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -28,7 +28,7 @@ export const sources = sqliteTable("sources", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 }, (table) => ({
-  sourceTypeKey: uniqueIndex("idx_sources_type_key").on(table.sourceType, table.sourceKey),
+  sourceTypeKey: index("idx_sources_type_key").on(table.sourceType, table.sourceKey),
   hostStreamKey: uniqueIndex("idx_sources_host_stream_key").on(table.hostId, table.streamKind, table.streamKey),
 }));
 

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -18,6 +18,7 @@ import { GithubDeliveryAdapter } from "./sources/github";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
 import { ExpandedSubscriptionInput, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry } from "./sources/remote_modules";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
+import { compatSourceTypeForStream } from "./source_hosts";
 
 export interface SourceAdapter {
   ensureSource(source: SubscriptionSource): Promise<void>;
@@ -130,11 +131,12 @@ export class AdapterRegistry {
   }
 
   async pollSource(source: SubscriptionSource): Promise<SourcePollResult> {
-    const adapter = this.sourceAdapterFor(source.sourceType);
+    const compatSourceType = compatSourceTypeForStream(source);
+    const adapter = this.sourceAdapterFor(compatSourceType);
     if (!adapter.pollSource) {
       return {
         sourceId: source.sourceId,
-        sourceType: source.sourceType,
+        sourceType: compatSourceType,
         appended: 0,
         deduped: 0,
         eventsRead: 0,
@@ -145,23 +147,25 @@ export class AdapterRegistry {
   }
 
   async pauseSource(source: SubscriptionSource): Promise<void> {
-    const adapter = this.sourceAdapterFor(source.sourceType);
+    const compatSourceType = compatSourceTypeForStream(source);
+    const adapter = this.sourceAdapterFor(compatSourceType);
     if (!adapter.pauseSource) {
-      throw new Error(`source type ${source.sourceType} does not support pause`);
+      throw new Error(`source type ${compatSourceType} does not support pause`);
     }
     await adapter.pauseSource?.(source.sourceId);
   }
 
   async resumeSource(source: SubscriptionSource): Promise<void> {
-    const adapter = this.sourceAdapterFor(source.sourceType);
+    const compatSourceType = compatSourceTypeForStream(source);
+    const adapter = this.sourceAdapterFor(compatSourceType);
     if (!adapter.resumeSource) {
-      throw new Error(`source type ${source.sourceType} does not support resume`);
+      throw new Error(`source type ${compatSourceType} does not support resume`);
     }
     await adapter.resumeSource?.(source.sourceId);
   }
 
   async removeSource(source: SubscriptionSource): Promise<void> {
-    const adapter = this.sourceAdapterFor(source.sourceType);
+    const adapter = this.sourceAdapterFor(compatSourceTypeForStream(source));
     await adapter.removeSource?.(source.sourceId);
   }
 
@@ -180,7 +184,7 @@ export class AdapterRegistry {
   }
 
   async projectLifecycleSignal(source: SubscriptionSource, rawPayload: Record<string, unknown>): Promise<LifecycleSignal | null> {
-    if (source.sourceType === "local_event") {
+    if (compatSourceTypeForStream(source) === "local_event") {
       return null;
     }
     return this.remoteSource.projectLifecycleSignal(source, rawPayload);
@@ -190,14 +194,14 @@ export class AdapterRegistry {
     source: SubscriptionSource,
     input: { name: string; args?: Record<string, unknown> },
   ): Promise<ExpandedSubscriptionInput | null> {
-    if (source.sourceType === "local_event") {
+    if (compatSourceTypeForStream(source) === "local_event") {
       return null;
     }
     return this.remoteSource.expandSubscriptionShortcut(source, input);
   }
 
   async deriveInlinePreview(source: SubscriptionSource, item: ActivationItem): Promise<string | null> {
-    if (source.sourceType === "local_event") {
+    if (compatSourceTypeForStream(source) === "local_event") {
       return null;
     }
     return this.remoteSource.deriveInlinePreview(source, item);
@@ -236,7 +240,7 @@ export class AdapterRegistry {
 
   private async resolveDeliveryModule(source: SubscriptionSource | null, handle: DeliveryHandle): Promise<RemoteSourceModule | null> {
     if (source) {
-      if (source.sourceType === "local_event") {
+      if (compatSourceTypeForStream(source) === "local_event") {
         return null;
       }
       return this.remoteModuleRegistry.resolve(source, this.homeDir);
@@ -254,6 +258,10 @@ export class AdapterRegistry {
 function syntheticBuiltinSource(sourceType: "github_repo" | "feishu_bot"): SubscriptionSource {
   return {
     sourceId: `builtin:${sourceType}`,
+    hostId: `builtin-host:${sourceType}`,
+    streamKind: sourceType === "github_repo" ? "repo_events" : "message_events",
+    streamKey: sourceType,
+    compatSourceType: sourceType,
     sourceType,
     sourceKey: sourceType,
     status: "active",

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -310,8 +310,8 @@ export function defaultInboxIdForAgent(agentId: string): string {
   return `inbox_${agentId}`;
 }
 
-export function streamKeyForSource(sourceType: string, sourceKey: string): string {
-  return `${sourceType}:${sourceKey}`;
+export function streamKeyForSource(sourceId: string): string {
+  return `source:${sourceId}`;
 }
 
 export function toAppendResult(result: AppendEventsResult): AppendSourceEventResult {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,177 @@ async function main(): Promise<void> {
 
   const client = await createClient(normalized);
 
+  if (command === "host" && normalized[1] === "add") {
+    const [hostType, hostKey] = normalized.slice(2, 4);
+    if (!hostType || !hostKey) {
+      throw new Error("usage: agentinbox host add <hostType> <hostKey> [--config-json JSON] [--config-ref REF]");
+    }
+    await printRemote(client, "/hosts", {
+      hostType,
+      hostKey,
+      configRef: takeFlagValue(normalized, "--config-ref") ?? undefined,
+      config: parseJsonArg(takeFlagValue(normalized, "--config-json")),
+    });
+    return;
+  }
+
+  if (command === "host" && normalized[1] === "list") {
+    await printRemote(client, "/hosts", undefined, "GET");
+    return;
+  }
+
+  if (command === "host" && normalized[1] === "show") {
+    const hostId = normalized[2];
+    if (!hostId) {
+      throw new Error("usage: agentinbox host show <hostId>");
+    }
+    await printRemote(client, `/hosts/${encodeURIComponent(hostId)}`, undefined, "GET");
+    return;
+  }
+
+  if (command === "host" && normalized[1] === "schema") {
+    const hostId = normalized[2];
+    if (!hostId) {
+      throw new Error("usage: agentinbox host schema <hostId>");
+    }
+    await printRemote(client, `/hosts/${encodeURIComponent(hostId)}/schema`, undefined, "GET");
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "add") {
+    const [hostId, streamKind, streamKey] = normalized.slice(2, 5);
+    if (!hostId || !streamKind || !streamKey) {
+      throw new Error("usage: agentinbox stream add <hostId> <streamKind> <streamKey> [--compat-source-type TYPE] [--config-json JSON] [--config-ref REF]");
+    }
+    await printRemote(client, "/streams", {
+      hostId,
+      streamKind,
+      streamKey,
+      compatSourceType: takeFlagValue(normalized, "--compat-source-type") ?? undefined,
+      configRef: takeFlagValue(normalized, "--config-ref") ?? undefined,
+      config: parseJsonArg(takeFlagValue(normalized, "--config-json")),
+    });
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "list") {
+    await printRemote(client, "/streams", undefined, "GET");
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "show") {
+    const streamId = normalized[2];
+    if (!streamId) {
+      throw new Error("usage: agentinbox stream show <streamId>");
+    }
+    await printRemote(client, `/streams/${encodeURIComponent(streamId)}`, undefined, "GET");
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "remove") {
+    const removeArgs = normalized.slice(2);
+    const positionals = positionalArgs(removeArgs, ["--with-subscriptions"]);
+    const streamId = positionals[0];
+    if (!streamId || positionals[1]) {
+      throw new Error("usage: agentinbox stream remove <streamId> [--with-subscriptions]");
+    }
+    const query = buildQuery({
+      with_subscriptions: hasFlag(normalized, "--with-subscriptions") ? "true" : undefined,
+    });
+    await printRemote(client, `/streams/${encodeURIComponent(streamId)}${query}`, undefined, "DELETE");
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "update") {
+    const streamId = normalized[2];
+    if (!streamId) {
+      throw new Error("usage: agentinbox stream update <streamId> [--config-json JSON] [--config-ref REF | --clear-config-ref]");
+    }
+    const configRef = takeFlagValue(normalized, "--config-ref");
+    const clearConfigRef = hasFlag(normalized, "--clear-config-ref");
+    const configJson = takeFlagValue(normalized, "--config-json");
+    if (configRef != null && clearConfigRef) {
+      throw new Error("stream update accepts only one of --config-ref or --clear-config-ref");
+    }
+    if (!clearConfigRef && configRef == null && configJson == null) {
+      throw new Error("usage: agentinbox stream update <streamId> [--config-json JSON] [--config-ref REF | --clear-config-ref]");
+    }
+    await printRemote(client, `/streams/${encodeURIComponent(streamId)}`, {
+      ...(clearConfigRef ? { configRef: null } : (configRef != null ? { configRef } : {})),
+      config: configJson != null ? parseJsonArg(configJson, "--config-json") : undefined,
+    }, "PATCH");
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "pause") {
+    const streamId = normalized[2];
+    if (!streamId) {
+      throw new Error("usage: agentinbox stream pause <streamId>");
+    }
+    await printRemote(client, `/streams/${encodeURIComponent(streamId)}/pause`, {});
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "resume") {
+    const streamId = normalized[2];
+    if (!streamId) {
+      throw new Error("usage: agentinbox stream resume <streamId>");
+    }
+    await printRemote(client, `/streams/${encodeURIComponent(streamId)}/resume`, {});
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "schema") {
+    if (normalized[2] === "preview") {
+      const sourceRef = normalized[3];
+      if (!sourceRef) {
+        throw new Error("usage: agentinbox stream schema preview <sourceKind|sourceType> [--config-json JSON] [--config-ref REF]");
+      }
+      await printRemote(client, "/streams/schema-preview", {
+        sourceRef,
+        configRef: takeFlagValue(normalized, "--config-ref") ?? undefined,
+        config: parseJsonArg(takeFlagValue(normalized, "--config-json")),
+      });
+      return;
+    }
+    const streamRef = normalized[2];
+    if (!streamRef) {
+      throw new Error("usage: agentinbox stream schema <streamId|sourceType>");
+    }
+    if (streamRef.startsWith("src_")) {
+      await printRemote(client, `/streams/${encodeURIComponent(streamRef)}/schema`, undefined, "GET");
+      return;
+    }
+    await printRemote(client, `/source-types/${encodeURIComponent(streamRef)}/schema`, undefined, "GET");
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "poll") {
+    const streamId = normalized[2];
+    if (!streamId) {
+      throw new Error("usage: agentinbox stream poll <streamId>");
+    }
+    await printRemote(client, `/streams/${encodeURIComponent(streamId)}/poll`, {});
+    return;
+  }
+
+  if (command === "stream" && normalized[1] === "event") {
+    const streamId = normalized[2];
+    const sourceNativeId = takeFlagValue(normalized, "--native-id");
+    const eventVariant = takeFlagValue(normalized, "--event");
+    if (!streamId || !sourceNativeId || !eventVariant) {
+      throw new Error("usage: agentinbox stream event <streamId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]");
+    }
+    await printRemote(client, `/streams/${encodeURIComponent(streamId)}/events`, {
+      sourceNativeId,
+      eventVariant,
+      occurredAt: takeFlagValue(normalized, "--occurred-at") ?? undefined,
+      metadata: parseJsonArg(takeFlagValue(normalized, "--metadata-json")),
+      rawPayload: parseJsonArg(takeFlagValue(normalized, "--payload-json")),
+    });
+    return;
+  }
+
   if (command === "source" && normalized[1] === "add") {
     const [type, sourceKey] = normalized.slice(2, 4);
     if (!type || !sourceKey) {
@@ -1086,6 +1257,29 @@ Usage:
   agentinbox daemon start [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock] [--log-level error|warn|info|debug|trace]
   agentinbox daemon stop [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
   agentinbox daemon status [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
+`,
+    host: `agentinbox host
+
+Usage:
+  agentinbox host add <hostType> <hostKey> [--config-json JSON] [--config-ref REF]
+  agentinbox host list
+  agentinbox host show <hostId>
+  agentinbox host schema <hostId>
+`,
+    stream: `agentinbox stream
+
+Usage:
+  agentinbox stream add <hostId> <streamKind> <streamKey> [--compat-source-type TYPE] [--config-json JSON] [--config-ref REF]
+  agentinbox stream list
+  agentinbox stream show <streamId>
+  agentinbox stream update <streamId> [--config-json JSON] [--config-ref REF | --clear-config-ref]
+  agentinbox stream remove <streamId> [--with-subscriptions]
+  agentinbox stream pause <streamId>
+  agentinbox stream resume <streamId>
+  agentinbox stream schema <streamId|sourceType>
+  agentinbox stream schema preview <sourceKind|sourceType> [--config-json JSON] [--config-ref REF]
+  agentinbox stream poll <streamId>
+  agentinbox stream event <streamId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]
 `,
     source: `agentinbox source
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -127,6 +127,162 @@ function buildFastifyServer(service: AgentInboxService) {
     },
   }, async () => service.gc());
 
+  app.get("/hosts", {
+    schema: {
+      tags: ["sources"],
+      response: {
+        200: {
+          type: "object",
+          required: ["hosts"],
+          properties: {
+            hosts: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async () => ({ hosts: service.listHosts() }));
+
+  app.post("/hosts", {
+    schema: {
+      tags: ["sources"],
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["hostType", "hostKey"],
+        properties: {
+          hostType: { type: "string", minLength: 1 },
+          hostKey: { type: "string", minLength: 1 },
+          configRef: { anyOf: [{ type: "string" }, { type: "null" }] },
+          config: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => service.registerHost(request.body as never));
+
+  app.get("/hosts/:hostId", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["hostId"],
+        properties: {
+          hostId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { hostId: string };
+    return service.getHostDetails(decodeURIComponent(params.hostId));
+  });
+
+  app.get("/hosts/:hostId/schema", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["hostId"],
+        properties: {
+          hostId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { hostId: string };
+    const host = service.getHost(decodeURIComponent(params.hostId));
+    return service.getHostSchema(host.hostType);
+  });
+
+  app.get("/streams", {
+    schema: {
+      tags: ["sources"],
+      response: {
+        200: {
+          type: "object",
+          required: ["streams"],
+          properties: {
+            streams: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async () => ({ streams: service.listStreams() }));
+
+  app.post("/streams", {
+    schema: {
+      tags: ["sources"],
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["hostId", "streamKind", "streamKey"],
+        properties: {
+          hostId: { type: "string", minLength: 1 },
+          streamKind: { type: "string", minLength: 1 },
+          streamKey: { type: "string", minLength: 1 },
+          compatSourceType: { type: "string" },
+          configRef: { anyOf: [{ type: "string" }, { type: "null" }] },
+          config: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => service.registerStream(request.body as never));
+
+  app.get("/streams/:streamId", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["streamId"],
+        properties: {
+          streamId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { streamId: string };
+    return service.getStreamDetails(decodeURIComponent(params.streamId));
+  });
+
+  app.get("/streams/:streamId/schema", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["streamId"],
+        properties: {
+          streamId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { streamId: string };
+    return service.getResolvedSourceSchema(decodeURIComponent(params.streamId));
+  });
+
   app.get("/sources", {
     schema: {
       tags: ["sources"],
@@ -202,6 +358,192 @@ function buildFastifyServer(service: AgentInboxService) {
   }, async (request) => {
     const params = request.params as { sourceId: string };
     return service.getResolvedSourceSchema(decodeURIComponent(params.sourceId));
+  });
+
+  app.patch("/streams/:streamId", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["streamId"],
+        properties: {
+          streamId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        minProperties: 1,
+        properties: {
+          configRef: { anyOf: [{ type: "string" }, { type: "null" }] },
+          config: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { streamId: string };
+    return service.updateSource(decodeURIComponent(params.streamId), request.body as never);
+  });
+
+  app.delete("/streams/:streamId", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["streamId"],
+        properties: {
+          streamId: { type: "string", minLength: 1 },
+        },
+      },
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          with_subscriptions: {
+            anyOf: [
+              { type: "boolean" },
+              { type: "string", enum: ["true", "false", "1", "0"] },
+            ],
+          },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { streamId: string };
+    const query = request.query as { with_subscriptions?: boolean | string };
+    return service.removeSource(decodeURIComponent(params.streamId), {
+      withSubscriptions: query.with_subscriptions === true || query.with_subscriptions === "true" || query.with_subscriptions === "1",
+    });
+  });
+
+  app.post("/streams/:streamId/pause", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["streamId"],
+        properties: {
+          streamId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { streamId: string };
+    return service.pauseSource(decodeURIComponent(params.streamId));
+  });
+
+  app.post("/streams/:streamId/resume", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["streamId"],
+        properties: {
+          streamId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { streamId: string };
+    return service.resumeSource(decodeURIComponent(params.streamId));
+  });
+
+  app.post("/streams/schema-preview", {
+    schema: {
+      tags: ["sources"],
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["sourceRef"],
+        properties: {
+          sourceRef: { type: "string", minLength: 1 },
+          configRef: { anyOf: [{ type: "string" }, { type: "null" }] },
+          config: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => service.previewSourceSchema(request.body as PreviewSourceSchemaInput));
+
+  app.post("/streams/:streamId/poll", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["streamId"],
+        properties: {
+          streamId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { streamId: string };
+    return service.pollSource(decodeURIComponent(params.streamId));
+  });
+
+  app.post("/streams/:streamId/events", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["streamId"],
+        properties: {
+          streamId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["sourceNativeId", "eventVariant"],
+        properties: {
+          sourceNativeId: { type: "string", minLength: 1 },
+          eventVariant: { type: "string", minLength: 1 },
+          occurredAt: { type: "string", minLength: 1 },
+          metadata: jsonObjectSchema,
+          rawPayload: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { streamId: string };
+    const body = request.body as {
+      sourceNativeId: string;
+      eventVariant: string;
+      occurredAt?: string;
+      metadata?: Record<string, unknown>;
+      rawPayload?: Record<string, unknown>;
+    };
+    return service.appendSourceEvent({
+      sourceId: decodeURIComponent(params.streamId),
+      sourceNativeId: body.sourceNativeId,
+      eventVariant: body.eventVariant,
+      occurredAt: body.occurredAt,
+      metadata: body.metadata ?? {},
+      rawPayload: body.rawPayload ?? {},
+    });
   });
 
   app.delete("/sources/:sourceId", {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,5 @@
 export type SourceType = "local_event" | "remote_source" | "github_repo" | "github_repo_ci" | "feishu_bot";
+export type HostType = "local_event" | "remote_source" | "github" | "feishu";
 
 export type SubscriptionStartPolicy = "latest" | "earliest" | "at_offset" | "at_time";
 export type ActivationMode = "activation_only" | "activation_with_items";
@@ -18,8 +19,24 @@ export interface DeliveryHandle {
   replyMode?: string | null;
 }
 
-export interface SubscriptionSource {
+export interface SourceHost {
+  hostId: string;
+  hostType: HostType;
+  hostKey: string;
+  configRef?: string | null;
+  config?: Record<string, unknown>;
+  status: "active" | "paused" | "error";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SourceStream {
   sourceId: string;
+  streamId?: string | null;
+  hostId?: string;
+  streamKind?: string;
+  streamKey?: string;
+  compatSourceType?: SourceType | null;
   sourceType: SourceType;
   sourceKey: string;
   configRef?: string | null;
@@ -29,6 +46,9 @@ export interface SubscriptionSource {
   createdAt: string;
   updatedAt: string;
 }
+
+// Deprecated compatibility alias. Product-level "sources" now resolve to streams.
+export type SubscriptionSource = SourceStream;
 
 export interface SourceIdleState {
   sourceId: string;
@@ -198,6 +218,32 @@ export interface DeliveryAttempt {
 export interface RegisterSourceInput {
   sourceType: SourceType;
   sourceKey: string;
+  configRef?: string | null;
+  config?: Record<string, unknown>;
+}
+
+export interface RegisterHostInput {
+  hostType: HostType;
+  hostKey: string;
+  configRef?: string | null;
+  config?: Record<string, unknown>;
+}
+
+export interface UpdateHostInput {
+  configRef?: string | null;
+  config?: Record<string, unknown>;
+}
+
+export interface RegisterStreamInput {
+  hostId: string;
+  streamKind: string;
+  streamKey: string;
+  compatSourceType?: SourceType | null;
+  configRef?: string | null;
+  config?: Record<string, unknown>;
+}
+
+export interface UpdateStreamInput {
   configRef?: string | null;
   config?: Record<string, unknown>;
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -21,14 +21,17 @@ import {
   PreviewSourceSchemaInput,
   RegisterAgentInput,
   RegisterAgentResult,
+  RegisterHostInput,
   RegisterSourceInput,
   RegisterSubscriptionInput,
   RegisterTimerInput,
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
+  SourceHost,
   SourceSchema,
   SourceSchemaPreview,
   SourcePollResult,
+  SourceStream,
   Subscription,
   CleanupPolicy,
   SubscriptionLifecycleRetirement,
@@ -66,6 +69,7 @@ import {
 import { LifecycleSignal } from "./sources/remote_modules";
 import { ActivationGate, DefaultActivationGate } from "./runtime_gate";
 import { Logger, NoopLogger } from "./logging";
+import { compatSourceTypeForStream, hostTypeForSourceType, resolveLegacySource, streamKindForSourceType } from "./source_hosts";
 
 const DEFAULT_SUBSCRIPTION_POLL_LIMIT = 100;
 const DEFAULT_ACTIVATION_WINDOW_MS = 3_000;
@@ -220,13 +224,32 @@ export class AgentInboxService {
     if (existing) {
       return existing;
     }
+    const resolved = resolveLegacySource(input);
     const now = nowIso();
+    let host = this.store.getSourceHostByKey(resolved.hostType, resolved.hostKey);
+    if (!host) {
+      host = {
+        hostId: generateId("hst"),
+        hostType: resolved.hostType,
+        hostKey: resolved.hostKey,
+        configRef: input.configRef ?? null,
+        config: resolved.hostConfig,
+        status: "active",
+        createdAt: now,
+        updatedAt: now,
+      };
+      this.store.insertSourceHost(host);
+    }
     const source: SubscriptionSource = {
       sourceId: generateId("src"),
+      hostId: host.hostId,
+      streamKind: resolved.streamKind,
+      streamKey: resolved.streamKey,
+      compatSourceType: resolved.compatSourceType,
       sourceType: input.sourceType,
       sourceKey: input.sourceKey,
       configRef: input.configRef ?? null,
-      config: input.config ?? {},
+      config: resolved.streamConfig,
       status: "active",
       checkpoint: null,
       createdAt: now,
@@ -242,6 +265,28 @@ export class AgentInboxService {
     return this.store.listSources();
   }
 
+  listHosts(): SourceHost[] {
+    return this.store.listSourceHosts();
+  }
+
+  getHost(hostId: string): SourceHost {
+    const host = this.store.getSourceHost(hostId);
+    if (!host) {
+      throw new Error(`unknown host: ${hostId}`);
+    }
+    return host;
+  }
+
+  getHostDetails(hostId: string): Record<string, unknown> {
+    const host = this.getHost(hostId);
+    const streams = this.store.listSources().filter((stream) => stream.hostId === hostId);
+    return {
+      host,
+      schema: this.getHostSchema(host.hostType),
+      streams,
+    };
+  }
+
   getSource(sourceId: string): SubscriptionSource {
     const source = this.store.getSource(sourceId);
     if (!source) {
@@ -252,7 +297,7 @@ export class AgentInboxService {
 
   async getSourceDetails(sourceId: string): Promise<Record<string, unknown>> {
     const source = this.getSource(sourceId);
-    const fallbackSchema = getSourceSchema(source.sourceType);
+    const fallbackSchema = getSourceSchema(compatSourceTypeForStream(source));
     let resolvedIdentity: ResolvedSourceIdentity | null = null;
     let resolutionError: string | null = null;
     let schema: SourceSchema | ResolvedSourceSchema = fallbackSchema;
@@ -269,6 +314,7 @@ export class AgentInboxService {
       : fallbackSchema;
     return {
       source,
+      host: source.hostId ? this.store.getSourceHost(source.hostId) : null,
       resolvedIdentity,
       ...(resolutionError ? { resolutionError } : {}),
       schema: resolvedSchema,
@@ -280,6 +326,90 @@ export class AgentInboxService {
 
   getSourceSchema(sourceType: SubscriptionSource["sourceType"]): SourceSchema {
     return getSourceSchema(sourceType);
+  }
+
+  getHostSchema(hostType: SourceHost["hostType"]): Record<string, unknown> {
+    return {
+      hostType,
+      configFields: getHostConfigFields(hostType),
+      streamKinds: listHostStreamKinds(hostType),
+    };
+  }
+
+  registerHost(input: RegisterHostInput): SourceHost {
+    const existing = this.store.getSourceHostByKey(input.hostType, input.hostKey);
+    if (existing) {
+      return existing;
+    }
+    const now = nowIso();
+    const host: SourceHost = {
+      hostId: generateId("hst"),
+      hostType: input.hostType,
+      hostKey: input.hostKey,
+      configRef: input.configRef ?? null,
+      config: input.config ?? {},
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.store.insertSourceHost(host);
+    return host;
+  }
+
+  registerStream(input: {
+    hostId: string;
+    streamKind: string;
+    streamKey: string;
+    compatSourceType?: SourceStream["compatSourceType"];
+    configRef?: string | null;
+    config?: Record<string, unknown>;
+  }): Promise<SourceStream> {
+    const host = this.getHost(input.hostId);
+    const existing = this.store.listSources().find((stream) =>
+      stream.hostId === input.hostId &&
+      stream.streamKind === input.streamKind &&
+      stream.streamKey === input.streamKey,
+    );
+    if (existing) {
+      return Promise.resolve(existing);
+    }
+    const compatSourceType = input.compatSourceType ?? sourceTypeForStreamRegistration(host.hostType, input.streamKind);
+    const now = nowIso();
+    const stream: SourceStream = {
+      sourceId: generateId("src"),
+      streamId: null,
+      hostId: input.hostId,
+      streamKind: input.streamKind,
+      streamKey: input.streamKey,
+      compatSourceType,
+      sourceType: compatSourceType,
+      sourceKey: input.streamKey,
+      configRef: input.configRef ?? host.configRef ?? null,
+      config: input.config ?? {},
+      status: "active",
+      checkpoint: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.store.insertSource(stream);
+    return this.adapters.sourceAdapterFor(compatSourceType)
+      .ensureSource(stream)
+      .then(async () => {
+        await this.ensureStreamForSource(stream);
+        return this.getStream(stream.sourceId);
+      });
+  }
+
+  listStreams(): SourceStream[] {
+    return this.listSources();
+  }
+
+  getStream(streamId: string): SourceStream {
+    return this.getSource(streamId);
+  }
+
+  getStreamDetails(streamId: string): Promise<Record<string, unknown>> {
+    return this.getSourceDetails(streamId);
   }
 
   async getResolvedSourceSchema(sourceId: string): Promise<ResolvedSourceSchema> {
@@ -3237,4 +3367,55 @@ function weekdayToNumber(value: string): number {
     default:
       throw new Error(`unsupported weekday: ${value}`);
   }
+}
+
+function listHostStreamKinds(hostType: SourceHost["hostType"]): string[] {
+  switch (hostType) {
+    case "github":
+      return ["repo_events", "ci_runs"];
+    case "feishu":
+      return ["message_events"];
+    case "local_event":
+      return ["events"];
+    case "remote_source":
+      return ["default"];
+  }
+}
+
+function getHostConfigFields(hostType: SourceHost["hostType"]): Array<{ name: string; type: string; description: string; required?: boolean }> {
+  switch (hostType) {
+    case "github":
+      return [
+        { name: "uxcAuth", type: "string", description: "Optional shared GitHub auth/runtime profile.", required: false },
+      ];
+    case "feishu":
+      return [
+        { name: "appId", type: "string", description: "Feishu app ID.", required: false },
+        { name: "appSecret", type: "string", description: "Feishu app secret.", required: false },
+        { name: "uxcAuth", type: "string", description: "Optional shared Feishu auth/runtime profile.", required: false },
+      ];
+    case "local_event":
+      return [];
+    case "remote_source":
+      return [
+        { name: "profilePath", type: "string", description: "Local module path under $AGENTINBOX_HOME/source-profiles.", required: false },
+        { name: "profileConfig", type: "object", description: "Module-specific host configuration.", required: false },
+      ];
+  }
+}
+
+function sourceTypeForStreamRegistration(hostType: SourceHost["hostType"], streamKind: string): SourceStream["sourceType"] {
+  if (hostType === "github") {
+    if (streamKind === "ci_runs") {
+      return "github_repo_ci";
+    }
+    return "github_repo";
+  }
+  if (hostType === "feishu") {
+    return "feishu_bot";
+  }
+  if (hostType === "local_event") {
+    return "local_event";
+  }
+  return "remote_source";
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1603,7 +1603,7 @@ export class AgentInboxService {
   private async ensureStreamForSource(source: SubscriptionSource) {
     return this.backend.ensureStream({
       sourceId: source.sourceId,
-      streamKey: streamKeyForSource(source.sourceType, source.sourceKey),
+      streamKey: streamKeyForSource(source.sourceId),
       backend: "sqlite",
     });
   }
@@ -3390,15 +3390,15 @@ function getHostConfigFields(hostType: SourceHost["hostType"]): Array<{ name: st
       ];
     case "feishu":
       return [
-        { name: "appId", type: "string", description: "Feishu app ID.", required: false },
-        { name: "appSecret", type: "string", description: "Feishu app secret.", required: false },
+        { name: "appId", type: "string", description: "Feishu app ID.", required: true },
+        { name: "appSecret", type: "string", description: "Feishu app secret.", required: true },
         { name: "uxcAuth", type: "string", description: "Optional shared Feishu auth/runtime profile.", required: false },
       ];
     case "local_event":
       return [];
     case "remote_source":
       return [
-        { name: "profilePath", type: "string", description: "Local module path under $AGENTINBOX_HOME/source-profiles.", required: false },
+        { name: "profilePath", type: "string", description: "Local module path under $AGENTINBOX_HOME/source-profiles.", required: true },
         { name: "profileConfig", type: "object", description: "Module-specific host configuration.", required: false },
       ];
   }

--- a/src/source_hosts.ts
+++ b/src/source_hosts.ts
@@ -1,0 +1,111 @@
+import { HostType, RegisterSourceInput, SourceHost, SourceType, SubscriptionSource } from "./model";
+
+export interface LegacySourceResolution {
+  hostType: HostType;
+  hostKey: string;
+  hostConfig: Record<string, unknown>;
+  streamKind: string;
+  streamKey: string;
+  streamConfig: Record<string, unknown>;
+  compatSourceType: SourceType;
+}
+
+export function resolveLegacySource(input: RegisterSourceInput): LegacySourceResolution {
+  const config = input.config ?? {};
+  if (input.sourceType === "github_repo") {
+    return {
+      hostType: "github",
+      hostKey: `uxcAuth:${stringOrDefault(config.uxcAuth, input.configRef ?? "default")}`,
+      hostConfig: {
+        ...(valueOrUndefined(config.uxcAuth) ? { uxcAuth: config.uxcAuth } : {}),
+      },
+      streamKind: "repo_events",
+      streamKey: input.sourceKey,
+      streamConfig: config,
+      compatSourceType: input.sourceType,
+    };
+  }
+  if (input.sourceType === "github_repo_ci") {
+    return {
+      hostType: "github",
+      hostKey: `uxcAuth:${stringOrDefault(config.uxcAuth, input.configRef ?? "default")}`,
+      hostConfig: {
+        ...(valueOrUndefined(config.uxcAuth) ? { uxcAuth: config.uxcAuth } : {}),
+      },
+      streamKind: "ci_runs",
+      streamKey: input.sourceKey,
+      streamConfig: config,
+      compatSourceType: input.sourceType,
+    };
+  }
+  if (input.sourceType === "feishu_bot") {
+    return {
+      hostType: "feishu",
+      hostKey: `app:${stringOrDefault(config.appId, input.configRef ?? input.sourceKey)}`,
+      hostConfig: {
+        ...(valueOrUndefined(config.appId) ? { appId: config.appId } : {}),
+        ...(valueOrUndefined(config.appSecret) ? { appSecret: config.appSecret } : {}),
+        ...(valueOrUndefined(config.schemaUrl) ? { schemaUrl: config.schemaUrl } : {}),
+        ...(valueOrUndefined(config.replyInThread) ? { replyInThread: config.replyInThread } : {}),
+        ...(valueOrUndefined(config.uxcAuth) ? { uxcAuth: config.uxcAuth } : {}),
+      },
+      streamKind: "message_events",
+      streamKey: input.sourceKey,
+      streamConfig: config,
+      compatSourceType: input.sourceType,
+    };
+  }
+  if (input.sourceType === "local_event") {
+    return {
+      hostType: "local_event",
+      hostKey: input.sourceKey,
+      hostConfig: {},
+      streamKind: "events",
+      streamKey: input.sourceKey,
+      streamConfig: config,
+      compatSourceType: input.sourceType,
+    };
+  }
+  return {
+    hostType: "remote_source",
+    hostKey: input.sourceKey,
+    hostConfig: config,
+    streamKind: "default",
+    streamKey: input.sourceKey,
+    streamConfig: config,
+    compatSourceType: input.sourceType,
+  };
+}
+
+export function hostTypeForSourceType(sourceType: SourceType): HostType {
+  return resolveLegacySource({ sourceType, sourceKey: sourceType, config: {} }).hostType;
+}
+
+export function compatSourceTypeForStream(stream: SubscriptionSource): SourceType {
+  return stream.compatSourceType ?? stream.sourceType;
+}
+
+export function streamKindForSourceType(sourceType: SourceType): string {
+  return resolveLegacySource({ sourceType, sourceKey: sourceType, config: {} }).streamKind;
+}
+
+export function sourceTypeFromHost(host: SourceHost): SourceType {
+  if (host.hostType === "github") {
+    return "github_repo";
+  }
+  if (host.hostType === "feishu") {
+    return "feishu_bot";
+  }
+  if (host.hostType === "local_event") {
+    return "local_event";
+  }
+  return "remote_source";
+}
+
+function stringOrDefault(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function valueOrUndefined(value: unknown): boolean {
+  return value !== undefined && value !== null;
+}

--- a/src/source_resolution.ts
+++ b/src/source_resolution.ts
@@ -2,6 +2,7 @@ import { resolveAgentInboxHome } from "./paths";
 import { ResolvedSourceIdentity, ResolvedSourceSchema, SourceSchema, SubscriptionSource } from "./model";
 import { RemoteSourceModule, RemoteSourceModuleRegistry, builtInModuleIdForSourceType, moduleConfigForSource } from "./sources/remote_modules";
 import { getSourceSchema } from "./source_schema";
+import { compatSourceTypeForStream } from "./source_hosts";
 
 export interface ResolveSourceContext {
   homeDir?: string;
@@ -14,7 +15,8 @@ export async function resolveSourceIdentity(
   source: SubscriptionSource,
   context: ResolveSourceContext = {},
 ): Promise<ResolvedSourceIdentity> {
-  if (source.sourceType === "local_event") {
+  const compatSourceType = compatSourceTypeForStream(source);
+  if (compatSourceType === "local_event") {
     return {
       hostType: "local_event",
       sourceKind: "local_event",
@@ -22,17 +24,17 @@ export async function resolveSourceIdentity(
     };
   }
 
-  const builtinImplementationId = builtInModuleIdForSourceType(source.sourceType);
+  const builtinImplementationId = builtInModuleIdForSourceType(compatSourceType);
   if (builtinImplementationId) {
     return {
       hostType: "remote_source",
-      sourceKind: source.sourceType,
+      sourceKind: compatSourceType,
       implementationId: builtinImplementationId,
     };
   }
 
-  if (source.sourceType !== "remote_source") {
-    throw new Error(`unsupported source type for source resolution: ${source.sourceType}`);
+  if (compatSourceType !== "remote_source") {
+    throw new Error(`unsupported source type for source resolution: ${compatSourceType}`);
   }
 
   const moduleRegistry = context.moduleRegistry ?? context.profileRegistry ?? new RemoteSourceModuleRegistry();
@@ -56,7 +58,7 @@ export async function resolveSourceSchema(
   const homeDir = context.homeDir ?? resolveAgentInboxHome(process.env);
   const resolvedContext: ResolveSourceContext = { ...context, moduleRegistry, homeDir };
   const identity = await resolveSourceIdentity(source, resolvedContext);
-  const staticSchema = getSourceSchema(source.sourceType);
+  const staticSchema = getSourceSchema(compatSourceTypeForStream(source));
   let capabilityDescription: ReturnType<NonNullable<RemoteSourceModule["describeCapabilities"]>> | undefined;
   let module: RemoteSourceModule | null = null;
   if (identity.hostType === "remote_source") {
@@ -125,7 +127,7 @@ export function withResolvedIdentity(
 }
 
 function moduleInputSource(source: SubscriptionSource): SubscriptionSource {
-  if (source.sourceType !== "remote_source") {
+  if (compatSourceTypeForStream(source) !== "remote_source") {
     return source;
   }
   return {

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -13,6 +13,7 @@ import {
   SubscriptionFilter,
   SubscriptionSource,
 } from "../model";
+import { compatSourceTypeForStream } from "../source_hosts";
 import {
   deriveGithubTrackedResource,
   expandGithubSubscriptionShortcut,
@@ -133,17 +134,18 @@ export class RemoteSourceModuleRegistry {
   private readonly moduleCache = new Map<string, RemoteSourceModule>();
 
   resolve(source: SubscriptionSource, homeDir: string): Promise<RemoteSourceModule> {
-    if (source.sourceType === "github_repo") {
+    const compatSourceType = compatSourceTypeForStream(source);
+    if (compatSourceType === "github_repo") {
       return Promise.resolve(GITHUB_REPO_MODULE);
     }
-    if (source.sourceType === "github_repo_ci") {
+    if (compatSourceType === "github_repo_ci") {
       return Promise.resolve(GITHUB_REPO_CI_MODULE);
     }
-    if (source.sourceType === "feishu_bot") {
+    if (compatSourceType === "feishu_bot") {
       return Promise.resolve(FEISHU_BOT_MODULE);
     }
-    if (source.sourceType !== "remote_source") {
-      throw new Error(`unsupported source type for remote module: ${source.sourceType}`);
+    if (compatSourceType !== "remote_source") {
+      throw new Error(`unsupported source type for remote module: ${compatSourceType}`);
     }
     return this.loadUserModule(source, homeDir);
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,6 +22,7 @@ import {
   ListInboxItemsOptions,
   AgentTimer,
   RegisterAgentInput,
+  SourceHost,
   SourceIdleState,
   Subscription,
   SubscriptionLifecycleRetirement,
@@ -238,6 +239,93 @@ export class AgentInboxStore {
     return Boolean(row);
   }
 
+  getSourceHostByKey(hostType: string, hostKey: string): SourceHost | null {
+    const row = this.getOne(
+      "select * from source_hosts where host_type = ? and host_key = ?",
+      [hostType, hostKey],
+    );
+    return row ? this.mapSourceHost(row) : null;
+  }
+
+  getSourceHost(hostId: string): SourceHost | null {
+    const row = this.getOne("select * from source_hosts where host_id = ?", [hostId]);
+    return row ? this.mapSourceHost(row) : null;
+  }
+
+  insertSourceHost(host: SourceHost): void {
+    this.db.run(
+      `
+      insert into source_hosts (
+        host_id, host_type, host_key, config_ref, config_json, status, created_at, updated_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      [
+        host.hostId,
+        host.hostType,
+        host.hostKey,
+        host.configRef ?? null,
+        JSON.stringify(host.config ?? {}),
+        host.status,
+        host.createdAt,
+        host.updatedAt,
+      ],
+    );
+    this.persist();
+  }
+
+  listSourceHosts(): SourceHost[] {
+    const rows = this.getAll("select * from source_hosts order by created_at asc");
+    return rows.map((row) => this.mapSourceHost(row));
+  }
+
+  updateSourceHostDefinition(
+    hostId: string,
+    input: { configRef?: string | null; config?: Record<string, unknown> },
+  ): SourceHost {
+    const current = this.getSourceHost(hostId);
+    if (!current) {
+      throw new Error(`unknown source host: ${hostId}`);
+    }
+    this.db.run(
+      `
+      update source_hosts
+      set config_ref = ?, config_json = ?, updated_at = ?
+      where host_id = ?
+    `,
+      [
+        Object.prototype.hasOwnProperty.call(input, "configRef") ? input.configRef ?? null : current.configRef ?? null,
+        JSON.stringify(Object.prototype.hasOwnProperty.call(input, "config") ? input.config ?? {} : current.config ?? {}),
+        nowIso(),
+        hostId,
+      ],
+    );
+    this.persist();
+    return this.getSourceHost(hostId)!;
+  }
+
+  updateSourceHostRuntime(
+    hostId: string,
+    input: { status?: SourceHost["status"] },
+  ): void {
+    const current = this.getSourceHost(hostId);
+    if (!current) {
+      throw new Error(`unknown source host: ${hostId}`);
+    }
+    this.db.run(
+      `
+      update source_hosts
+      set status = ?, updated_at = ?
+      where host_id = ?
+    `,
+      [
+        Object.prototype.hasOwnProperty.call(input, "status") ? input.status ?? current.status : current.status,
+        nowIso(),
+        hostId,
+      ],
+    );
+    this.persist();
+  }
+
   getSourceByKey(sourceType: string, sourceKey: string): SubscriptionSource | null {
     const row = this.getOne(
       "select * from sources where source_type = ? and source_key = ?",
@@ -252,15 +340,23 @@ export class AgentInboxStore {
   }
 
   insertSource(source: SubscriptionSource): void {
+    const hostId = source.hostId ?? this.ensureCompatibilityHostForSource(source);
+    const streamKind = source.streamKind ?? "default";
+    const streamKey = source.streamKey ?? source.sourceKey;
     this.db.run(
       `
       insert into sources (
-        source_id, source_type, source_key, config_ref, config_json,
+        source_id, host_id, stream_kind, stream_key, compat_source_type,
+        source_type, source_key, config_ref, config_json,
         status, checkpoint, created_at, updated_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         source.sourceId,
+        hostId,
+        streamKind,
+        streamKey,
+        source.compatSourceType ?? null,
         source.sourceType,
         source.sourceKey,
         source.configRef ?? null,
@@ -392,6 +488,13 @@ export class AgentInboxStore {
       }
       this.db.run("delete from source_idle_states where source_id = ?", [sourceId]);
       this.db.run("delete from sources where source_id = ?", [sourceId]);
+      const hostId = source.hostId ?? null;
+      const siblings = hostId
+        ? this.getOne("select count(*) as count from sources where host_id = ?", [hostId])
+        : null;
+      if (hostId && Number(siblings?.count ?? 0) === 0) {
+        this.db.run("delete from source_hosts where host_id = ?", [hostId]);
+      }
     });
     this.persist();
     return source;
@@ -1519,12 +1622,62 @@ export class AgentInboxStore {
   private mapSource(row: Record<string, unknown>): SubscriptionSource {
     return {
       sourceId: String(row.source_id),
+      streamId: String(row.source_id),
+      hostId: String(row.host_id),
+      streamKind: String(row.stream_kind),
+      streamKey: String(row.stream_key),
+      compatSourceType: row.compat_source_type ? String(row.compat_source_type) as SubscriptionSource["compatSourceType"] : null,
       sourceType: row.source_type as SubscriptionSource["sourceType"],
       sourceKey: String(row.source_key),
       configRef: row.config_ref ? String(row.config_ref) : null,
       config: parseJson<Record<string, unknown>>(row.config_json as string),
       status: row.status as SubscriptionSource["status"],
       checkpoint: row.checkpoint ? String(row.checkpoint) : null,
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
+    };
+  }
+
+  private ensureCompatibilityHostForSource(source: SubscriptionSource): string {
+    const hostType = source.sourceType === "github_repo" || source.sourceType === "github_repo_ci"
+      ? "github"
+      : source.sourceType === "feishu_bot"
+        ? "feishu"
+        : source.sourceType === "local_event"
+          ? "local_event"
+          : "remote_source";
+    const hostKey = source.sourceType === "github_repo" || source.sourceType === "github_repo_ci"
+      ? `uxcAuth:${String((source.config ?? {}).uxcAuth ?? source.configRef ?? "default")}`
+      : source.sourceType === "feishu_bot"
+        ? `app:${String((source.config ?? {}).appId ?? source.configRef ?? source.sourceId)}`
+        : source.sourceKey;
+    const existing = this.getSourceHostByKey(hostType, hostKey);
+    if (existing) {
+      return existing.hostId;
+    }
+    const now = nowIso();
+    const host: SourceHost = {
+      hostId: generateId("hst"),
+      hostType: hostType as SourceHost["hostType"],
+      hostKey,
+      configRef: source.configRef ?? null,
+      config: source.config ?? {},
+      status: source.status,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.insertSourceHost(host);
+    return host.hostId;
+  }
+
+  private mapSourceHost(row: Record<string, unknown>): SourceHost {
+    return {
+      hostId: String(row.host_id),
+      hostType: String(row.host_type) as SourceHost["hostType"],
+      hostKey: String(row.host_key),
+      configRef: row.config_ref ? String(row.config_ref) : null,
+      config: parseJson<Record<string, unknown>>(row.config_json as string),
+      status: String(row.status) as SourceHost["status"],
       createdAt: String(row.created_at),
       updatedAt: String(row.updated_at),
     };

--- a/src/store.ts
+++ b/src/store.ts
@@ -369,6 +369,7 @@ export class AgentInboxStore {
         ],
       );
     });
+    this.persist();
   }
 
   listSources(): SubscriptionSource[] {

--- a/src/store.ts
+++ b/src/store.ts
@@ -340,34 +340,35 @@ export class AgentInboxStore {
   }
 
   insertSource(source: SubscriptionSource): void {
-    const hostId = source.hostId ?? this.ensureCompatibilityHostForSource(source);
-    const streamKind = source.streamKind ?? "default";
-    const streamKey = source.streamKey ?? source.sourceKey;
-    this.db.run(
-      `
-      insert into sources (
-        source_id, host_id, stream_kind, stream_key, compat_source_type,
-        source_type, source_key, config_ref, config_json,
-        status, checkpoint, created_at, updated_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `,
-      [
-        source.sourceId,
-        hostId,
-        streamKind,
-        streamKey,
-        source.compatSourceType ?? null,
-        source.sourceType,
-        source.sourceKey,
-        source.configRef ?? null,
-        JSON.stringify(source.config ?? {}),
-        source.status,
-        source.checkpoint ?? null,
-        source.createdAt,
-        source.updatedAt,
-      ],
-    );
-    this.persist();
+    this.inTransaction(() => {
+      const hostId = source.hostId ?? this.ensureCompatibilityHostForSource(source);
+      const streamKind = source.streamKind ?? "default";
+      const streamKey = source.streamKey ?? source.sourceKey;
+      this.db.run(
+        `
+        insert into sources (
+          source_id, host_id, stream_kind, stream_key, compat_source_type,
+          source_type, source_key, config_ref, config_json,
+          status, checkpoint, created_at, updated_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+        [
+          source.sourceId,
+          hostId,
+          streamKind,
+          streamKey,
+          source.compatSourceType ?? null,
+          source.sourceType,
+          source.sourceKey,
+          source.configRef ?? null,
+          JSON.stringify(source.config ?? {}),
+          source.status,
+          source.checkpoint ?? null,
+          source.createdAt,
+          source.updatedAt,
+        ],
+      );
+    });
   }
 
   listSources(): SubscriptionSource[] {
@@ -1620,12 +1621,15 @@ export class AgentInboxStore {
   }
 
   private mapSource(row: Record<string, unknown>): SubscriptionSource {
+    const hostId = requiredText(row, "host_id");
+    const streamKind = requiredText(row, "stream_kind");
+    const streamKey = requiredText(row, "stream_key");
     return {
       sourceId: String(row.source_id),
       streamId: String(row.source_id),
-      hostId: String(row.host_id),
-      streamKind: String(row.stream_kind),
-      streamKey: String(row.stream_key),
+      hostId,
+      streamKind,
+      streamKey,
       compatSourceType: row.compat_source_type ? String(row.compat_source_type) as SubscriptionSource["compatSourceType"] : null,
       sourceType: row.source_type as SubscriptionSource["sourceType"],
       sourceKey: String(row.source_key),
@@ -1666,7 +1670,23 @@ export class AgentInboxStore {
       createdAt: now,
       updatedAt: now,
     };
-    this.insertSourceHost(host);
+    this.db.run(
+      `
+      insert into source_hosts (
+        host_id, host_type, host_key, config_ref, config_json, status, created_at, updated_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      [
+        host.hostId,
+        host.hostType,
+        host.hostKey,
+        host.configRef ?? null,
+        JSON.stringify(host.config ?? {}),
+        host.status,
+        host.createdAt,
+        host.updatedAt,
+      ],
+    );
     return host.hostId;
   }
 
@@ -1917,4 +1937,12 @@ export class AgentInboxStore {
       updatedAt: String(row.updated_at),
     };
   }
+}
+
+function requiredText(row: Record<string, unknown>, key: string): string {
+  const value = row[key];
+  if (value == null) {
+    throw new Error(`missing required column: ${key}`);
+  }
+  return String(value);
 }

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -213,13 +213,18 @@ async function readMigrationState(dbPath: string): Promise<{ appliedCount: numbe
   return { appliedCount, hasNewIndex };
 }
 
+function expectedMigrationCount(): number {
+  const migrationsDir = path.join(__dirname, "..", "drizzle", "migrations");
+  return fs.readdirSync(migrationsDir).filter((name) => /^\d+_.*\.sql$/.test(name)).length;
+}
+
 test("store migrates a new database using drizzle SQL migrations", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-migrate-new-"));
   const dbPath = path.join(dir, "agentinbox.sqlite");
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 9);
+    assert.equal(state.appliedCount, expectedMigrationCount());
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 0);
@@ -236,7 +241,7 @@ test("store upgrades a legacy v12 database with backup and forward migration", a
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.equal(state.appliedCount, 9);
+    assert.equal(state.appliedCount, expectedMigrationCount());
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.startsWith("agentinbox.sqlite.backup-"));
     assert.equal(backups.length, 1);

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -2787,6 +2787,127 @@ test("control plane source details degrade when remote_source resolution fails b
   }
 });
 
+test("control plane groups compatible GitHub source aliases under one host", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-host-stream-grouping-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+
+      const repoEvents = await client.request<{ hostId: string; sourceId: string }>("/sources", {
+        sourceType: "github_repo",
+        sourceKey: "holon-run/agentinbox",
+        config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+      });
+      const ciRuns = await client.request<{ hostId: string; sourceId: string }>("/sources", {
+        sourceType: "github_repo_ci",
+        sourceKey: "holon-run/agentinbox",
+        config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+      });
+
+      assert.equal(repoEvents.statusCode, 200);
+      assert.equal(ciRuns.statusCode, 200);
+      assert.equal(repoEvents.data.hostId, ciRuns.data.hostId);
+
+      const hosts = await client.request<{ hosts: Array<{ hostId: string; hostType: string }> }>("/hosts", undefined, "GET");
+      assert.equal(hosts.statusCode, 200);
+      assert.equal(hosts.data.hosts.filter((host) => host.hostType === "github").length, 1);
+
+      const hostDetails = await client.request<{ host: { hostId: string; hostType: string }; streams: Array<{ sourceId: string; streamKind: string }> }>(
+        `/hosts/${encodeURIComponent(repoEvents.data.hostId)}`,
+        undefined,
+        "GET",
+      );
+      assert.equal(hostDetails.statusCode, 200);
+      assert.equal(hostDetails.data.host.hostType, "github");
+      assert.deepEqual(
+        hostDetails.data.streams.map((stream) => stream.streamKind).sort(),
+        ["ci_runs", "repo_events"],
+      );
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane creates streams under explicit hosts", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-host-stream-create-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const host = await client.request<{ hostId: string; hostType: string }>("/hosts", {
+        hostType: "local_event",
+        hostKey: "local-default",
+        config: {},
+      });
+      assert.equal(host.statusCode, 200);
+
+      const stream = await client.request<{ sourceId: string; hostId: string; streamKind: string }>(
+        "/streams",
+        {
+          hostId: host.data.hostId,
+          streamKind: "events",
+          streamKey: "local-default",
+          compatSourceType: "local_event",
+          config: {},
+        },
+      );
+      assert.equal(stream.statusCode, 200);
+      assert.equal(stream.data.hostId, host.data.hostId);
+      assert.equal(stream.data.streamKind, "events");
+
+      const listed = await client.request<{ streams: Array<{ sourceId: string; hostId: string }> }>("/streams", undefined, "GET");
+      assert.equal(listed.statusCode, 200);
+      assert.equal(listed.data.streams.some((candidate) => candidate.sourceId === stream.data.sourceId && candidate.hostId === host.data.hostId), true);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("control plane source remove accepts with_subscriptions for explicit cascade cleanup", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-control-plane-remove-"));
   const socketPath = path.join(homeDir, "agentinbox.sock");

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -2908,6 +2908,78 @@ test("control plane creates streams under explicit hosts", async () => {
   }
 });
 
+test("control plane allows the same GitHub stream key under different hosts", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aib-host-dups-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const hostA = await client.request<{ hostId: string }>("/hosts", {
+        hostType: "github",
+        hostKey: "uxcAuth:github-a",
+        config: { uxcAuth: "github-a" },
+      });
+      const hostB = await client.request<{ hostId: string }>("/hosts", {
+        hostType: "github",
+        hostKey: "uxcAuth:github-b",
+        config: { uxcAuth: "github-b" },
+      });
+
+      assert.equal(hostA.statusCode, 200);
+      assert.equal(hostB.statusCode, 200);
+      assert.notEqual(hostA.data.hostId, hostB.data.hostId);
+
+      const streamA = await client.request<{ sourceId: string; hostId: string; streamKind: string }>(
+        "/streams",
+        {
+          hostId: hostA.data.hostId,
+          streamKind: "repo_events",
+          streamKey: "holon-run/agentinbox",
+          config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-a" },
+        },
+      );
+      const streamB = await client.request<{ sourceId: string; hostId: string; streamKind: string }>(
+        "/streams",
+        {
+          hostId: hostB.data.hostId,
+          streamKind: "repo_events",
+          streamKey: "holon-run/agentinbox",
+          config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-b" },
+        },
+      );
+
+      assert.equal(streamA.statusCode, 200);
+      assert.equal(streamB.statusCode, 200);
+      assert.notEqual(streamA.data.sourceId, streamB.data.sourceId);
+      assert.equal(streamA.data.hostId, hostA.data.hostId);
+      assert.equal(streamB.data.hostId, hostB.data.hostId);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("control plane source remove accepts with_subscriptions for explicit cascade cleanup", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-control-plane-remove-"));
   const socketPath = path.join(homeDir, "agentinbox.sock");


### PR DESCRIPTION
Implements #115.

Summary:
- adds a product-level source host + source stream model while keeping the existing internal event-bus streams separate
- migrates persisted source records to carry host/stream metadata and groups compatible GitHub feeds under a shared host
- adds `/hosts` + `/streams` control-plane surfaces and `host` / `stream` CLI commands
- keeps `source` CLI commands working as compatibility aliases over streams

Validation:
- `npm run build`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern "control plane groups compatible GitHub source aliases under one host|control plane creates streams under explicit hosts|control plane source remove accepts with_subscriptions for explicit cascade cleanup|control plane source details degrade when remote_source resolution fails but instance schema reports an error" test/control_plane.test.ts`
- `node --require ts-node/register --test --test-force-exit test/source_schema.test.ts test/github_ci.test.ts`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern "remote_source remove --with-subscriptions stops remote binding and deletes dependent subscriptions" test/remote_source.test.ts`