### PR TITLE
feat: add target notification thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,15 @@ Register the current terminal session:
 ```bash
 agentinbox agent register
 agentinbox agent register --agent-id agent-alpha
+agentinbox agent register --notify-lease-ms 600000 --min-unacked-items 5
 agentinbox agent current
 ```
+
+`notifyLeaseMs` and `minUnackedItems` are target-facing notification policy:
+they control how often a target may be reminded and how many unacked items must
+accumulate before AgentInbox notifies it. Service-wide activation batching
+(`windowMs`, `maxItems`) and terminal gating heuristics remain daemon-level
+policy, not per-agent knobs.
 
 Create a local source and publish an event:
 

--- a/drizzle/migrations/0010_activation_target_min_unacked_items.sql
+++ b/drizzle/migrations/0010_activation_target_min_unacked_items.sql
@@ -1,0 +1,1 @@
+alter table activation_targets add column min_unacked_items integer;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -119,6 +119,7 @@ export const activationTargets = sqliteTable("activation_targets", {
   lastError: text("last_error"),
   mode: text("mode").notNull(),
   notifyLeaseMs: integer("notify_lease_ms").notNull(),
+  minUnackedItems: integer("min_unacked_items"),
   url: text("url"),
   runtimeKind: text("runtime_kind"),
   runtimeSessionId: text("runtime_session_id"),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -383,6 +383,7 @@ async function main(): Promise<void> {
       termProgram: detected.termProgram ?? undefined,
       itermSessionId: detected.itermSessionId ?? undefined,
       notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? undefined,
+      minUnackedItems: parseOptionalNumber(takeFlagValue(normalized, "--min-unacked-items")) ?? undefined,
     });
     return;
   }
@@ -428,13 +429,14 @@ async function main(): Promise<void> {
     const agentId = normalized[4];
     const url = takeFlagValue(normalized, "--url");
     if (!agentId || !url) {
-      throw new Error("usage: agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N]");
+      throw new Error("usage: agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N] [--min-unacked-items N]");
     }
     await printRemote(client, `/agents/${encodeURIComponent(agentId)}/targets`, {
       kind: "webhook",
       url,
       activationMode: takeFlagValue(normalized, "--activation-mode") ?? undefined,
       notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? undefined,
+      minUnackedItems: parseOptionalNumber(takeFlagValue(normalized, "--min-unacked-items")) ?? undefined,
     });
     return;
   }
@@ -1299,13 +1301,13 @@ Usage:
     agent: `agentinbox agent
 
 Usage:
-  agentinbox agent register [--agent-id ID] [--force-rebind] [--notify-lease-ms N]
+  agentinbox agent register [--agent-id ID] [--force-rebind] [--notify-lease-ms N] [--min-unacked-items N]
   agentinbox agent list
   agentinbox agent current
   agentinbox agent show <agentId>
   agentinbox agent remove <agentId>
   agentinbox agent resume <agentId>
-  agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N]
+  agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N] [--min-unacked-items N]
   agentinbox agent target list <agentId>
   agentinbox agent target remove <agentId> <targetId>
   agentinbox agent target resume <agentId> <targetId>

--- a/src/http.ts
+++ b/src/http.ts
@@ -817,6 +817,7 @@ function buildFastifyServer(service: AgentInboxService) {
           termProgram: { type: "string" },
           itermSessionId: { type: "string" },
           notifyLeaseMs: { type: "integer", minimum: 1 },
+          minUnackedItems: { type: "integer", minimum: 1 },
         },
       },
       response: {
@@ -839,6 +840,7 @@ function buildFastifyServer(service: AgentInboxService) {
       termProgram: optionalString(body.termProgram),
       itermSessionId: optionalString(body.itermSessionId),
       notifyLeaseMs: typeof body.notifyLeaseMs === "number" ? body.notifyLeaseMs : null,
+      minUnackedItems: typeof body.minUnackedItems === "number" ? body.minUnackedItems : null,
     });
   });
 
@@ -945,6 +947,7 @@ function buildFastifyServer(service: AgentInboxService) {
           url: { type: "string", minLength: 1 },
           activationMode: { type: "string" },
           notifyLeaseMs: { type: "integer", minimum: 1 },
+          minUnackedItems: { type: "integer", minimum: 1 },
         },
       },
       response: {
@@ -958,11 +961,13 @@ function buildFastifyServer(service: AgentInboxService) {
       url: string;
       activationMode?: ActivationMode;
       notifyLeaseMs?: number;
+      minUnackedItems?: number;
     };
     return service.addWebhookActivationTarget(decodeURIComponent(params.agentId), {
       url: body.url,
       activationMode: body.activationMode,
       notifyLeaseMs: body.notifyLeaseMs ?? null,
+      minUnackedItems: body.minUnackedItems ?? null,
     });
   });
 
@@ -1784,6 +1789,7 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("expected integer") ||
     message.startsWith("expected positive integer") ||
     message.startsWith("notifyLeaseMs must be a positive integer") ||
+    message.startsWith("minUnackedItems must be a positive integer") ||
     message.startsWith("invalid webhook activation target") ||
     message.startsWith("remote_source requires") ||
     message.startsWith("remote_source profile") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -112,6 +112,11 @@ export interface SubscriptionLifecycleRetirement {
   updatedAt: string;
 }
 
+export interface NotificationPolicy {
+  notifyLeaseMs: number;
+  minUnackedItems?: number | null;
+}
+
 interface ActivationTargetBase {
   targetId: string;
   agentId: string;
@@ -122,6 +127,8 @@ interface ActivationTargetBase {
   lastDeliveredAt?: string | null;
   lastError?: string | null;
   notifyLeaseMs: number;
+  minUnackedItems?: number | null;
+  notificationPolicy?: NotificationPolicy;
   createdAt: string;
   updatedAt: string;
   lastSeenAt: string;
@@ -266,6 +273,7 @@ export interface RegisterAgentInput {
   termProgram?: string | null;
   itermSessionId?: string | null;
   notifyLeaseMs?: number | null;
+  minUnackedItems?: number | null;
 }
 
 export interface RegisterAgentResult {
@@ -278,6 +286,7 @@ export interface AddWebhookActivationTargetInput {
   url: string;
   activationMode?: ActivationMode;
   notifyLeaseMs?: number | null;
+  minUnackedItems?: number | null;
 }
 
 export interface DirectInboxTextMessageInput {

--- a/src/runtime_gate.ts
+++ b/src/runtime_gate.ts
@@ -7,18 +7,28 @@ import { TerminalActivationTarget } from "./model";
 import { Logger, NoopLogger } from "./logging";
 
 const execFileAsync = promisify(execFile);
-const DEFAULT_ITERM2_SAMPLE_DELAY_MS = 900;
-const DEFAULT_TMUX_SAMPLE_DELAY_MS = 900;
-const NORMALIZED_BUFFER_TAIL_LINES = 20;
-const ACTIVE_BUFFER_MARKERS = [
-  "esc to interrupt",
-  "Working (",
-  "⠼ ",
-];
-const TYPING_PROMPT_PREFIXES = [
-  "› ",
-  "> ",
-];
+export interface GatingPolicy {
+  iTerm2SampleDelayMs: number;
+  tmuxSampleDelayMs: number;
+  normalizedBufferTailLines: number;
+  activeBufferMarkers: string[];
+  typingPromptPrefixes: string[];
+}
+
+const DEFAULT_GATING_POLICY: GatingPolicy = {
+  iTerm2SampleDelayMs: 900,
+  tmuxSampleDelayMs: 900,
+  normalizedBufferTailLines: 20,
+  activeBufferMarkers: [
+    "esc to interrupt",
+    "Working (",
+    "⠼ ",
+  ],
+  typingPromptPrefixes: [
+    "› ",
+    "> ",
+  ],
+};
 
 type ExecFileAsyncLike = (
   file: string,
@@ -61,6 +71,7 @@ export class DefaultActivationGate implements ActivationGate {
     runtimeProbes?: RuntimePresenceProbe[],
     terminalProbes?: TerminalStateProbe[],
     logger: Logger = new NoopLogger(),
+    gatingPolicy: GatingPolicy = DEFAULT_GATING_POLICY,
   ) {
     this.logger = logger.child("activation_gate");
     this.runtimeProbes = runtimeProbes ?? [
@@ -68,10 +79,10 @@ export class DefaultActivationGate implements ActivationGate {
       new ClaudeCodeRuntimePresenceProbe(undefined, undefined, this.logger.child("claude_runtime")),
     ];
     this.terminalProbes = terminalProbes ?? [
-      new CodexTerminalStateProbe(undefined, undefined, undefined, undefined, undefined, this.logger.child("codex_terminal")),
-      new Iterm2TerminalStateProbe(undefined, {}, this.logger.child("iterm2_terminal")),
+      new CodexTerminalStateProbe(undefined, undefined, undefined, undefined, undefined, this.logger.child("codex_terminal"), gatingPolicy),
+      new Iterm2TerminalStateProbe(undefined, {}, this.logger.child("iterm2_terminal"), gatingPolicy),
       new ClaudeCodeTerminalStateProbe(undefined, undefined, undefined, this.logger.child("claude_terminal")),
-      new TmuxTerminalStateProbe(undefined, {}, this.logger.child("tmux_terminal")),
+      new TmuxTerminalStateProbe(undefined, {}, this.logger.child("tmux_terminal"), gatingPolicy),
     ];
   }
 
@@ -209,12 +220,13 @@ export class CodexRuntimePresenceProbe implements RuntimePresenceProbe {
 
 export class CodexTerminalStateProbe implements TerminalStateProbe {
   constructor(
-    private readonly iTermProbe: TerminalStateProbe = new Iterm2TerminalStateProbe(),
-    private readonly tmuxProbe: TerminalStateProbe = new TmuxTerminalStateProbe(),
+    private readonly iTermProbe: TerminalStateProbe = new Iterm2TerminalStateProbe(undefined, {}, new NoopLogger(), DEFAULT_GATING_POLICY),
+    private readonly tmuxProbe: TerminalStateProbe = new TmuxTerminalStateProbe(undefined, {}, new NoopLogger(), DEFAULT_GATING_POLICY),
     private readonly sessionFileReader?: (sessionId: string) => Promise<CodexSessionLookupResult>,
     private readonly statReader?: (filePath: string) => Promise<{ mtimeMs: number } | null>,
     private readonly nowFn: () => number = () => Date.now(),
     private readonly logger: Logger = new NoopLogger(),
+    private readonly gatingPolicy: GatingPolicy = DEFAULT_GATING_POLICY,
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -315,6 +327,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
       enablePythonProbe?: boolean;
     } = {},
     private readonly logger: Logger = new NoopLogger(),
+    private readonly gatingPolicy: GatingPolicy = DEFAULT_GATING_POLICY,
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -395,7 +408,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
       if (data.status === "available") {
         // If we have cursor and lines data, use cursor-aware detection
         if (data.cursor && Array.isArray(data.lines)) {
-          const bufferTail = normalizeProbeTailFromLines(data.lines);
+          const bufferTail = normalizeProbeTailFromLines(data.lines, this.gatingPolicy.normalizedBufferTailLines);
           if (!bufferTail) {
             this.logger.trace("probe_python_result", {
               sessionId,
@@ -430,14 +443,14 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
           // If cursor-aware detection is certain it's not busy, don't apply prompt heuristics
           if (busyStatus === "not_busy") {
             // Still check for buffer changes and active markers
-            await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? DEFAULT_ITERM2_SAMPLE_DELAY_MS);
+            await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? this.gatingPolicy.iTerm2SampleDelayMs);
             const secondResult = await this.execAsync("python3", [scriptPath, sessionId], {
               env: { ...process.env, PYTHONIOENCODING: "utf-8" }
             });
             const secondData = JSON.parse(secondResult.stdout);
 
             if (secondData.status === "available" && Array.isArray(secondData.lines)) {
-              const secondBufferTail = normalizeProbeTailFromLines(secondData.lines);
+              const secondBufferTail = normalizeProbeTailFromLines(secondData.lines, this.gatingPolicy.normalizedBufferTailLines);
               if (secondBufferTail && bufferTail !== secondBufferTail) {
                 this.logger.trace("probe_python_result", {
                   sessionId,
@@ -449,7 +462,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
             }
 
             // Check for active buffer markers
-            if (containsActiveBufferMarker(bufferTail)) {
+            if (containsActiveBufferMarker(bufferTail, this.gatingPolicy.activeBufferMarkers)) {
               this.logger.trace("probe_python_result", {
                 sessionId,
                 result: { presence: "available", busy: "busy" },
@@ -469,14 +482,14 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
           // If cursor-aware detection is uncertain, fall back to buffer change detection only
           // Do NOT use generic typing prompts to avoid false positives (see #116)
           if (busyStatus === "unknown") {
-            await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? DEFAULT_ITERM2_SAMPLE_DELAY_MS);
+            await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? this.gatingPolicy.iTerm2SampleDelayMs);
             const secondResult = await this.execAsync("python3", [scriptPath, sessionId], {
               env: { ...process.env, PYTHONIOENCODING: "utf-8" }
             });
             const secondData = JSON.parse(secondResult.stdout);
 
             if (secondData.status === "available" && Array.isArray(secondData.lines)) {
-              const secondBufferTail = normalizeProbeTailFromLines(secondData.lines);
+              const secondBufferTail = normalizeProbeTailFromLines(secondData.lines, this.gatingPolicy.normalizedBufferTailLines);
               if (secondBufferTail && bufferTail !== secondBufferTail) {
                 this.logger.trace("probe_python_result", {
                   sessionId,
@@ -488,7 +501,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
             }
 
             // Check for active buffer markers
-            if (containsActiveBufferMarker(bufferTail)) {
+            if (containsActiveBufferMarker(bufferTail, this.gatingPolicy.activeBufferMarkers)) {
               this.logger.trace("probe_python_result", {
                 sessionId,
                 result: { presence: "available", busy: "busy" },
@@ -574,7 +587,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
     if (!first) {
       return { presence: "available", busy: "unknown" };
     }
-    await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? DEFAULT_ITERM2_SAMPLE_DELAY_MS);
+    await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? this.gatingPolicy.iTerm2SampleDelayMs);
     const second = await this.readBufferTail(it2api, sessionId);
     if (!second) {
       return { presence: "available", busy: "unknown" };
@@ -588,7 +601,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
       });
       return { presence: "available", busy: "busy" };
     }
-    if (containsActiveBufferMarker(second)) {
+    if (containsActiveBufferMarker(second, this.gatingPolicy.activeBufferMarkers)) {
       this.logger.trace("probe_cli_result", {
         sessionId,
         result: { presence: "available", busy: "busy" },
@@ -632,7 +645,7 @@ export class Iterm2TerminalStateProbe implements TerminalStateProbe {
   private async readBufferTail(it2api: string, sessionId: string): Promise<string | null> {
     try {
       const result = await this.execAsync(it2api, ["get-buffer", sessionId]);
-      return normalizeBufferTail(result.stdout);
+      return normalizeBufferTail(result.stdout, this.gatingPolicy.normalizedBufferTailLines);
     } catch {
       return null;
     }
@@ -647,6 +660,7 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
       sleep?: (ms: number) => Promise<void>;
     } = {},
     private readonly logger: Logger = new NoopLogger(),
+    private readonly gatingPolicy: GatingPolicy = DEFAULT_GATING_POLICY,
   ) {}
 
   supports(target: TerminalActivationTarget): boolean {
@@ -700,7 +714,7 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
     if (!first) {
       return { presence: "available", busy: "unknown" };
     }
-    await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? DEFAULT_TMUX_SAMPLE_DELAY_MS);
+    await (this.options.sleep ?? sleep)(this.options.sampleDelayMs ?? this.gatingPolicy.tmuxSampleDelayMs);
     const second = await this.readBufferTail(paneId);
     if (!second) {
       return { presence: "available", busy: "unknown" };
@@ -715,7 +729,7 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
       });
       return { presence: "available", busy: "busy" };
     }
-    if (containsActiveBufferMarker(second)) {
+    if (containsActiveBufferMarker(second, this.gatingPolicy.activeBufferMarkers)) {
       this.logger.trace("probe_result", {
         targetId: target.targetId,
         paneId,
@@ -781,19 +795,19 @@ export class TmuxTerminalStateProbe implements TerminalStateProbe {
 
   private async readBufferTail(paneId: string): Promise<string | null> {
     try {
-      const result = await this.execAsync("tmux", ["capture-pane", "-p", "-t", paneId, "-S", `-${NORMALIZED_BUFFER_TAIL_LINES}`]);
-      return normalizeBufferTail(result.stdout);
+      const result = await this.execAsync("tmux", ["capture-pane", "-p", "-t", paneId, "-S", `-${this.gatingPolicy.normalizedBufferTailLines}`]);
+      return normalizeBufferTail(result.stdout, this.gatingPolicy.normalizedBufferTailLines);
     } catch {
       return null;
     }
   }
 }
 
-function containsActiveBufferMarker(bufferTail: string): boolean {
-  return ACTIVE_BUFFER_MARKERS.some((marker) => bufferTail.includes(marker));
+function containsActiveBufferMarker(bufferTail: string, markers: readonly string[] = DEFAULT_GATING_POLICY.activeBufferMarkers): boolean {
+  return markers.some((marker) => bufferTail.includes(marker));
 }
 
-function hasVisibleTypingPrompt(bufferTail: string, prefixes: readonly string[] = TYPING_PROMPT_PREFIXES): boolean {
+function hasVisibleTypingPrompt(bufferTail: string, prefixes: readonly string[] = DEFAULT_GATING_POLICY.typingPromptPrefixes): boolean {
   const lines = bufferTail
     .split("\n")
     .map((line) => line.trimEnd())
@@ -861,7 +875,7 @@ function typingPromptPrefixesForRuntime(runtimeKind: TerminalActivationTarget["r
   if (runtimeKind === "claude_code") {
     return ["❯ ", "› "];
   }
-  return TYPING_PROMPT_PREFIXES;
+  return DEFAULT_GATING_POLICY.typingPromptPrefixes;
 }
 
 function parseOptionalInt(value: string | undefined): number | null {
@@ -872,19 +886,19 @@ function parseOptionalInt(value: string | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function normalizeBufferTail(buffer: string): string | null {
+function normalizeBufferTail(buffer: string, tailLines = DEFAULT_GATING_POLICY.normalizedBufferTailLines): string | null {
   const normalized = buffer
     .replace(/\r/g, "")
     .split("\n")
     .map((line) => line.trimEnd())
-    .slice(-NORMALIZED_BUFFER_TAIL_LINES)
+    .slice(-tailLines)
     .join("\n")
     .trim();
   return normalized.length > 0 ? normalized : null;
 }
 
-function normalizeProbeTailFromLines(lines: readonly string[]): string | null {
-  return normalizeBufferTail(lines.join("\n"));
+function normalizeProbeTailFromLines(lines: readonly string[], tailLines = DEFAULT_GATING_POLICY.normalizedBufferTailLines): string | null {
+  return normalizeBufferTail(lines.join("\n"), tailLines);
 }
 
 function resolveIterm2ApiPath(override?: string): string {

--- a/src/service.ts
+++ b/src/service.ts
@@ -1717,6 +1717,7 @@ export class AgentInboxService {
   private upsertTerminalActivationTarget(agentId: string, input: RegisterAgentInput, now: string): TerminalActivationTarget {
     const existing = findExistingTerminalActivationTarget(this.store, input);
     if (existing) {
+      const existingPolicy = notificationPolicyForTarget(existing);
       const target = this.store.updateTerminalActivationTargetHeartbeat(existing.targetId, {
         runtimeKind: input.runtimeKind ?? "unknown",
         runtimeSessionId: input.runtimeSessionId ?? null,
@@ -1725,8 +1726,8 @@ export class AgentInboxService {
         tty: input.tty ?? null,
         termProgram: input.termProgram ?? null,
         itermSessionId: input.itermSessionId ?? null,
-        notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_NOTIFY_LEASE_MS,
-        minUnackedItems: input.minUnackedItems ?? null,
+        notifyLeaseMs: input.notifyLeaseMs ?? existingPolicy.notifyLeaseMs,
+        minUnackedItems: input.minUnackedItems ?? existingPolicy.minUnackedItems ?? null,
         updatedAt: now,
         lastSeenAt: now,
       });

--- a/src/service.ts
+++ b/src/service.ts
@@ -18,6 +18,7 @@ import {
   Inbox,
   InboxItem,
   InboxWatchEvent,
+  NotificationPolicy,
   PreviewSourceSchemaInput,
   RegisterAgentInput,
   RegisterAgentResult,
@@ -67,7 +68,7 @@ import {
   TerminalDispatcher,
 } from "./terminal";
 import { LifecycleSignal } from "./sources/remote_modules";
-import { ActivationGate, DefaultActivationGate } from "./runtime_gate";
+import { ActivationGate, DefaultActivationGate, GatingPolicy } from "./runtime_gate";
 import { Logger, NoopLogger } from "./logging";
 import { compatSourceTypeForStream, hostTypeForSourceType, resolveLegacySource, streamKindForSourceType } from "./source_hosts";
 
@@ -164,6 +165,7 @@ export class AgentInboxService {
     terminalDispatcher: TerminalDispatcher = new TerminalDispatcher(),
     activationGate?: ActivationGate,
     logger: Logger = new NoopLogger(),
+    gatingPolicy?: GatingPolicy,
   ) {
     this.activationDispatcher = activationDispatcher;
     this.backend = backend ?? new SqliteEventBusBackend(store);
@@ -172,7 +174,7 @@ export class AgentInboxService {
     this.ackedRetentionMs = DEFAULT_ACKED_RETENTION_MS;
     this.terminalDispatcher = terminalDispatcher;
     this.logger = logger;
-    this.activationGate = activationGate ?? new DefaultActivationGate(undefined, undefined, this.logger.child("gate"));
+    this.activationGate = activationGate ?? new DefaultActivationGate(undefined, undefined, this.logger.child("gate"), gatingPolicy);
   }
 
   private readonly activationDispatcher: ActivationDispatcher;
@@ -557,6 +559,7 @@ export class AgentInboxService {
 
   registerAgent(input: RegisterAgentInput): RegisterAgentResult {
     validateNotifyLeaseMs(input.notifyLeaseMs);
+    validateMinUnackedItems(input.minUnackedItems);
     validateTerminalRegistration(input);
 
     const runtimeKind = input.runtimeKind ?? "unknown";
@@ -772,6 +775,7 @@ export class AgentInboxService {
   addWebhookActivationTarget(agentId: string, input: AddWebhookActivationTargetInput): WebhookActivationTarget {
     this.getAgent(agentId);
     validateNotifyLeaseMs(input.notifyLeaseMs);
+    validateMinUnackedItems(input.minUnackedItems);
     const mode = normalizeWebhookActivationMode(input.activationMode);
     const now = nowIso();
     const target: WebhookActivationTarget = {
@@ -786,6 +790,11 @@ export class AgentInboxService {
       mode,
       url: input.url,
       notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_NOTIFY_LEASE_MS,
+      minUnackedItems: input.minUnackedItems ?? null,
+      notificationPolicy: {
+        notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_NOTIFY_LEASE_MS,
+        minUnackedItems: input.minUnackedItems ?? null,
+      },
       createdAt: now,
       updatedAt: now,
       lastSeenAt: now,
@@ -1716,6 +1725,8 @@ export class AgentInboxService {
         tty: input.tty ?? null,
         termProgram: input.termProgram ?? null,
         itermSessionId: input.itermSessionId ?? null,
+        notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_NOTIFY_LEASE_MS,
+        minUnackedItems: input.minUnackedItems ?? null,
         updatedAt: now,
         lastSeenAt: now,
       });
@@ -1737,6 +1748,11 @@ export class AgentInboxService {
       lastError: null,
       mode: "agent_prompt",
       notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_NOTIFY_LEASE_MS,
+      minUnackedItems: input.minUnackedItems ?? null,
+      notificationPolicy: {
+        notifyLeaseMs: input.notifyLeaseMs ?? DEFAULT_NOTIFY_LEASE_MS,
+        minUnackedItems: input.minUnackedItems ?? null,
+      },
       runtimeKind: input.runtimeKind ?? "unknown",
       runtimeSessionId: input.runtimeSessionId ?? null,
       runtimePid: input.runtimePid ?? null,
@@ -1862,7 +1878,8 @@ export class AgentInboxService {
     const entries = buffer.pending.splice(0, buffer.pending.length);
     try {
       const state = this.store.getActivationDispatchState(buffer.agentId, buffer.targetId);
-      if (!state) {
+      const shouldAttemptDispatch = !state || (state.status === "dirty" && state.leaseExpiresAt == null);
+      if (shouldAttemptDispatch) {
         const inbox = this.ensureInboxForAgent(buffer.agentId);
         const unackedItems = this.store.listInboxItems(inbox.inboxId, { includeAcked: false }).map((item) => ({
           itemId: item.itemId,
@@ -1878,15 +1895,34 @@ export class AgentInboxService {
         const dispatched = await this.dispatchActivationTarget({
           agentId: buffer.agentId,
           targetId: buffer.targetId,
-          newItemCount: entries.length,
+          newItemCount: state ? state.pendingNewItemCount + entries.length : entries.length,
           totalUnackedCount: unackedItems.length,
-          summary: latestSummary(entries),
-          subscriptionIds: uniqueSortedNullable(entries.map((entry) => entry.subscriptionId)),
-          sourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
+          summary: state ? latestSummary(entries) ?? state.pendingSummary : latestSummary(entries),
+          subscriptionIds: state
+            ? uniqueSortedNullable([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)])
+            : uniqueSortedNullable(entries.map((entry) => entry.subscriptionId)),
+          sourceIds: state
+            ? uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)])
+            : uniqueSorted(entries.map((entry) => entry.sourceId)),
           items: unackedItems,
         });
         if (dispatched === "retryable_failure") {
-          this.upsertDirtyDispatchState(buffer.agentId, buffer.targetId, entries);
+          if (state && state.status === "dirty" && state.leaseExpiresAt == null) {
+            this.store.upsertActivationDispatchState({
+              agentId: buffer.agentId,
+              targetId: buffer.targetId,
+              status: "dirty",
+              leaseExpiresAt: new Date(Date.now() + DEFAULT_NOTIFY_RETRY_MS).toISOString(),
+              lastNotifiedFingerprint: state.lastNotifiedFingerprint,
+              pendingNewItemCount: state.pendingNewItemCount + entries.length,
+              pendingSummary: latestSummary(entries) ?? state.pendingSummary,
+              pendingSubscriptionIds: uniqueSortedNullable([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)]),
+              pendingSourceIds: uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)]),
+              updatedAt: nowIso(),
+            });
+          } else {
+            this.upsertDirtyDispatchState(buffer.agentId, buffer.targetId, entries);
+          }
         }
       } else {
         this.store.upsertActivationDispatchState({
@@ -1943,6 +1979,7 @@ export class AgentInboxService {
       return;
     }
 
+    const target = this.getActivationTarget(targetId);
     const inbox = this.ensureInboxForAgent(agentId);
     const unacked = this.store.countInboxItems(inbox.inboxId, false);
     if (unacked === 0) {
@@ -1950,11 +1987,21 @@ export class AgentInboxService {
       return;
     }
 
+    if (!meetsNotificationThreshold(notificationPolicyForTarget(target), unacked)) {
+      this.store.upsertActivationDispatchState({
+        ...state,
+        status: "dirty",
+        leaseExpiresAt: null,
+        pendingNewItemCount: state.pendingNewItemCount > 0 ? state.pendingNewItemCount : unacked,
+        updatedAt: nowIso(),
+      });
+      return;
+    }
+
     if (reason === "ack" && state.status !== "dirty") {
       return;
     }
     if (reason === "lease" && state.status === "notified") {
-      const target = this.getActivationTarget(targetId);
       if (target.kind !== "terminal") {
         // Webhook targets keep the existing lease-based behavior.
       } else {
@@ -2020,6 +2067,29 @@ export class AgentInboxService {
     const inbox = this.ensureInboxForAgent(input.agentId);
     const summary = summarizeActivation(inbox.inboxId, input.newItemCount, input.summary);
     const totalUnackedCount = input.totalUnackedCount ?? this.store.countInboxItems(inbox.inboxId, false);
+    const notificationPolicy = notificationPolicyForTarget(target);
+    if (!meetsNotificationThreshold(notificationPolicy, totalUnackedCount)) {
+      this.logger.debug("activation.dispatch_suppressed", {
+        agentId: input.agentId,
+        targetId: target.targetId,
+        reason: "min_unacked_items",
+        totalUnackedCount,
+        minUnackedItems: notificationPolicy.minUnackedItems ?? null,
+      });
+      this.store.upsertActivationDispatchState({
+        agentId: input.agentId,
+        targetId: input.targetId,
+        status: "dirty",
+        leaseExpiresAt: null,
+        lastNotifiedFingerprint: state?.lastNotifiedFingerprint ?? null,
+        pendingNewItemCount: input.newItemCount,
+        pendingSummary: input.summary,
+        pendingSubscriptionIds: uniqueSortedNullable(input.subscriptionIds),
+        pendingSourceIds: uniqueSorted(input.sourceIds),
+        updatedAt: nowIso(),
+      });
+      return "suppressed";
+    }
     let terminalPrompt: string | null = null;
     try {
       if (target.kind === "terminal") {
@@ -2898,6 +2968,29 @@ function validateNotifyLeaseMs(value: number | null | undefined): void {
   if (!Number.isInteger(value) || value <= 0) {
     throw new Error("notifyLeaseMs must be a positive integer");
   }
+}
+
+function validateMinUnackedItems(value: number | null | undefined): void {
+  if (value == null) {
+    return;
+  }
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error("minUnackedItems must be a positive integer");
+  }
+}
+
+function notificationPolicyForTarget(target: ActivationTarget): NotificationPolicy {
+  return target.notificationPolicy ?? {
+    notifyLeaseMs: target.notifyLeaseMs,
+    minUnackedItems: target.minUnackedItems ?? null,
+  };
+}
+
+function meetsNotificationThreshold(policy: NotificationPolicy, totalUnackedCount: number): boolean {
+  if (policy.minUnackedItems == null) {
+    return true;
+  }
+  return totalUnackedCount >= policy.minUnackedItems;
 }
 
 function normalizeWebhookActivationMode(mode: AddWebhookActivationTargetInput["activationMode"]): WebhookActivationTarget["mode"] {

--- a/src/store.ts
+++ b/src/store.ts
@@ -764,8 +764,8 @@ export class AgentInboxStore {
         `
         insert into activation_targets (
           target_id, agent_id, kind, status, offline_since, consecutive_failures, last_delivered_at, last_error,
-          mode, notify_lease_ms, url, created_at, updated_at, last_seen_at
-        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          mode, notify_lease_ms, min_unacked_items, url, created_at, updated_at, last_seen_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         [
           target.targetId,
@@ -778,6 +778,7 @@ export class AgentInboxStore {
           target.lastError ?? null,
           target.mode,
           target.notifyLeaseMs,
+          target.minUnackedItems ?? null,
           target.url,
           target.createdAt,
           target.updatedAt,
@@ -788,10 +789,10 @@ export class AgentInboxStore {
       this.db.run(
         `
         insert into activation_targets (
-          target_id, agent_id, kind, status, offline_since, consecutive_failures, last_delivered_at, last_error, mode, notify_lease_ms,
+          target_id, agent_id, kind, status, offline_since, consecutive_failures, last_delivered_at, last_error, mode, notify_lease_ms, min_unacked_items,
           runtime_kind, runtime_session_id, runtime_pid, backend, tmux_pane_id, tty, term_program, iterm_session_id,
           created_at, updated_at, last_seen_at
-        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         [
           target.targetId,
@@ -804,6 +805,7 @@ export class AgentInboxStore {
           target.lastError ?? null,
           target.mode,
           target.notifyLeaseMs,
+          target.minUnackedItems ?? null,
           target.runtimeKind,
           target.runtimeSessionId ?? null,
           target.runtimePid ?? null,
@@ -831,6 +833,8 @@ export class AgentInboxStore {
       tty?: string | null;
       termProgram?: string | null;
       itermSessionId?: string | null;
+      notifyLeaseMs?: number;
+      minUnackedItems?: number | null;
       updatedAt: string;
       lastSeenAt: string;
     },
@@ -839,7 +843,7 @@ export class AgentInboxStore {
       `
       update activation_targets
       set status = 'active', offline_since = null, last_error = null, consecutive_failures = 0,
-          runtime_kind = ?, runtime_session_id = ?, runtime_pid = ?, tmux_pane_id = ?, tty = ?, term_program = ?, iterm_session_id = ?, updated_at = ?, last_seen_at = ?
+          runtime_kind = ?, runtime_session_id = ?, runtime_pid = ?, tmux_pane_id = ?, tty = ?, term_program = ?, iterm_session_id = ?, notify_lease_ms = ?, min_unacked_items = ?, updated_at = ?, last_seen_at = ?
       where target_id = ? and kind = 'terminal'
     `,
       [
@@ -850,6 +854,8 @@ export class AgentInboxStore {
         input.tty ?? null,
         input.termProgram ?? null,
         input.itermSessionId ?? null,
+        input.notifyLeaseMs ?? null,
+        input.minUnackedItems ?? null,
         input.updatedAt,
         input.lastSeenAt,
         targetId,
@@ -1782,6 +1788,11 @@ export class AgentInboxStore {
         mode: row.mode as WebhookActivationTarget["mode"],
         url,
         notifyLeaseMs: Number(row.notify_lease_ms),
+        minUnackedItems: row.min_unacked_items == null ? null : Number(row.min_unacked_items),
+        notificationPolicy: {
+          notifyLeaseMs: Number(row.notify_lease_ms),
+          minUnackedItems: row.min_unacked_items == null ? null : Number(row.min_unacked_items),
+        },
         createdAt: String(row.created_at),
         updatedAt: String(row.updated_at),
         lastSeenAt: String(row.last_seen_at),
@@ -1798,6 +1809,11 @@ export class AgentInboxStore {
       lastError: row.last_error ? String(row.last_error) : null,
       mode: row.mode as TerminalActivationTarget["mode"],
       notifyLeaseMs: Number(row.notify_lease_ms),
+      minUnackedItems: row.min_unacked_items == null ? null : Number(row.min_unacked_items),
+      notificationPolicy: {
+        notifyLeaseMs: Number(row.notify_lease_ms),
+        minUnackedItems: row.min_unacked_items == null ? null : Number(row.min_unacked_items),
+      },
       runtimeKind: (row.runtime_kind ? String(row.runtime_kind) : "unknown") as TerminalActivationTarget["runtimeKind"],
       runtimeSessionId: row.runtime_session_id ? String(row.runtime_session_id) : null,
       runtimePid: row.runtime_pid == null ? null : Number(row.runtime_pid),

--- a/src/store.ts
+++ b/src/store.ts
@@ -833,8 +833,8 @@ export class AgentInboxStore {
       tty?: string | null;
       termProgram?: string | null;
       itermSessionId?: string | null;
-      notifyLeaseMs?: number;
-      minUnackedItems?: number | null;
+      notifyLeaseMs: number;
+      minUnackedItems: number | null;
       updatedAt: string;
       lastSeenAt: string;
     },
@@ -854,8 +854,8 @@ export class AgentInboxStore {
         input.tty ?? null,
         input.termProgram ?? null,
         input.itermSessionId ?? null,
-        input.notifyLeaseMs ?? null,
-        input.minUnackedItems ?? null,
+        input.notifyLeaseMs,
+        input.minUnackedItems,
         input.updatedAt,
         input.lastSeenAt,
         targetId,

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2679,6 +2679,44 @@ test("lease reminders stay suppressed while unacked items remain below minUnacke
   }
 });
 
+test("re-registering a terminal agent preserves notification policy when flags are omitted", async () => {
+  const { service, dir, store } = await makeService({
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-policy-preserve",
+      tmuxPaneId: "%422",
+      notifyLeaseMs: 250,
+      minUnackedItems: 4,
+    });
+
+    const rebound = service.registerAgent({
+      agentId: registered.agent.agentId,
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-policy-preserve",
+      tmuxPaneId: "%422",
+    });
+
+    assert.equal(rebound.terminalTarget.targetId, registered.terminalTarget.targetId);
+    assert.equal(rebound.terminalTarget.notifyLeaseMs, 250);
+    assert.equal(rebound.terminalTarget.minUnackedItems, 4);
+    assert.deepEqual(rebound.terminalTarget.notificationPolicy, {
+      notifyLeaseMs: 250,
+      minUnackedItems: 4,
+    });
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("terminal activation prompts use the current unacked inbox total", async () => {
   const terminalDispatcher = new RecordingTerminalDispatcher();
   const { service, dir, store } = await makeService({

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2551,6 +2551,134 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
   }
 });
 
+test("notification thresholds defer activation until minUnackedItems is reached", async () => {
+  const dispatcher = new RecordingActivationDispatcher();
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { store, service, dir } = await makeService({
+    dispatcher,
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-threshold-gated",
+      tmuxPaneId: "%420",
+      notifyLeaseMs: 100,
+      minUnackedItems: 2,
+    });
+    service.addWebhookActivationTarget(registered.agent.agentId, {
+      url: "http://127.0.0.1:9999/webhook",
+      activationMode: "activation_with_items",
+      notifyLeaseMs: 100,
+      minUnackedItems: 2,
+    });
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-event-threshold-gated",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-threshold-1",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(dispatcher.calls.length, 0);
+    assert.equal(terminalDispatcher.calls.length, 0);
+    const statesAfterFirst = store.listActivationDispatchStatesForAgent(registered.agent.agentId);
+    assert.equal(statesAfterFirst.length, 2);
+    assert.ok(statesAfterFirst.every((state) => state.status === "dirty" && state.leaseExpiresAt === null));
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-threshold-2",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(dispatcher.calls.length, 1);
+    assert.equal(terminalDispatcher.calls.length, 1);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("lease reminders stay suppressed while unacked items remain below minUnackedItems", async () => {
+  const terminalDispatcher = new RecordingTerminalDispatcher();
+  const { service, dir, store } = await makeService({
+    terminalDispatcher,
+    activationWindowMs: 20,
+    activationMaxItems: 20,
+    activationGate: new FixedActivationGate("inject", "test"),
+  });
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-threshold-reminder",
+      tmuxPaneId: "%421",
+      notifyLeaseMs: 50,
+      minUnackedItems: 2,
+    });
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "local-event-threshold-reminder",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: registered.agent.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEventByCaller(source.sourceId, {
+      sourceNativeId: "evt-threshold-reminder-1",
+      eventVariant: "message.created",
+      metadata: {},
+      rawPayload: {},
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 0);
+    let state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    assert.ok(state);
+    assert.equal(state.status, "dirty");
+    assert.equal(state.leaseExpiresAt, null);
+
+    await sleep(70);
+    await (service as any).syncActivationDispatchStates();
+    await sleep(40);
+
+    assert.equal(terminalDispatcher.calls.length, 0);
+    state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    assert.ok(state);
+    assert.equal(state.status, "dirty");
+    assert.equal(state.leaseExpiresAt, null);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("terminal activation prompts use the current unacked inbox total", async () => {
   const terminalDispatcher = new RecordingTerminalDispatcher();
   const { service, dir, store } = await makeService({

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -813,6 +813,33 @@ test("cli resolves current agent, auto-registers session workflows, and warns on
   }
 });
 
+test("cli agent register accepts min-unacked-items", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-cli-pol-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%903",
+    CODEX_THREAD_ID: "thread-cli-policy",
+  };
+
+  try {
+    const register = runCli(["agent", "register", "--notify-lease-ms", "200", "--min-unacked-items", "3"], env);
+    assert.equal(register.status, 0, register.stderr);
+    const payload = JSON.parse(register.stdout) as {
+      agent: { agentId: string };
+      terminalTarget: { notifyLeaseMs: number; minUnackedItems: number | null };
+    };
+    assert.equal(payload.terminalTarget.notifyLeaseMs, 200);
+    assert.equal(payload.terminalTarget.minUnackedItems, 3);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli source schema resolves source ids to instance schema", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-schema-"));
   const env = {
@@ -2154,6 +2181,85 @@ test("control plane accepts direct inbox text messages and rejects blank payload
   } finally {
     await adapters.stop();
     webhookServer.close();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane accepts notification policy thresholds for agent and webhook targets", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-http-pol-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters, undefined, undefined, {
+    windowMs: 10,
+    maxItems: 1,
+  }, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+
+      const agentResponse = await client.request<{
+        agent: { agentId: string };
+        terminalTarget: { notifyLeaseMs: number; minUnackedItems: number | null; notificationPolicy?: { notifyLeaseMs: number; minUnackedItems: number | null } };
+      }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-policy-http",
+        tmuxPaneId: "%166",
+        notifyLeaseMs: 200,
+        minUnackedItems: 3,
+      });
+      assert.equal(agentResponse.statusCode, 200);
+      const agentId = agentResponse.data.agent.agentId;
+      assert.equal(agentResponse.data.terminalTarget.notifyLeaseMs, 200);
+      assert.equal(agentResponse.data.terminalTarget.minUnackedItems, 3);
+      assert.deepEqual(agentResponse.data.terminalTarget.notificationPolicy, {
+        notifyLeaseMs: 200,
+        minUnackedItems: 3,
+      });
+
+      const targetResponse = await client.request<{
+        targetId: string;
+        notifyLeaseMs: number;
+        minUnackedItems: number | null;
+        notificationPolicy?: { notifyLeaseMs: number; minUnackedItems: number | null };
+      }>(`/agents/${encodeURIComponent(agentId)}/targets`, {
+        kind: "webhook",
+        url: "http://127.0.0.1:9999/activate",
+        activationMode: "activation_only",
+        notifyLeaseMs: 300,
+        minUnackedItems: 5,
+      });
+      assert.equal(targetResponse.statusCode, 200);
+      assert.equal(targetResponse.data.notifyLeaseMs, 300);
+      assert.equal(targetResponse.data.minUnackedItems, 5);
+      assert.deepEqual(targetResponse.data.notificationPolicy, {
+        notifyLeaseMs: 300,
+        minUnackedItems: 5,
+      });
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
     await service.stop();
     store.close();
     fs.rmSync(homeDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add target-facing notification policy thresholding with `minUnackedItems`
- keep activation batching daemon-level and collect terminal probe knobs under internal gating policy
- expose the new threshold through CLI/HTTP while preserving flat request shapes

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit test/runtime_gate.test.ts
- node --require ts-node/register --test --test-force-exit --test-name-pattern "notification thresholds defer activation until minUnackedItems is reached|lease reminders stay suppressed while unacked items remain below minUnackedItems|webhook and terminal targets share ack-gated notification flow|terminal activation prompts use the current unacked inbox total|lease expiry does not repeat identical terminal prompts for unchanged inbox state|dirty terminal reminders re-notify only when the effective prompt changes" test/agentinbox.test.ts
- node --require ts-node/register --test --test-force-exit --test-name-pattern "control plane accepts notification policy thresholds for agent and webhook targets|cli agent register accepts min-unacked-items" test/control_plane.test.ts
