### PR TITLE
feat: add digest-threaded inbox entries

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -24,6 +24,7 @@ webhook targets.
 ## RFCs
 
 - [Event Filtering RFC](./rfcs/event-filtering.md)
+- [Inbox Digests And Threaded Notification Entries](./rfcs/inbox-digests-and-threaded-notification-entries.md)
 
 ## Current Status
 

--- a/docs/site/rfcs/README.md
+++ b/docs/site/rfcs/README.md
@@ -3,6 +3,7 @@
 - [Event Filtering](./event-filtering.md)
 - [Source Kinds And Resolved Schemas](./source-kinds-and-resolved-schemas.md)
 - [Subscription Lifecycle And Terminal Auto-Retire](./subscription-lifecycle-and-terminal-retire.md)
+- [Inbox Digests And Threaded Notification Entries](./inbox-digests-and-threaded-notification-entries.md)
 
 <!-- INDEX:START -->
 
@@ -12,6 +13,10 @@
 
 - [Delivery Handles And Source-Specific Operations](./delivery-handles-and-operations.md)
   2026-04-16 · Keep outbound delivery in AgentInbox, but standardize handle routing and source-specific operations instead of forcing all providers into one generic send action.
+  <!-- mdorigin:index kind=article -->
+
+- [Inbox Digests And Threaded Notification Entries](./inbox-digests-and-threaded-notification-entries.md)
+  2026-04-17 · Reduce bursty notification noise by keeping raw inbox items immutable, while materializing agent-facing digest threads and immutable digest snapshots for read, activation, and ack.
   <!-- mdorigin:index kind=article -->
 
 - [Source Hosts And Streams](./source-hosts-and-streams.md)

--- a/docs/site/rfcs/inbox-digests-and-threaded-notification-entries.md
+++ b/docs/site/rfcs/inbox-digests-and-threaded-notification-entries.md
@@ -1,0 +1,560 @@
+---
+title: Inbox Digests And Threaded Notification Entries
+date: 2026-04-17
+type: page
+summary: Reduce bursty notification noise by keeping raw inbox items immutable, while materializing agent-facing digest threads and immutable digest snapshots for read, activation, and ack.
+---
+
+# Inbox Digests And Threaded Notification Entries
+
+## Summary
+
+`AgentInbox` should reduce bursty notification noise without hiding or
+destroying the original source events.
+
+The current activation buffer can coalesce bursts into fewer dispatches, but it
+still leaves the runtime with the same core problem:
+
+- the runtime receives fewer wakeups
+- but it still needs to read many raw `InboxItem` records to understand one
+  logical burst
+
+This RFC proposes a two-layer model:
+
+- keep raw `InboxItem` records immutable and durable
+- add an agent-facing read model made of:
+  - stable `InboxEntry` records
+  - logical `DigestThread` grouping
+  - immutable `DigestSnapshot` entries for read, activation, and ack
+
+In this model:
+
+- source events still enter the system one by one
+- aggregation happens after durable ingest, but before activation/read
+- runtimes can read compact digest entries instead of reconstructing grouping
+  themselves
+- ack stays stable by targeting immutable snapshots rather than mutable live
+  threads
+
+## Problem
+
+For bursty sources such as GitHub PR reviews or CI updates, one logical unit of
+work often arrives as many raw events:
+
+- several review comments on the same PR
+- multiple CI status changes on the same branch or PR
+- related timeline or resource updates emitted over a short period
+
+Today `AgentInbox` already batches activation dispatches using a service-level
+window and max-items threshold, but that only reduces activation frequency. It
+does not change the agent-facing read surface.
+
+That means the runtime still has to:
+
+1. receive an activation
+2. read raw inbox items
+3. discover that many items are about the same object
+4. re-aggregate them in runtime logic
+
+This pushes grouping semantics back into the runtime, which conflicts with the
+product boundary.
+
+## Goals
+
+- reduce notification noise for bursty, related source events
+- keep raw inbox items durable and replayable
+- let runtimes read one compact digest instead of reconstructing grouping from
+  many raw items
+- keep ack semantics stable even when a logical digest thread continues to
+  receive new items over time
+- keep source-specific grouping knowledge at the source/module edge, not in
+  generic core heuristics
+- preserve the current shared-source, agent-specific-subscription model
+
+## Non-Goals
+
+- do not delete or replace raw `InboxItem` records with aggregate-only data
+- do not make grouping a source-ingest concern
+- do not move grouping logic into downstream runtimes
+- do not make outbound delivery responsible for aggregation
+- do not force all sources to support grouping on day one
+
+## Design Principles
+
+## 1. Raw Facts Stay Raw
+
+`InboxItem` remains the immutable, durable record of what the source produced.
+
+Aggregation should not mutate or collapse the fact layer. It should build an
+agent-facing read model on top of it.
+
+## 2. Read Units Must Be Stable
+
+If a runtime reads a digest and later acks it, the meaning of that ack must not
+change underneath it.
+
+That means:
+
+- live grouping can evolve over time
+- but read/ack must operate on immutable snapshots
+
+## 3. Grouping Belongs At The Inbox Presentation Boundary
+
+Grouping should happen:
+
+- after item ingest
+- before activation/read
+- inside `AgentInbox`
+
+It should not live:
+
+- in the source adapter’s durable ingest path
+- in outbound delivery
+- in the runtime
+
+## 4. Source Semantics At The Edge
+
+The core should not try to infer too much provider-specific meaning.
+
+Source or module implementations should be able to supply:
+
+- groupability hints
+- resource references
+- event family classification
+- summary hints
+- immediate-flush hints
+
+The core can provide a conservative fallback, but high-quality grouping should
+come from the source edge.
+
+## Current State
+
+Today the relevant pieces are:
+
+- raw `InboxItem` storage
+- subscription matching
+- target notification buffering
+- activation dispatch
+- ack by item id / through item id
+
+The existing activation buffer:
+
+- groups only by target
+- has no concept of resource/thread grouping
+- does not create a stable grouped read model
+- uses summary coalescing only for dispatch, not for inbox read
+
+So it solves “fewer wakeups” but not “fewer things to read”.
+
+## Core Design
+
+## 1. Add An Agent-Facing `InboxEntry` Read Model
+
+`InboxItem` remains the fact layer.
+
+On top of it, `AgentInbox` should introduce a new agent-facing read model:
+
+- `InboxEntry`
+
+An `InboxEntry` is what runtimes read, what activations reference, and what ack
+targets by default.
+
+Suggested entry kinds:
+
+- `item`
+  - a direct pass-through view over one raw `InboxItem`
+- `digest_snapshot`
+  - a compact grouped entry representing many raw inbox items
+
+This means the runtime-facing mailbox becomes a presentation model, not just a
+raw event table.
+
+## 2. Introduce `DigestThread` As The Logical Group
+
+Some related events should continue to accumulate into one logical thread as
+long as that thread remains active and unacked.
+
+Suggested internal object:
+
+- `DigestThread`
+
+Responsibilities:
+
+- own the grouping identity for one logical burst/conversation/object
+- accumulate related raw inbox item ids over time
+- track first/last item timestamps
+- decide whether later items still belong to the same logical thread
+
+`DigestThread` is mutable and long-lived.
+
+It is **not** the object that runtimes ack directly.
+
+## 3. Materialize Immutable `DigestSnapshot` Entries
+
+Because a live thread can change over time, runtimes should never ack the live
+thread directly.
+
+Instead, each visible grouped entry should be an immutable snapshot of a thread
+at a particular revision.
+
+Suggested object:
+
+- `DigestSnapshot`
+
+Suggested fields:
+
+- `entryId`
+- `threadId`
+- `revision`
+- `groupKey`
+- `itemIds`
+- `count`
+- `summary`
+- `firstItemAt`
+- `lastItemAt`
+- `sourceIds`
+- `subscriptionIds`
+- `deliveryHandle?`
+- `sequence`
+- `ackedAt?`
+- `supersededAt?`
+
+Behavior:
+
+- the logical thread can continue to evolve
+- but each snapshot is immutable once created
+- read returns snapshots
+- ack targets snapshots
+
+This is what keeps read/ack semantics stable.
+
+## 4. Grouping Is Keyed By Resource + Event Family
+
+Grouping should be driven by a source/module-provided grouping hint.
+
+Suggested minimum group key components:
+
+- `agentId`
+- `sourceId`
+- `resourceRef`
+- `eventFamily`
+
+Examples:
+
+- `github_repo + pr:135 + review_comments`
+- `github_repo_ci + pr:135 + ci_updates`
+
+Default fallback should be conservative, for example:
+
+- `sourceId + eventVariant`
+
+If a source cannot provide useful grouping semantics, `AgentInbox` should
+prefer under-grouping over incorrect grouping.
+
+## 5. Aggregation Policy Belongs To The Agent-Facing Inbox Layer
+
+Because grouped entries are part of the shared read model for an agent inbox,
+aggregation policy should not be target-specific.
+
+That is an important boundary:
+
+- target notification policy decides **when** to remind
+- inbox aggregation policy decides **what** the runtime reads
+
+Suggested placement:
+
+- agent-level default policy
+- optional subscription-level override later
+
+Phase 1 suggested policy shape:
+
+```ts
+type InboxAggregationPolicy = {
+  enabled?: boolean;
+  windowMs?: number;
+  maxItems?: number;
+  maxThreadAgeMs?: number;
+};
+```
+
+This is separate from:
+
+- `notifyLeaseMs`
+- `minUnackedItems`
+- terminal gating heuristics
+
+## 6. Two-Stage Aggregation: Burst Buffer + Unacked Thread Merge
+
+Pure time-window grouping is not enough.
+
+If grouping only happens within a short flush window, it solves simultaneous
+bursts but not long-lived notification threads like social-network notifications.
+
+So the model should have two stages:
+
+### Stage A: Burst Buffer
+
+New raw items enter a short pending aggregation buffer keyed by the grouping
+key.
+
+This prevents re-materializing the thread on every single event in a burst.
+
+### Stage B: Unacked Thread Merge
+
+When the burst buffer flushes:
+
+- if there is no open digest thread, create one
+- if there is an existing unacked thread with the same group key, merge into
+  that thread
+- materialize a new immutable snapshot for the thread’s new revision
+
+This is what allows cross-time grouping while still keeping stable snapshots.
+
+## 7. Flush Rules
+
+The pending burst buffer should flush when any of these happen:
+
+- `windowMs` expires
+- `maxItems` is reached
+- source/module marks an event as `immediate`
+- host/subscription/agent lifecycle requires cleanup
+
+The logical thread itself should roll over and start a new thread when:
+
+- the previous thread is acked
+- the event family changes in a way that should not merge
+- a source/module marks the event as thread-breaking
+- the thread exceeds `maxThreadAgeMs`
+
+## 8. Source/Module Hooks
+
+`RemoteSourceModule` should be able to provide optional grouping hooks.
+
+Suggested hook shape:
+
+```ts
+deriveNotificationGrouping?(item, source, subscription) => {
+  groupable: boolean;
+  resourceRef?: string | null;
+  eventFamily?: string | null;
+  summaryHint?: string | null;
+  flushClass?: "normal" | "immediate";
+}
+```
+
+Later, modules may also provide:
+
+```ts
+summarizeDigestThread?(items, context) => string | null
+```
+
+This keeps source semantics at the edge:
+
+- GitHub can define PR/resource-aware grouping
+- GitHub CI can define CI burst grouping
+- user-defined remote sources can opt in
+
+## 9. Identifier Strategy
+
+The new aggregation-layer objects should optimize for local operator and
+runtime interaction, not for globally opaque UUID-style identifiers.
+
+For this RFC, the recommended strategy is:
+
+- store `DigestThread` with an integer primary key
+- store `InboxEntry` / `DigestSnapshot` with an integer primary key
+- expose agent-facing refs with typed prefixes
+
+Suggested agent-facing refs:
+
+- `thr_<thread_id>`
+- `ent_<entry_id>`
+
+Examples:
+
+- `thr_12`
+- `ent_42`
+
+This keeps the storage model simple and the agent-facing surface compact:
+
+- lower token cost in LLM-heavy loops
+- easier CLI usage such as `ack --through ent_42`
+- clear type distinction between threads and entries
+
+The database should still keep ordering concerns separate from identity.
+
+Recommended shape:
+
+- `thread_id INTEGER PRIMARY KEY`
+- `entry_id INTEGER PRIMARY KEY`
+- `sequence INTEGER NOT NULL UNIQUE`
+
+Where:
+
+- `thread_id` identifies one logical digest thread
+- `entry_id` identifies one immutable read/ack unit
+- `sequence` defines inbox ordering and `ack --through` boundaries
+
+If phase 1 wants to keep things even simpler, it is acceptable for
+`entry_id == sequence`, but the conceptual model should still treat:
+
+- identity as `entry_id`
+- visible ordering as `sequence`
+
+Formatting and parsing the typed refs should happen at the boundary layer. The
+database itself does not need to store literal strings like `ent_42`.
+
+## Read And Ack Semantics
+
+## 1. Read Returns Stable Entries
+
+Default inbox read should return `InboxEntry[]`, not just raw inbox items.
+
+For grouped bursts, the runtime sees one `digest_snapshot` entry instead of
+many related raw items.
+
+If the runtime wants details, it can explicitly expand a digest snapshot into
+its referenced raw `itemIds`.
+
+## 2. Ack Targets Immutable Snapshots
+
+Ack should continue to support batch semantics, but the ack object should be a
+stable entry boundary.
+
+Recommended behavior:
+
+- `ack entryId`
+- `ack --through <entryId>`
+
+For digest snapshots:
+
+- acking the snapshot acks the raw `InboxItem` set referenced by that snapshot
+- if the logical thread has advanced to a newer revision, later items are not
+  acked implicitly
+
+This preserves stable boundaries even when the underlying digest thread keeps
+growing.
+
+## 3. Superseded Snapshots Stay Valid Ack Boundaries
+
+If a digest thread receives more items and materializes a newer snapshot:
+
+- the older snapshot may be hidden from the default visible read set
+- but it remains a valid ack boundary for any runtime that already read it
+
+This avoids the “read/ack window changed underneath me” problem.
+
+## Activation Semantics
+
+Activation should target `InboxEntry` units, not raw inbox item batches.
+
+That means:
+
+- a burst may generate one digest snapshot activation
+- the runtime reads one digest entry
+- the runtime can expand raw child items only when needed
+
+This keeps activation, read, and ack aligned on the same agent-facing object.
+
+## Compatibility
+
+Phase 1 does not need to remove the raw-item APIs immediately.
+
+A safe rollout path is:
+
+1. keep raw `InboxItem` storage and internal behavior unchanged
+2. add `InboxEntry` and digest thread materialization alongside it
+3. make runtime-facing inbox read default to entries
+4. keep an explicit raw-item read path for debugging, replay, and low-level
+   tooling
+
+This preserves operability while shifting the default experience to grouped
+reads.
+
+## Observability
+
+Aggregation must be observable.
+
+Suggested metrics/events:
+
+- thread created
+- snapshot materialized
+- flush reason (`window`, `size`, `immediate`, `rollover`)
+- group size distribution
+- merge-into-existing-thread count
+- expand-digest-to-raw-item usage
+
+Without these, grouping bugs will be difficult to debug.
+
+## Why Not Only Activation-Level Aggregation
+
+An earlier, simpler option would have been:
+
+- keep inbox read raw
+- only collapse activation dispatch summaries
+
+This is insufficient because it only reduces wakeups, not runtime work.
+
+The runtime would still need to:
+
+- read all raw items
+- regroup them itself
+
+That would move grouping semantics back into runtime logic, which is not the
+intended boundary.
+
+## Why Not Replace Raw Items Entirely
+
+Replacing raw items with only aggregate records would make:
+
+- replay harder
+- debugging harder
+- source correctness harder to verify
+- regrouping impossible without information loss
+
+So raw `InboxItem` records must remain the durable fact layer.
+
+## Phased Rollout
+
+### Phase 1
+
+- land this RFC
+- add simulation tests for:
+  - burst buffering
+  - thread merge
+  - immutable snapshots
+  - ack-through snapshot boundaries
+
+### Phase 2
+
+- implement core digest-thread primitives
+- implement one generic grouping strategy
+- add entry-based inbox read and snapshot-based ack
+
+### Phase 3
+
+- add source/module grouping hooks
+- dogfood with `github_repo` and `github_repo_ci`
+
+## Open Questions
+
+- should digest expansion be part of inbox read, or a separate explicit
+  endpoint?
+- should aggregation policy live at agent inbox level only, or later allow
+  subscription-level override?
+- should non-groupable critical events bypass digest threads entirely, or still
+  attach to the thread with `flushClass = immediate`?
+
+## Conclusion
+
+`AgentInbox` should not stop at reducing activation frequency.
+
+To actually lower runtime overhead, it needs an agent-facing grouped read model
+that:
+
+- preserves raw inbox items as facts
+- materializes digest threads and immutable snapshots
+- aligns activation, read, and ack on the same stable grouped object
+
+That gives `AgentInbox` a real inbox-level notification aggregation model,
+instead of leaving runtimes to rediscover grouping from raw events.

--- a/drizzle/migrations/0011_inbox_entries_and_digest_threads.sql
+++ b/drizzle/migrations/0011_inbox_entries_and_digest_threads.sql
@@ -1,0 +1,78 @@
+alter table inboxes add column aggregation_enabled integer not null default 0;
+alter table inboxes add column aggregation_window_ms integer;
+alter table inboxes add column aggregation_max_items integer;
+alter table inboxes add column aggregation_max_thread_age_ms integer;
+
+create table if not exists digest_threads (
+  thread_id integer primary key autoincrement,
+  inbox_id text not null,
+  source_id text not null,
+  group_key text not null,
+  resource_ref text,
+  event_family text,
+  latest_revision integer not null,
+  latest_entry_id integer,
+  status text not null,
+  summary text not null,
+  first_item_at text not null,
+  last_item_at text not null,
+  flush_after_at text,
+  created_at text not null,
+  updated_at text not null
+);
+
+create index if not exists idx_digest_threads_inbox_status
+  on digest_threads(inbox_id, status);
+
+create index if not exists idx_digest_threads_group_status
+  on digest_threads(inbox_id, group_key, status);
+
+create index if not exists idx_digest_threads_flush_after
+  on digest_threads(status, flush_after_at);
+
+create table if not exists inbox_entries (
+  entry_id integer primary key autoincrement,
+  inbox_id text not null,
+  kind text not null,
+  sequence integer not null unique,
+  thread_id integer,
+  revision integer,
+  group_key text,
+  resource_ref text,
+  event_family text,
+  item_json text,
+  count integer not null,
+  summary text not null,
+  first_item_at text not null,
+  last_item_at text not null,
+  source_ids_json text not null,
+  subscription_ids_json text not null,
+  delivery_handle_json text,
+  acked_at text,
+  superseded_at text,
+  created_at text not null
+);
+
+create index if not exists idx_inbox_entries_inbox_visible
+  on inbox_entries(inbox_id, acked_at, superseded_at, sequence);
+
+create index if not exists idx_inbox_entries_thread_revision
+  on inbox_entries(thread_id, revision);
+
+create table if not exists inbox_entry_items (
+  entry_id integer not null,
+  item_id text not null,
+  primary key (entry_id, item_id)
+);
+
+create index if not exists idx_inbox_entry_items_item
+  on inbox_entry_items(item_id);
+
+create table if not exists digest_thread_items (
+  thread_id integer not null,
+  item_id text not null,
+  primary key (thread_id, item_id)
+);
+
+create index if not exists idx_digest_thread_items_item
+  on digest_thread_items(item_id);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -78,7 +78,7 @@ export const agents = sqliteTable("agents", {
 export const inboxes = sqliteTable("inboxes", {
   inboxId: text("inbox_id").primaryKey(),
   ownerAgentId: text("owner_agent_id").notNull(),
-  aggregationEnabled: integer("aggregation_enabled"),
+  aggregationEnabled: integer("aggregation_enabled").notNull().default(0),
   aggregationWindowMs: integer("aggregation_window_ms"),
   aggregationMaxItems: integer("aggregation_max_items"),
   aggregationMaxThreadAgeMs: integer("aggregation_max_thread_age_ms"),

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -78,6 +78,10 @@ export const agents = sqliteTable("agents", {
 export const inboxes = sqliteTable("inboxes", {
   inboxId: text("inbox_id").primaryKey(),
   ownerAgentId: text("owner_agent_id").notNull(),
+  aggregationEnabled: integer("aggregation_enabled"),
+  aggregationWindowMs: integer("aggregation_window_ms"),
+  aggregationMaxItems: integer("aggregation_max_items"),
+  aggregationMaxThreadAgeMs: integer("aggregation_max_thread_age_ms"),
   createdAt: text("created_at").notNull(),
 }, (table) => ({
   ownerAgentIdUnique: uniqueIndex("idx_inboxes_owner_agent_id").on(table.ownerAgentId),
@@ -172,6 +176,71 @@ export const inboxItems = sqliteTable("inbox_items", {
   inboxAckedAtIdx: index("idx_inbox_items_inbox_acked_at").on(table.inboxId, table.ackedAt),
   inboxSequenceIdx: index("idx_inbox_items_inbox_sequence_order").on(table.inboxId, table.inboxSequence),
   sourceOccurredAtIdx: index("idx_inbox_items_source_occurred_at").on(table.sourceId, table.occurredAt),
+}));
+
+export const digestThreads = sqliteTable("digest_threads", {
+  threadId: integer("thread_id").primaryKey({ autoIncrement: true }),
+  inboxId: text("inbox_id").notNull(),
+  sourceId: text("source_id").notNull(),
+  groupKey: text("group_key").notNull(),
+  resourceRef: text("resource_ref"),
+  eventFamily: text("event_family"),
+  latestRevision: integer("latest_revision").notNull(),
+  latestEntryId: integer("latest_entry_id"),
+  status: text("status").notNull(),
+  summary: text("summary").notNull(),
+  firstItemAt: text("first_item_at").notNull(),
+  lastItemAt: text("last_item_at").notNull(),
+  flushAfterAt: text("flush_after_at"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+}, (table) => ({
+  inboxStatusIdx: index("idx_digest_threads_inbox_status").on(table.inboxId, table.status),
+  groupStatusIdx: index("idx_digest_threads_group_status").on(table.inboxId, table.groupKey, table.status),
+  flushIdx: index("idx_digest_threads_flush_after").on(table.status, table.flushAfterAt),
+}));
+
+export const inboxEntries = sqliteTable("inbox_entries", {
+  entryId: integer("entry_id").primaryKey({ autoIncrement: true }),
+  inboxId: text("inbox_id").notNull(),
+  kind: text("kind").notNull(),
+  sequence: integer("sequence").notNull(),
+  threadId: integer("thread_id"),
+  revision: integer("revision"),
+  groupKey: text("group_key"),
+  resourceRef: text("resource_ref"),
+  eventFamily: text("event_family"),
+  itemJson: text("item_json"),
+  count: integer("count").notNull(),
+  summary: text("summary").notNull(),
+  firstItemAt: text("first_item_at").notNull(),
+  lastItemAt: text("last_item_at").notNull(),
+  sourceIdsJson: text("source_ids_json").notNull(),
+  subscriptionIdsJson: text("subscription_ids_json").notNull(),
+  deliveryHandleJson: text("delivery_handle_json"),
+  ackedAt: text("acked_at"),
+  supersededAt: text("superseded_at"),
+  createdAt: text("created_at").notNull(),
+}, (table) => ({
+  sequenceUnique: uniqueIndex("idx_inbox_entries_sequence").on(table.sequence),
+  inboxVisibleIdx: index("idx_inbox_entries_inbox_visible").on(table.inboxId, table.ackedAt, table.supersededAt, table.sequence),
+  threadRevisionIdx: index("idx_inbox_entries_thread_revision").on(table.threadId, table.revision),
+}));
+
+export const inboxEntryItems = sqliteTable("inbox_entry_items", {
+  entryId: integer("entry_id").notNull(),
+  itemId: text("item_id").notNull(),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.entryId, table.itemId] }),
+  itemIdx: index("idx_inbox_entry_items_item").on(table.itemId),
+}));
+
+export const digestThreadItems = sqliteTable("digest_thread_items", {
+  threadId: integer("thread_id").notNull(),
+  itemId: text("item_id").notNull(),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.threadId, table.itemId] }),
+  itemIdx: index("idx_digest_thread_items_item").on(table.itemId),
 }));
 
 export const activations = sqliteTable("activations", {

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -5,6 +5,7 @@ import {
   DeliveryRequest,
   DeliveryHandle,
   DeliveryOperationDescriptor,
+  NotificationGrouping,
   SubscriptionSource,
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
@@ -205,6 +206,24 @@ export class AdapterRegistry {
       return null;
     }
     return this.remoteSource.deriveInlinePreview(source, item);
+  }
+
+  async deriveNotificationGrouping(source: SubscriptionSource, item: ActivationItem): Promise<NotificationGrouping | null> {
+    if (compatSourceTypeForStream(source) === "local_event") {
+      return null;
+    }
+    return this.remoteSource.deriveNotificationGrouping(source, item);
+  }
+
+  async summarizeDigestThread(
+    source: SubscriptionSource,
+    items: ActivationItem[],
+    grouping: NotificationGrouping,
+  ): Promise<string | null> {
+    if (compatSourceTypeForStream(source) === "local_event") {
+      return null;
+    }
+    return this.remoteSource.summarizeDigestThread(source, items, grouping);
   }
 
   async listDeliveryOperations(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -654,9 +654,28 @@ async function main(): Promise<void> {
 
   if (command === "inbox" && normalized[1] === "read") {
     const args = normalized.slice(2);
+    const allowedFlags = ["--agent-id", "--after-entry", "--include-acked"];
+    if (positionalArgs(args, ["--agent-id", "--after-entry"]).length > 0 || unexpectedFlags(args, allowedFlags).length > 0) {
+      throw new Error("usage: agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked]");
+    }
+    const selection = await selectAgentForCommand(client, {
+      explicitAgentId: takeFlagValue(normalized, "--agent-id"),
+      autoRegister: true,
+    });
+    const query = buildQuery({
+      after_entry_id: takeFlagValue(normalized, "--after-entry"),
+      include_acked: hasFlag(normalized, "--include-acked") ? "true" : undefined,
+    });
+    const response = await requestRemote<Record<string, unknown>>(client, `/agents/${encodeURIComponent(selection.agentId)}/inbox/entries${query}`, undefined, "GET");
+    console.log(jsonResponse(withCommandMetadata(response.data, selection)));
+    return;
+  }
+
+  if (command === "inbox" && normalized[1] === "read-raw") {
+    const args = normalized.slice(2);
     const allowedFlags = ["--agent-id", "--after-item", "--include-acked"];
     if (positionalArgs(args, ["--agent-id", "--after-item"]).length > 0 || unexpectedFlags(args, allowedFlags).length > 0) {
-      throw new Error("usage: agentinbox inbox read [--agent-id ID] [--after-item ID] [--include-acked]");
+      throw new Error("usage: agentinbox inbox read-raw [--agent-id ID] [--after-item ID] [--include-acked]");
     }
     const selection = await selectAgentForCommand(client, {
       explicitAgentId: takeFlagValue(normalized, "--agent-id"),
@@ -666,7 +685,7 @@ async function main(): Promise<void> {
       after_item_id: takeFlagValue(normalized, "--after-item"),
       include_acked: hasFlag(normalized, "--include-acked") ? "true" : undefined,
     });
-    const response = await requestRemote<Record<string, unknown>>(client, `/agents/${encodeURIComponent(selection.agentId)}/inbox/items${query}`, undefined, "GET");
+    const response = await requestRemote<Record<string, unknown>>(client, `/agents/${encodeURIComponent(selection.agentId)}/inbox/raw-items${query}`, undefined, "GET");
     console.log(jsonResponse(withCommandMetadata(response.data, selection)));
     return;
   }
@@ -691,8 +710,8 @@ async function main(): Promise<void> {
 
   if (command === "inbox" && normalized[1] === "watch") {
     const args = normalized.slice(2);
-    if (positionalArgs(args, ["--agent-id", "--after-item", "--heartbeat-ms"]).length > 0) {
-      throw new Error("usage: agentinbox inbox watch [--agent-id ID] [--after-item ID] [--include-acked] [--heartbeat-ms N]");
+    if (positionalArgs(args, ["--agent-id", "--after-entry", "--heartbeat-ms"]).length > 0) {
+      throw new Error("usage: agentinbox inbox watch [--agent-id ID] [--after-entry ID] [--include-acked] [--heartbeat-ms N]");
     }
     const selection = await selectAgentForCommand(client, {
       explicitAgentId: takeFlagValue(normalized, "--agent-id"),
@@ -705,7 +724,7 @@ async function main(): Promise<void> {
       console.log(jsonResponse(metadata));
     }
     for await (const event of client.watchInbox(selection.agentId, {
-      afterItemId: takeFlagValue(normalized, "--after-item"),
+      afterEntryId: takeFlagValue(normalized, "--after-entry"),
       includeAcked: hasFlag(normalized, "--include-acked"),
       heartbeatMs: parseOptionalNumber(takeFlagValue(normalized, "--heartbeat-ms")),
     })) {
@@ -719,12 +738,12 @@ async function main(): Promise<void> {
 
   if (command === "inbox" && normalized[1] === "ack") {
     const args = normalized.slice(2);
-    const itemId = takeFlagValue(normalized, "--item");
+    const itemId = takeFlagValue(normalized, "--entry");
     const throughItemId = takeFlagValue(normalized, "--through");
     const ackAll = hasFlag(normalized, "--all");
     const modeCount = Number(Boolean(itemId)) + Number(Boolean(throughItemId)) + Number(ackAll);
-    if (positionalArgs(args, ["--agent-id", "--item", "--through"]).length > 0 || modeCount !== 1) {
-      throw new Error("usage: agentinbox inbox ack [--agent-id ID] (--through <itemId> | --item <itemId> | --all)");
+    if (positionalArgs(args, ["--agent-id", "--entry", "--through"]).length > 0 || modeCount !== 1) {
+      throw new Error("usage: agentinbox inbox ack [--agent-id ID] (--through <entryId> | --entry <entryId> | --all)");
     }
     const selection = await selectAgentForCommand(client, {
       explicitAgentId: takeFlagValue(normalized, "--agent-id"),
@@ -733,7 +752,41 @@ async function main(): Promise<void> {
     const response = await requestRemote<Record<string, unknown>>(
       client,
       `/agents/${encodeURIComponent(selection.agentId)}/inbox/ack`,
-      ackAll ? { all: true } : (throughItemId ? { throughItemId } : { itemIds: [itemId] }),
+      ackAll ? { all: true } : (throughItemId ? { throughEntryId: throughItemId } : { entryIds: [itemId] }),
+    );
+    console.log(jsonResponse(withCommandMetadata(response.data, selection)));
+    return;
+  }
+
+  if (command === "inbox" && normalized[1] === "policy" && normalized[2] === "show") {
+    const selection = await selectAgentForCommand(client, {
+      explicitAgentId: takeFlagValue(normalized, "--agent-id"),
+      autoRegister: true,
+    });
+    const response = await requestRemote<Record<string, unknown>>(
+      client,
+      `/agents/${encodeURIComponent(selection.agentId)}/inbox/policy`,
+      undefined,
+      "GET",
+    );
+    console.log(jsonResponse(withCommandMetadata(response.data, selection)));
+    return;
+  }
+
+  if (command === "inbox" && normalized[1] === "policy" && normalized[2] === "set") {
+    const selection = await selectAgentForCommand(client, {
+      explicitAgentId: takeFlagValue(normalized, "--agent-id"),
+      autoRegister: true,
+    });
+    const response = await requestRemote<Record<string, unknown>>(
+      client,
+      `/agents/${encodeURIComponent(selection.agentId)}/inbox/policy`,
+      {
+        enabled: hasFlag(normalized, "--enabled") ? true : (hasFlag(normalized, "--disabled") ? false : undefined),
+        windowMs: parseOptionalNumber(takeFlagValue(normalized, "--window-ms")),
+        maxItems: parseOptionalNumber(takeFlagValue(normalized, "--max-items")),
+        maxThreadAgeMs: parseOptionalNumber(takeFlagValue(normalized, "--max-thread-age-ms")),
+      },
     );
     console.log(jsonResponse(withCommandMetadata(response.data, selection)));
     return;
@@ -1337,10 +1390,13 @@ Usage:
 Usage:
   agentinbox inbox list
   agentinbox inbox show <agentId>
-  agentinbox inbox read [--agent-id ID] [--after-item ID] [--include-acked]
+  agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked]
+  agentinbox inbox read-raw [--agent-id ID] [--after-item ID] [--include-acked]
   agentinbox inbox send --agent-id ID --message TEXT [--sender SENDER]
-  agentinbox inbox watch [--agent-id ID] [--after-item ID] [--include-acked] [--heartbeat-ms N]
-  agentinbox inbox ack [--agent-id ID] (--through <itemId> | --item <itemId> | --all)
+  agentinbox inbox watch [--agent-id ID] [--after-entry ID] [--include-acked] [--heartbeat-ms N]
+  agentinbox inbox ack [--agent-id ID] (--through <entryId> | --entry <entryId> | --all)
+  agentinbox inbox policy show [--agent-id ID]
+  agentinbox inbox policy set [--agent-id ID] [--enabled|--disabled] [--window-ms N] [--max-items N] [--max-thread-age-ms N]
   agentinbox inbox compact <agentId>
 `,
     deliver: `agentinbox deliver

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,8 +24,8 @@ export class AgentInboxClient {
 
   watchInbox(agentId: string, options: WatchInboxOptions = {}): AsyncIterable<InboxWatchEvent> {
     const query = new URLSearchParams();
-    if (options.afterItemId) {
-      query.set("after_item_id", options.afterItemId);
+    if (options.afterEntryId ?? options.afterItemId) {
+      query.set("after_entry_id", options.afterEntryId ?? options.afterItemId ?? "");
     }
     if (options.includeAcked) {
       query.set("include_acked", "true");

--- a/src/http.ts
+++ b/src/http.ts
@@ -1352,7 +1352,46 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.getInboxDetailsByAgent(decodeURIComponent(params.agentId));
   });
 
-  app.get("/agents/:agentId/inbox/items", {
+  app.get("/agents/:agentId/inbox/entries", {
+    schema: {
+      tags: ["inbox"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          after_entry_id: { type: "string" },
+          include_acked: { type: "string", enum: ["true", "false"] },
+        },
+      },
+      response: {
+        200: {
+          type: "object",
+          required: ["entries"],
+          properties: {
+            entries: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    const query = request.query as { after_entry_id?: string; include_acked?: "true" | "false" };
+    return {
+      entries: service.listInboxItems(decodeURIComponent(params.agentId), {
+        afterEntryId: query.after_entry_id,
+        includeAcked: query.include_acked ? query.include_acked === "true" : undefined,
+      }),
+    };
+  });
+
+  app.get("/agents/:agentId/inbox/raw-items", {
     schema: {
       tags: ["inbox"],
       params: {
@@ -1384,7 +1423,7 @@ function buildFastifyServer(service: AgentInboxService) {
     const params = request.params as { agentId: string };
     const query = request.query as { after_item_id?: string; include_acked?: "true" | "false" };
     return {
-      items: service.listInboxItems(decodeURIComponent(params.agentId), {
+      items: service.listRawInboxItems(decodeURIComponent(params.agentId), {
         afterItemId: query.after_item_id,
         includeAcked: query.include_acked ? query.include_acked === "true" : undefined,
       }),
@@ -1439,7 +1478,7 @@ function buildFastifyServer(service: AgentInboxService) {
         type: "object",
         additionalProperties: false,
         properties: {
-          after_item_id: { type: "string" },
+          after_entry_id: { type: "string" },
           include_acked: { type: "string", enum: ["true", "false"] },
           heartbeat_ms: { type: "string", pattern: "^[1-9][0-9]*$" },
         },
@@ -1451,13 +1490,13 @@ function buildFastifyServer(service: AgentInboxService) {
   }, async (request, reply) => {
     const params = request.params as { agentId: string };
     const query = request.query as {
-      after_item_id?: string;
+      after_entry_id?: string;
       include_acked?: "true" | "false";
       heartbeat_ms?: string;
     };
     const agentId = decodeURIComponent(params.agentId);
     const watchOptions: WatchInboxOptions = {
-      afterItemId: query.after_item_id,
+      afterEntryId: query.after_entry_id,
       includeAcked: query.include_acked ? query.include_acked === "true" : undefined,
       heartbeatMs: query.heartbeat_ms ? Number(query.heartbeat_ms) : undefined,
     };
@@ -1476,7 +1515,7 @@ function buildFastifyServer(service: AgentInboxService) {
     sendSse(raw, "items", {
       event: "items",
       agentId,
-      items: session.initialItems,
+      entries: session.initialItems,
     });
     session.start();
 
@@ -1532,9 +1571,9 @@ function buildFastifyServer(service: AgentInboxService) {
           {
             type: "object",
             additionalProperties: false,
-            required: ["itemIds"],
+            required: ["entryIds"],
             properties: {
-              itemIds: {
+              entryIds: {
                 type: "array",
                 minItems: 1,
                 items: { type: "string", minLength: 1 },
@@ -1544,9 +1583,9 @@ function buildFastifyServer(service: AgentInboxService) {
           {
             type: "object",
             additionalProperties: false,
-            required: ["throughItemId"],
+            required: ["throughEntryId"],
             properties: {
-              throughItemId: { type: "string", minLength: 1 },
+              throughEntryId: { type: "string", minLength: 1 },
             },
           },
           {
@@ -1567,15 +1606,69 @@ function buildFastifyServer(service: AgentInboxService) {
   }, async (request) => {
     const params = request.params as { agentId: string };
     const body = request.body as {
-      itemIds?: string[];
-      throughItemId?: string;
+      entryIds?: string[];
+      throughEntryId?: string;
       all?: boolean;
     };
     return service.ackInbox(decodeURIComponent(params.agentId), {
-      itemIds: body.itemIds ?? [],
-      throughItemId: body.throughItemId ?? null,
+      itemIds: body.entryIds ?? [],
+      throughItemId: body.throughEntryId ?? null,
       all: body.all ?? false,
     });
+  });
+
+  app.get("/agents/:agentId/inbox/policy", {
+    schema: {
+      tags: ["inbox"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    return service.getInboxAggregationPolicy(decodeURIComponent(params.agentId));
+  });
+
+  app.post("/agents/:agentId/inbox/policy", {
+    schema: {
+      tags: ["inbox"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          enabled: { type: "boolean" },
+          windowMs: { type: "integer", minimum: 1 },
+          maxItems: { type: "integer", minimum: 1 },
+          maxThreadAgeMs: { type: "integer", minimum: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    const body = request.body as {
+      enabled?: boolean;
+      windowMs?: number;
+      maxItems?: number;
+      maxThreadAgeMs?: number;
+    };
+    return service.updateInboxAggregationPolicy(decodeURIComponent(params.agentId), body);
   });
 
   app.post("/deliveries/send", {

--- a/src/model.ts
+++ b/src/model.ts
@@ -84,6 +84,10 @@ export interface Agent {
 export interface Inbox {
   inboxId: string;
   ownerAgentId: string;
+  aggregationEnabled?: boolean;
+  aggregationWindowMs?: number | null;
+  aggregationMaxItems?: number | null;
+  aggregationMaxThreadAgeMs?: number | null;
   createdAt: string;
 }
 
@@ -115,6 +119,13 @@ export interface SubscriptionLifecycleRetirement {
 export interface NotificationPolicy {
   notifyLeaseMs: number;
   minUnackedItems?: number | null;
+}
+
+export interface InboxAggregationPolicy {
+  enabled?: boolean;
+  windowMs?: number | null;
+  maxItems?: number | null;
+  maxThreadAgeMs?: number | null;
 }
 
 interface ActivationTargetBase {
@@ -193,6 +204,56 @@ export interface ActivationItem {
   deliveryHandle?: DeliveryHandle | null;
 }
 
+export type InboxEntryKind = "item" | "digest_snapshot";
+
+interface InboxEntryBase {
+  entryId: string;
+  inboxId: string;
+  kind: InboxEntryKind;
+  sequence: number;
+  itemId: string;
+  sourceId?: string;
+  sourceNativeId?: string;
+  eventVariant?: string;
+  occurredAt?: string;
+  metadata?: Record<string, unknown>;
+  rawPayload?: Record<string, unknown>;
+  summary: string;
+  count: number;
+  itemIds: string[];
+  sourceIds: string[];
+  subscriptionIds: string[];
+  firstItemAt: string;
+  lastItemAt: string;
+  deliveryHandle?: DeliveryHandle | null;
+  ackedAt?: string | null;
+  supersededAt?: string | null;
+}
+
+export interface InboxItemEntry extends InboxEntryBase {
+  kind: "item";
+  item: ActivationItem;
+}
+
+export interface DigestSnapshotEntry extends InboxEntryBase {
+  kind: "digest_snapshot";
+  threadId: string;
+  revision: number;
+  groupKey: string;
+  resourceRef?: string | null;
+  eventFamily?: string | null;
+}
+
+export type InboxEntry = InboxItemEntry | DigestSnapshotEntry;
+
+export interface NotificationGrouping {
+  groupable: boolean;
+  resourceRef?: string | null;
+  eventFamily?: string | null;
+  summaryHint?: string | null;
+  flushClass?: "normal" | "immediate";
+}
+
 export interface Activation {
   kind: "agentinbox.activation";
   activationId: string;
@@ -202,9 +263,11 @@ export interface Activation {
   targetKind: ActivationTargetKind;
   subscriptionIds: string[];
   sourceIds: string[];
+  newEntryCount: number;
   newItemCount: number;
   summary: string;
   items?: ActivationItem[];
+  entries?: InboxEntry[];
   createdAt: string;
   deliveredAt?: string | null;
 }
@@ -476,6 +539,7 @@ export interface SubscriptionPollResult {
 }
 
 export interface ListInboxItemsOptions {
+  afterEntryId?: string;
   afterItemId?: string;
   includeAcked?: boolean;
 }
@@ -487,7 +551,7 @@ export interface WatchInboxOptions extends ListInboxItemsOptions {
 export interface InboxWatchItemsEvent {
   event: "items";
   agentId: string;
-  items: InboxItem[];
+  entries: InboxEntry[];
 }
 
 export interface InboxWatchHeartbeatEvent {

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,8 +16,11 @@ import {
   DeliveryOperationDescriptor,
   DeliveryRequest,
   Inbox,
+  InboxAggregationPolicy,
+  InboxEntry,
   InboxItem,
   InboxWatchEvent,
+  NotificationGrouping,
   NotificationPolicy,
   PreviewSourceSchemaInput,
   RegisterAgentInput,
@@ -55,7 +58,7 @@ import {
   streamKeyForSource,
   toAppendResult,
 } from "./backend";
-import { generateId, nowIso } from "./util";
+import { formatEntryRef, generateId, nowIso } from "./util";
 import { getSourceSchema } from "./source_schema";
 import { withResolvedIdentity } from "./source_resolution";
 import { matchSubscriptionFilter, validateSubscriptionFilter } from "./filter";
@@ -82,6 +85,9 @@ const DEFAULT_OFFLINE_AGENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_GC_INTERVAL_MS = 60 * 1000;
 const DEFAULT_SYNC_INTERVAL_MS = 2_000;
 const DEFAULT_IDLE_SOURCE_GRACE_MS = 5 * 60 * 1000;
+const DEFAULT_INBOX_AGGREGATION_WINDOW_MS = 30 * 1000;
+const DEFAULT_INBOX_AGGREGATION_MAX_ITEMS = 20;
+const DEFAULT_INBOX_AGGREGATION_MAX_THREAD_AGE_MS = 24 * 60 * 60 * 1000;
 const DIRECT_INBOX_SOURCE_ID = "__agentinbox_direct_text__";
 const DIRECT_INBOX_EVENT_VARIANT = "agentinbox.direct_text_message";
 const TIMER_INBOX_SOURCE_ID = "__agentinbox_timer__";
@@ -102,20 +108,20 @@ interface BufferedNotification {
     subscriptionId: string | null;
     sourceId: string;
     summary: string;
-    item: ActivationItem;
+    entry: InboxEntry;
   }>;
   timer: NodeJS.Timeout | null;
   inFlight: boolean;
 }
 
 interface InboxWatcher {
-  onItems(items: InboxItem[]): void;
+  onItems(entries: InboxEntry[]): void;
 }
 
 type ActivationDispatchOutcome = "dispatched" | "retryable_failure" | "offline" | "deferred" | "suppressed";
 
 export interface InboxWatchSession {
-  initialItems: InboxItem[];
+  initialItems: InboxEntry[];
   start(): void;
   close(): void;
 }
@@ -189,12 +195,14 @@ export class AgentInboxService {
     this.stopping = false;
     this.syncInterval = setInterval(() => {
       void this.syncAllSubscriptions();
+      void this.syncPendingDigestThreads();
       void this.syncActivationDispatchStates();
       void this.runAckedInboxGcIfDue();
       void this.syncLifecycleGc();
     }, DEFAULT_SYNC_INTERVAL_MS);
     this.refreshTimersOnStart();
     await this.syncAllSubscriptions();
+    await this.syncPendingDigestThreads();
     await this.syncActivationDispatchStates();
     await this.runAckedInboxGcIfDue(true);
     await this.syncLifecycleGc();
@@ -1062,8 +1070,28 @@ export class AgentInboxService {
     };
   }
 
-  listInboxItems(agentId: string, options?: WatchInboxOptions): InboxItem[] {
+  listInboxItems(agentId: string, options?: WatchInboxOptions): InboxEntry[] {
+    return this.store.listInboxEntries(this.ensureInboxForAgent(agentId).inboxId, options);
+  }
+
+  listRawInboxItems(agentId: string, options?: WatchInboxOptions): InboxItem[] {
     return this.store.listInboxItems(this.ensureInboxForAgent(agentId).inboxId, options);
+  }
+
+  getInboxAggregationPolicy(agentId: string): InboxAggregationPolicy {
+    const inbox = this.ensureInboxForAgent(agentId);
+    return inboxAggregationPolicy(inbox);
+  }
+
+  updateInboxAggregationPolicy(agentId: string, input: InboxAggregationPolicy): InboxAggregationPolicy {
+    const inbox = this.ensureInboxForAgent(agentId);
+    const updated = this.store.updateInboxAggregationPolicy(inbox.inboxId, {
+      enabled: input.enabled,
+      windowMs: input.windowMs,
+      maxItems: input.maxItems,
+      maxThreadAgeMs: input.maxThreadAgeMs,
+    });
+    return inboxAggregationPolicy(updated);
   }
 
   async addDirectInboxTextMessage(
@@ -1159,19 +1187,12 @@ export class AgentInboxService {
         activated: false,
       };
     }
-    this.notifyInboxWatchers(agentId, [item]);
+    const entry = this.store.createInboxItemEntry(inbox.inboxId, item, {
+      summary: input.summary,
+      subscriptionIds: [],
+    });
+    this.notifyInboxWatchers(agentId, [entry]);
 
-    const activationItem: ActivationItem = {
-      itemId: item.itemId,
-      sourceId: item.sourceId,
-      sourceNativeId: item.sourceNativeId,
-      eventVariant: item.eventVariant,
-      inboxId: item.inboxId,
-      occurredAt: item.occurredAt,
-      metadata: item.metadata,
-      rawPayload: item.rawPayload,
-      deliveryHandle: item.deliveryHandle,
-    };
     const targets = this.store.listActivationTargetsForAgent(agentId).filter((target) => target.status === "active");
     for (const target of targets) {
       this.enqueueActivationTarget(target, {
@@ -1179,7 +1200,7 @@ export class AgentInboxService {
         subscriptionId: null,
         sourceId: input.sourceId,
         summary: input.summary,
-        item: activationItem,
+        entry,
       });
     }
 
@@ -1190,33 +1211,154 @@ export class AgentInboxService {
     };
   }
 
+  private async materializeInboxEntryForItem(input: {
+    agentId: string;
+    inbox: Inbox;
+    source: SubscriptionSource | null;
+    subscriptionId: string | null;
+    item: InboxItem;
+    summary: string;
+  }): Promise<InboxEntry[]> {
+    const activationItem = activationItemFromInboxItem(input.item);
+    const policy = inboxAggregationPolicy(input.inbox);
+    if (!policy.enabled || !input.source) {
+      return [this.store.createInboxItemEntry(input.inbox.inboxId, input.item, {
+        summary: input.summary,
+        subscriptionIds: input.subscriptionId ? [input.subscriptionId] : [],
+      })];
+    }
+
+    const grouping = await this.adapters.deriveNotificationGrouping(input.source, activationItem);
+    if (!grouping?.groupable || !grouping.resourceRef || !grouping.eventFamily) {
+      return [this.store.createInboxItemEntry(input.inbox.inboxId, input.item, {
+        summary: input.summary,
+        subscriptionIds: input.subscriptionId ? [input.subscriptionId] : [],
+      })];
+    }
+
+    const groupKey = digestGroupKey(input.source.sourceId, grouping.resourceRef, grouping.eventFamily);
+    let thread = this.store.getOpenDigestThread(input.inbox.inboxId, groupKey);
+    const now = nowIso();
+    if (thread && Date.parse(thread.createdAt) + (policy.maxThreadAgeMs ?? DEFAULT_INBOX_AGGREGATION_MAX_THREAD_AGE_MS) <= Date.now()) {
+      this.store.closeDigestThread(thread.threadId, now);
+      thread = null;
+    }
+    const flushAfterAt = new Date(Date.now() + (policy.windowMs ?? DEFAULT_INBOX_AGGREGATION_WINDOW_MS)).toISOString();
+    if (!thread) {
+      thread = this.store.createDigestThread({
+        inboxId: input.inbox.inboxId,
+        sourceId: input.source.sourceId,
+        groupKey,
+        resourceRef: grouping.resourceRef,
+        eventFamily: grouping.eventFamily,
+        summary: grouping.summaryHint ?? input.summary,
+        firstItemAt: input.item.occurredAt,
+        flushAfterAt,
+        createdAt: now,
+      });
+    } else {
+      thread = this.store.addItemToDigestThread(
+        thread.threadId,
+        input.item.itemId,
+        input.item.occurredAt,
+        grouping.summaryHint ?? thread.summary,
+        flushAfterAt,
+      );
+    }
+    if (!thread || this.store.listUnackedInboxItemsForDigestThread(thread.threadId).find((entry) => entry.itemId === input.item.itemId) == null) {
+      thread = this.store.addItemToDigestThread(
+        thread.threadId,
+        input.item.itemId,
+        input.item.occurredAt,
+        grouping.summaryHint ?? thread.summary,
+        flushAfterAt,
+      );
+    }
+
+    const unacked = this.store.listUnackedInboxItemsForDigestThread(thread.threadId);
+    const shouldFlush = grouping.flushClass === "immediate" || unacked.length >= (policy.maxItems ?? DEFAULT_INBOX_AGGREGATION_MAX_ITEMS);
+    if (!shouldFlush) {
+      return [];
+    }
+    const entry = await this.flushDigestThread(input.source, thread.threadId, grouping);
+    return entry ? [entry] : [];
+  }
+
+  private async flushDigestThread(
+    source: SubscriptionSource,
+    threadId: number,
+    groupingHint?: NotificationGrouping | null,
+  ): Promise<InboxEntry | null> {
+    const thread = this.store.getDigestThread(threadId);
+    if (!thread || thread.status !== "open") {
+      return null;
+    }
+    const items = this.store.listUnackedInboxItemsForDigestThread(threadId);
+    if (items.length === 0) {
+      this.store.closeDigestThread(threadId, nowIso());
+      return null;
+    }
+    const activationItems = items.map((item) => activationItemFromInboxItem(item));
+    const grouping: NotificationGrouping = groupingHint ?? {
+      groupable: true,
+      resourceRef: thread.resourceRef,
+      eventFamily: thread.eventFamily,
+      summaryHint: thread.summary,
+      flushClass: "normal",
+    };
+    const moduleSummary = await this.adapters.summarizeDigestThread(source, activationItems, grouping);
+    const summary = moduleSummary ?? `${items.length} ${thread.summary}`;
+    const sourceIds = uniqueSorted(items.map((item) => item.sourceId));
+    const subscriptionIds = uniqueSortedNullable(
+      items.map((item) => typeof item.metadata.subscriptionId === "string" ? item.metadata.subscriptionId : null),
+    );
+    const firstItemAt = items[0]!.occurredAt;
+    const lastItemAt = items[items.length - 1]!.occurredAt;
+    const deliveryHandle = sharedDeliveryHandle(items);
+    return this.store.materializeDigestSnapshot({
+      threadId,
+      inboxId: thread.inboxId,
+      groupKey: thread.groupKey,
+      resourceRef: thread.resourceRef,
+      eventFamily: thread.eventFamily,
+      summary,
+      sourceIds,
+      subscriptionIds,
+      itemIds: items.map((item) => item.itemId),
+      firstItemAt,
+      lastItemAt,
+      deliveryHandleJson: deliveryHandle ? JSON.stringify(deliveryHandle) : null,
+      createdAt: nowIso(),
+    });
+  }
+
   watchInbox(
     agentId: string,
     options: WatchInboxOptions,
     onEvent: (event: InboxWatchEvent) => void,
   ): InboxWatchSession {
     const inbox = this.ensureInboxForAgent(agentId);
-    const pendingItems: InboxItem[] = [];
+    const pendingItems: InboxEntry[] = [];
     let started = false;
 
-    const emitItems = (items: InboxItem[]) => {
-      if (items.length === 0) {
+    const emitItems = (entries: InboxEntry[]) => {
+      if (entries.length === 0) {
         return;
       }
       onEvent({
         event: "items",
         agentId,
-        items,
+        entries,
       });
     };
 
     const watcher: InboxWatcher = {
-      onItems: (items) => {
+      onItems: (entries) => {
         if (!started) {
-          pendingItems.push(...items);
+          pendingItems.push(...entries);
           return;
         }
-        emitItems(items);
+        emitItems(entries);
       },
     };
 
@@ -1227,10 +1369,10 @@ export class AgentInboxService {
     }
     watchers.add(watcher);
 
-    let initialItems: InboxItem[];
+    let initialItems: InboxEntry[];
     try {
-      initialItems = this.store.listInboxItems(inbox.inboxId, {
-        afterItemId: options.afterItemId,
+      initialItems = this.store.listInboxEntries(inbox.inboxId, {
+        afterEntryId: options.afterEntryId ?? options.afterItemId,
         includeAcked: options.includeAcked ?? false,
       });
     } catch (error) {
@@ -1241,7 +1383,7 @@ export class AgentInboxService {
       throw error;
     }
 
-    const initialItemIds = new Set(initialItems.map((item) => item.itemId));
+    const initialItemIds = new Set(initialItems.map((item) => item.entryId));
     return {
       initialItems,
       start: () => {
@@ -1249,7 +1391,7 @@ export class AgentInboxService {
           return;
         }
         started = true;
-        const replayItems = pendingItems.filter((item) => !initialItemIds.has(item.itemId));
+        const replayItems = pendingItems.filter((item) => !initialItemIds.has(item.entryId));
         pendingItems.length = 0;
         emitItems(replayItems);
       },
@@ -1266,39 +1408,39 @@ export class AgentInboxService {
     };
   }
 
-  ackInboxItems(agentId: string, itemIds: string[]): { acked: number } {
+  async ackInboxItems(agentId: string, itemIds: string[]): Promise<{ acked: number }> {
     const inbox = this.ensureInboxForAgent(agentId);
-    const acked = this.store.ackItems(inbox.inboxId, itemIds, nowIso());
-    if (acked > 0) {
-      void this.handleInboxAckEffects(agentId);
+    const acked = this.store.ackInboxEntries(inbox.inboxId, itemIds, nowIso());
+    if (acked.ackedEntries > 0 || acked.ackedItems > 0) {
+      await this.handleInboxAckEffects(agentId);
     }
-    return { acked };
+    return { acked: acked.ackedEntries };
   }
 
-  ackInboxItemsThrough(agentId: string, itemId: string): { acked: number } {
+  async ackInboxItemsThrough(agentId: string, itemId: string): Promise<{ acked: number }> {
     const inbox = this.ensureInboxForAgent(agentId);
-    const acked = this.store.ackItemsThrough(inbox.inboxId, itemId, nowIso());
-    if (acked > 0) {
-      void this.handleInboxAckEffects(agentId);
+    const acked = this.store.ackInboxEntriesThrough(inbox.inboxId, itemId, nowIso());
+    if (acked.ackedEntries > 0 || acked.ackedItems > 0) {
+      await this.handleInboxAckEffects(agentId);
     }
-    return { acked };
+    return { acked: acked.ackedEntries };
   }
 
-  ackAllInboxItems(agentId: string): { acked: number } {
+  async ackAllInboxItems(agentId: string): Promise<{ acked: number }> {
     const inbox = this.ensureInboxForAgent(agentId);
-    const itemIds = this.store.listInboxItems(inbox.inboxId, { includeAcked: false }).map((item) => item.itemId);
-    const acked = this.store.ackItems(inbox.inboxId, itemIds, nowIso());
-    if (acked > 0) {
-      void this.handleInboxAckEffects(agentId);
+    const itemIds = this.store.listInboxEntries(inbox.inboxId, { includeAcked: false }).map((item) => item.entryId);
+    const acked = this.store.ackInboxEntries(inbox.inboxId, itemIds, nowIso());
+    if (acked.ackedEntries > 0 || acked.ackedItems > 0) {
+      await this.handleInboxAckEffects(agentId);
     }
-    return { acked };
+    return { acked: acked.ackedEntries };
   }
 
-  ackInbox(agentId: string, input: {
+  async ackInbox(agentId: string, input: {
     itemIds?: string[];
     throughItemId?: string | null;
     all?: boolean;
-  }): { acked: number } {
+  }): Promise<{ acked: number }> {
     if (input.all) {
       return this.ackAllInboxItems(agentId);
     }
@@ -1377,7 +1519,7 @@ export class AgentInboxService {
       let matched = 0;
       let inboxItemsCreated = 0;
       let lastProcessedOffset: number | null = null;
-      const insertedItems: InboxItem[] = [];
+      const insertedEntries: InboxEntry[] = [];
       const lifecycleSignals = new Map<string, LifecycleSignal>();
       try {
         for (const event of batch.events) {
@@ -1401,7 +1543,12 @@ export class AgentInboxService {
             eventVariant: event.eventVariant,
             inboxId: inbox.inboxId,
             occurredAt: event.occurredAt,
-            metadata: { ...event.metadata, matchReason: match.reason, agentId: subscription.agentId },
+            metadata: {
+              ...event.metadata,
+              matchReason: match.reason,
+              agentId: subscription.agentId,
+              subscriptionId: subscription.subscriptionId,
+            },
             rawPayload: event.rawPayload,
             deliveryHandle: event.deliveryHandle as DeliveryHandle | null,
             ackedAt: null,
@@ -1411,32 +1558,30 @@ export class AgentInboxService {
             continue;
           }
           inboxItemsCreated += 1;
-          insertedItems.push(item);
-
-          const activationItem: ActivationItem = {
-            itemId: item.itemId,
-            sourceId: item.sourceId,
-            sourceNativeId: item.sourceNativeId,
-            eventVariant: item.eventVariant,
-            inboxId: item.inboxId,
-            occurredAt: item.occurredAt,
-            metadata: item.metadata,
-            rawPayload: item.rawPayload,
-            deliveryHandle: item.deliveryHandle,
-          };
-          for (const target of targets) {
-            this.enqueueActivationTarget(target, {
-              agentId: subscription.agentId,
-              subscriptionId: subscription.subscriptionId,
-              sourceId: source.sourceId,
-              summary: summarizeSourceEvent(source.sourceType, source.sourceKey, event.eventVariant),
-              item: activationItem,
-            });
+          const entries = await this.materializeInboxEntryForItem({
+            agentId: subscription.agentId,
+            inbox,
+            source,
+            subscriptionId: subscription.subscriptionId,
+            item,
+            summary: summarizeSourceEvent(source.sourceType, source.sourceKey, event.eventVariant),
+          });
+          insertedEntries.push(...entries);
+          for (const entry of entries) {
+            for (const target of targets) {
+              this.enqueueActivationTarget(target, {
+                agentId: subscription.agentId,
+                subscriptionId: subscription.subscriptionId,
+                sourceId: source.sourceId,
+                summary: entry.summary,
+                entry,
+              });
+            }
           }
         }
       } catch (error) {
-        if (insertedItems.length > 0) {
-          this.notifyInboxWatchers(subscription.agentId, insertedItems);
+        if (insertedEntries.length > 0) {
+          this.notifyInboxWatchers(subscription.agentId, insertedEntries);
         }
         if (lastProcessedOffset != null) {
           await this.backend.commit({
@@ -1447,8 +1592,8 @@ export class AgentInboxService {
         throw error;
       }
 
-      if (insertedItems.length > 0) {
-        this.notifyInboxWatchers(subscription.agentId, insertedItems);
+      if (insertedEntries.length > 0) {
+        this.notifyInboxWatchers(subscription.agentId, insertedEntries);
       }
       if (lastProcessedOffset != null) {
         await this.backend.commit({
@@ -1674,7 +1819,7 @@ export class AgentInboxService {
     });
   }
 
-  private notifyInboxWatchers(agentId: string, items: InboxItem[]): void {
+  private notifyInboxWatchers(agentId: string, items: InboxEntry[]): void {
     const watchers = this.inboxWatchers.get(agentId);
     if (!watchers || watchers.size === 0) {
       return;
@@ -1778,7 +1923,7 @@ export class AgentInboxService {
       subscriptionId: string | null;
       sourceId: string;
       summary: string;
-      item: ActivationItem;
+      entry: InboxEntry;
     },
   ): void {
     const key = notificationBufferKey(target.agentId, target.targetId);
@@ -1798,7 +1943,7 @@ export class AgentInboxService {
       subscriptionId: input.subscriptionId,
       sourceId: input.sourceId,
       summary: input.summary,
-      item: input.item,
+      entry: input.entry,
     });
 
     if (!buffer.timer && !buffer.inFlight) {
@@ -1882,17 +2027,7 @@ export class AgentInboxService {
       const shouldAttemptDispatch = !state || (state.status === "dirty" && state.leaseExpiresAt == null);
       if (shouldAttemptDispatch) {
         const inbox = this.ensureInboxForAgent(buffer.agentId);
-        const unackedItems = this.store.listInboxItems(inbox.inboxId, { includeAcked: false }).map((item) => ({
-          itemId: item.itemId,
-          sourceId: item.sourceId,
-          sourceNativeId: item.sourceNativeId,
-          eventVariant: item.eventVariant,
-          inboxId: item.inboxId,
-          occurredAt: item.occurredAt,
-          metadata: item.metadata,
-          rawPayload: item.rawPayload,
-          deliveryHandle: item.deliveryHandle,
-        }));
+        const unackedItems = this.store.listInboxEntries(inbox.inboxId, { includeAcked: false });
         const dispatched = await this.dispatchActivationTarget({
           agentId: buffer.agentId,
           targetId: buffer.targetId,
@@ -1905,7 +2040,7 @@ export class AgentInboxService {
           sourceIds: state
             ? uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)])
             : uniqueSorted(entries.map((entry) => entry.sourceId)),
-          items: unackedItems,
+          entries: unackedItems,
         });
         if (dispatched === "retryable_failure") {
           if (state && state.status === "dirty" && state.leaseExpiresAt == null) {
@@ -1964,9 +2099,31 @@ export class AgentInboxService {
   }
 
   private async handleInboxAckEffects(agentId: string): Promise<void> {
+    await this.reconcileDigestThreadsForInbox(this.ensureInboxForAgent(agentId).inboxId);
     const states = this.store.listActivationDispatchStatesForAgent(agentId);
     for (const state of states) {
       await this.maybeDispatchActivationTarget(agentId, state.targetId, "ack");
+    }
+  }
+
+  private async reconcileDigestThreadsForInbox(inboxId: string): Promise<void> {
+    for (const thread of this.store.listOpenDigestThreadsForInbox(inboxId)) {
+      const source = this.store.getSource(thread.sourceId);
+      if (!source) {
+        this.store.closeDigestThread(thread.threadId, nowIso());
+        continue;
+      }
+      const items = this.store.listUnackedInboxItemsForDigestThread(thread.threadId);
+      if (items.length === 0) {
+        this.store.closeDigestThread(thread.threadId, nowIso());
+        continue;
+      }
+      const head = thread.latestEntryId != null ? this.store.getInboxEntry(formatEntryRef(thread.latestEntryId)) : null;
+      const currentIds = items.map((item) => item.itemId);
+      const headIds = head?.itemIds ?? [];
+      if (!sameStringArray(currentIds, headIds)) {
+        await this.flushDigestThread(source, thread.threadId);
+      }
     }
   }
 
@@ -1982,7 +2139,7 @@ export class AgentInboxService {
 
     const target = this.getActivationTarget(targetId);
     const inbox = this.ensureInboxForAgent(agentId);
-    const unacked = this.store.countInboxItems(inbox.inboxId, false);
+    const unacked = this.store.listInboxEntries(inbox.inboxId, { includeAcked: false }).length;
     if (unacked === 0) {
       this.store.deleteActivationDispatchState(agentId, targetId);
       return;
@@ -2023,17 +2180,7 @@ export class AgentInboxService {
       summary: state.pendingSummary,
       subscriptionIds: state.pendingSubscriptionIds,
       sourceIds: state.pendingSourceIds,
-      items: this.store.listInboxItems(inbox.inboxId, { includeAcked: false }).map((item) => ({
-        itemId: item.itemId,
-        sourceId: item.sourceId,
-        sourceNativeId: item.sourceNativeId,
-        eventVariant: item.eventVariant,
-        inboxId: item.inboxId,
-        occurredAt: item.occurredAt,
-        metadata: item.metadata,
-        rawPayload: item.rawPayload,
-        deliveryHandle: item.deliveryHandle,
-      })),
+      entries: this.store.listInboxEntries(inbox.inboxId, { includeAcked: false }),
     });
 
     if (dispatched === "offline") {
@@ -2058,7 +2205,7 @@ export class AgentInboxService {
     summary: string | null;
     subscriptionIds: string[];
     sourceIds: string[];
-    items: ActivationItem[];
+    entries: InboxEntry[];
   }): Promise<ActivationDispatchOutcome> {
     const target = this.getActivationTarget(input.targetId);
     if (target.status === "offline") {
@@ -2067,7 +2214,7 @@ export class AgentInboxService {
     const state = this.store.getActivationDispatchState(input.agentId, input.targetId);
     const inbox = this.ensureInboxForAgent(input.agentId);
     const summary = summarizeActivation(inbox.inboxId, input.newItemCount, input.summary);
-    const totalUnackedCount = input.totalUnackedCount ?? this.store.countInboxItems(inbox.inboxId, false);
+    const totalUnackedCount = input.totalUnackedCount ?? this.store.listInboxEntries(inbox.inboxId, { includeAcked: false }).length;
     const notificationPolicy = notificationPolicyForTarget(target);
     if (!meetsNotificationThreshold(notificationPolicy, totalUnackedCount)) {
       this.logger.debug("activation.dispatch_suppressed", {
@@ -2136,8 +2283,8 @@ export class AgentInboxService {
           return "deferred";
         }
         let preview: string | null = null;
-        if (totalUnackedCount === 1 && input.items.length === 1) {
-          const singleItem = input.items[0];
+        if (totalUnackedCount === 1 && input.entries.length === 1 && input.entries[0]?.kind === "item") {
+          const singleItem = input.entries[0].item;
           const source = this.store.getSource(singleItem.sourceId);
           if (source) {
             try {
@@ -2156,7 +2303,7 @@ export class AgentInboxService {
           preview,
         });
         terminalPrompt = prompt;
-        const promptFingerprint = terminalReminderFingerprint(prompt, input.items);
+        const promptFingerprint = terminalReminderFingerprint(prompt, input.entries);
         if (state?.status === "dirty" && state.lastNotifiedFingerprint === promptFingerprint) {
           this.logger.debug("activation.dispatch_suppressed", {
             agentId: input.agentId,
@@ -2200,9 +2347,15 @@ export class AgentInboxService {
           targetKind: target.kind,
           subscriptionIds: input.subscriptionIds,
           sourceIds: input.sourceIds,
+          newEntryCount: input.entries.length,
           newItemCount: input.newItemCount,
           summary,
-          items: target.mode === "activation_with_items" && input.items.length > 0 ? input.items : undefined,
+          items: target.mode === "activation_with_items"
+            ? input.entries
+              .filter((entry): entry is Extract<InboxEntry, { kind: "item" }> => entry.kind === "item")
+              .map((entry) => entry.item)
+            : undefined,
+          entries: target.mode === "activation_with_items" && input.entries.length > 0 ? input.entries : undefined,
           createdAt: nowIso(),
           deliveredAt: null,
         };
@@ -2219,7 +2372,7 @@ export class AgentInboxService {
         status: "notified",
         leaseExpiresAt: new Date(Date.now() + target.notifyLeaseMs).toISOString(),
         lastNotifiedFingerprint: target.kind === "terminal"
-          ? terminalReminderFingerprint(terminalPrompt ?? "", input.items)
+          ? terminalReminderFingerprint(terminalPrompt ?? "", input.entries)
           : state?.lastNotifiedFingerprint ?? null,
         pendingNewItemCount: 0,
         pendingSummary: null,
@@ -2561,6 +2714,43 @@ export class AgentInboxService {
         await this.maybeDispatchActivationTarget(state.agentId, state.targetId, "lease");
       } catch (error) {
         console.warn(`activation target lease sync failed for ${state.targetId}/${state.agentId}:`, error);
+      }
+    }
+  }
+
+  private async syncPendingDigestThreads(force = false): Promise<void> {
+    const now = nowIso();
+    const threads = force
+      ? this.store.listOpenDigestThreads()
+      : this.store.listDueDigestThreads(now);
+    for (const thread of threads) {
+      try {
+        const source = this.store.getSource(thread.sourceId);
+        if (!source) {
+          this.store.closeDigestThread(thread.threadId, now);
+          continue;
+        }
+        const entry = await this.flushDigestThread(source, thread.threadId);
+        if (!entry) {
+          continue;
+        }
+        const inbox = this.store.getInbox(thread.inboxId);
+        if (!inbox) {
+          continue;
+        }
+        this.notifyInboxWatchers(inbox.ownerAgentId, [entry]);
+        const targets = this.store.listActivationTargetsForAgent(inbox.ownerAgentId).filter((target) => target.status === "active");
+        for (const target of targets) {
+          this.enqueueActivationTarget(target, {
+            agentId: inbox.ownerAgentId,
+            subscriptionId: null,
+            sourceId: thread.sourceId,
+            summary: entry.summary,
+            entry,
+          });
+        }
+      } catch (error) {
+        console.warn(`digest thread flush failed for ${thread.threadId}:`, error);
       }
     }
   }
@@ -2987,11 +3177,67 @@ function notificationPolicyForTarget(target: ActivationTarget): NotificationPoli
   };
 }
 
+function inboxAggregationPolicy(inbox: Inbox): Required<InboxAggregationPolicy> {
+  return {
+    enabled: inbox.aggregationEnabled ?? false,
+    windowMs: inbox.aggregationWindowMs ?? DEFAULT_INBOX_AGGREGATION_WINDOW_MS,
+    maxItems: inbox.aggregationMaxItems ?? DEFAULT_INBOX_AGGREGATION_MAX_ITEMS,
+    maxThreadAgeMs: inbox.aggregationMaxThreadAgeMs ?? DEFAULT_INBOX_AGGREGATION_MAX_THREAD_AGE_MS,
+  };
+}
+
 function meetsNotificationThreshold(policy: NotificationPolicy, totalUnackedCount: number): boolean {
   if (policy.minUnackedItems == null) {
     return true;
   }
   return totalUnackedCount >= policy.minUnackedItems;
+}
+
+function activationItemFromInboxItem(item: InboxItem): ActivationItem {
+  return {
+    itemId: item.itemId,
+    sourceId: item.sourceId,
+    sourceNativeId: item.sourceNativeId,
+    eventVariant: item.eventVariant,
+    inboxId: item.inboxId,
+    occurredAt: item.occurredAt,
+    metadata: item.metadata,
+    rawPayload: item.rawPayload,
+    deliveryHandle: item.deliveryHandle,
+  };
+}
+
+function digestGroupKey(sourceId: string, resourceRef: string, eventFamily: string): string {
+  return `${sourceId}::${resourceRef}::${eventFamily}`;
+}
+
+function sameStringArray(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function sameDeliveryHandle(left: DeliveryHandle | null | undefined, right: DeliveryHandle | null | undefined): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+function sharedDeliveryHandle(items: InboxItem[]): DeliveryHandle | null {
+  const first = items[0]?.deliveryHandle ?? null;
+  if (!first) {
+    return null;
+  }
+  for (const item of items.slice(1)) {
+    if (!sameDeliveryHandle(first, item.deliveryHandle ?? null)) {
+      return null;
+    }
+  }
+  return first;
 }
 
 function normalizeWebhookActivationMode(mode: AddWebhookActivationTargetInput["activationMode"]): WebhookActivationTarget["mode"] {
@@ -3071,11 +3317,11 @@ function latestSummary(entries: Array<{ summary: string | null }>): string | nul
   return null;
 }
 
-function terminalReminderFingerprint(prompt: string, items: ActivationItem[]): string {
+function terminalReminderFingerprint(prompt: string, items: InboxEntry[]): string {
   const payload = JSON.stringify({
     prompt,
     itemIds: items
-      .map((item) => item.itemId)
+      .map((item) => item.entryId)
       .sort((left, right) => left.localeCompare(right)),
   });
   return createHash("sha256").update(payload).digest("hex");

--- a/src/service.ts
+++ b/src/service.ts
@@ -1437,17 +1437,20 @@ export class AgentInboxService {
   }
 
   async ackInbox(agentId: string, input: {
+    entryIds?: string[];
+    throughEntryId?: string | null;
+    all?: boolean;
     itemIds?: string[];
     throughItemId?: string | null;
-    all?: boolean;
   }): Promise<{ acked: number }> {
     if (input.all) {
       return this.ackAllInboxItems(agentId);
     }
-    if (input.throughItemId) {
-      return this.ackInboxItemsThrough(agentId, input.throughItemId);
+    const throughEntryId = input.throughEntryId ?? input.throughItemId ?? null;
+    if (throughEntryId) {
+      return this.ackInboxItemsThrough(agentId, throughEntryId);
     }
-    return this.ackInboxItems(agentId, input.itemIds ?? []);
+    return this.ackInboxItems(agentId, input.entryIds ?? input.itemIds ?? []);
   }
 
   compactInbox(agentId: string): { deleted: number; retentionMs: number } {

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -1,5 +1,5 @@
 import { ManagedSourceEnsureResponse, ManagedStreamReadResponse, UxcDaemonClient } from "@holon-run/uxc-daemon-client";
-import { ActivationItem, AppendSourceEventInput, SourcePollResult, SubscriptionSource } from "../model";
+import { ActivationItem, AppendSourceEventInput, NotificationGrouping, SourcePollResult, SubscriptionSource } from "../model";
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
 import { nowIso } from "../util";
@@ -252,6 +252,32 @@ export class RemoteSourceRuntime {
       return null;
     }
     return module.deriveInlinePreview(item, moduleInputSource(source));
+  }
+
+  async deriveNotificationGrouping(source: SubscriptionSource, item: ActivationItem): Promise<NotificationGrouping | null> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return null;
+    }
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    if (typeof module.deriveNotificationGrouping !== "function") {
+      return null;
+    }
+    return module.deriveNotificationGrouping(item, moduleInputSource(source));
+  }
+
+  async summarizeDigestThread(
+    source: SubscriptionSource,
+    items: ActivationItem[],
+    grouping: NotificationGrouping,
+  ): Promise<string | null> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return null;
+    }
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    if (typeof module.summarizeDigestThread !== "function") {
+      return null;
+    }
+    return module.summarizeDigestThread(items, moduleInputSource(source), grouping);
   }
 
   private async syncAll(): Promise<void> {

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -9,6 +9,7 @@ import {
   DeliveryAttempt,
   DeliveryHandle,
   DeliveryOperationDescriptor,
+  NotificationGrouping,
   SourceSchemaField,
   SubscriptionFilter,
   SubscriptionSource,
@@ -123,8 +124,10 @@ export interface RemoteSourceModule {
   deriveTrackedResource?(filter: SubscriptionFilter, source: SubscriptionSource): { ref: string } | null;
   projectLifecycleSignal?(rawPayload: Record<string, unknown>, source: SubscriptionSource): LifecycleSignal | null;
   deriveInlinePreview?(item: ActivationItem, source: SubscriptionSource): string | null;
+  deriveNotificationGrouping?(item: ActivationItem, source: SubscriptionSource): NotificationGrouping | null;
   listDeliveryOperations?(input: ListDeliveryOperationsInput): DeliveryOperationDescriptor[];
   invokeDeliveryOperation?(input: InvokeDeliveryOperationInput): Promise<{ status: DeliveryAttempt["status"]; note: string }>;
+  summarizeDigestThread?(items: ActivationItem[], source: SubscriptionSource, grouping: NotificationGrouping): string | null;
 }
 
 const REMOTE_USER_MODULE_ROOT_DIR = "source-profiles";
@@ -219,8 +222,10 @@ function validateModuleContract(module: RemoteSourceModule, sourcePath: string):
   validateOptionalHook(module.deriveTrackedResource, "deriveTrackedResource", sourcePath);
   validateOptionalHook(module.projectLifecycleSignal, "projectLifecycleSignal", sourcePath);
   validateOptionalHook(module.deriveInlinePreview, "deriveInlinePreview", sourcePath);
+  validateOptionalHook(module.deriveNotificationGrouping, "deriveNotificationGrouping", sourcePath);
   validateOptionalHook(module.listDeliveryOperations, "listDeliveryOperations", sourcePath);
   validateOptionalHook(module.invokeDeliveryOperation, "invokeDeliveryOperation", sourcePath);
+  validateOptionalHook(module.summarizeDigestThread, "summarizeDigestThread", sourcePath);
 }
 
 function validateOptionalHook(value: unknown, name: string, sourcePath: string): void {
@@ -330,6 +335,54 @@ const GITHUB_REPO_MODULE: RemoteSourceModule = {
   deriveTrackedResource(filter: SubscriptionFilter): { ref: string } | null {
     return deriveGithubTrackedResource(filter);
   },
+  deriveNotificationGrouping(item: ActivationItem): NotificationGrouping | null {
+    const number = typeof item.metadata.number === "number" ? item.metadata.number : null;
+    if (!number) {
+      return null;
+    }
+    const variant = item.eventVariant;
+    if (variant.startsWith("PullRequestReviewCommentEvent.")) {
+      return {
+        groupable: true,
+        resourceRef: `pr:${number}`,
+        eventFamily: "review_comments",
+        summaryHint: `review comments on PR #${number}`,
+      };
+    }
+    if (variant.startsWith("PullRequestReviewEvent.")) {
+      return {
+        groupable: true,
+        resourceRef: `pr:${number}`,
+        eventFamily: "reviews",
+        summaryHint: `reviews on PR #${number}`,
+      };
+    }
+    if (variant.startsWith("IssueCommentEvent.")) {
+      return {
+        groupable: true,
+        resourceRef: item.metadata.isPullRequest === true ? `pr:${number}` : `issue:${number}`,
+        eventFamily: "comments",
+        summaryHint: item.metadata.isPullRequest === true ? `comments on PR #${number}` : `comments on issue #${number}`,
+      };
+    }
+    if (variant.startsWith("PullRequestEvent.closed")) {
+      return {
+        groupable: true,
+        resourceRef: `pr:${number}`,
+        eventFamily: "lifecycle",
+        summaryHint: `PR #${number} lifecycle updates`,
+        flushClass: "immediate",
+      };
+    }
+    return null;
+  },
+  summarizeDigestThread(items: ActivationItem[], _source: SubscriptionSource, grouping: NotificationGrouping): string | null {
+    if (!grouping.summaryHint || items.length === 0) {
+      return null;
+    }
+    const count = items.length;
+    return `${count} ${grouping.summaryHint}`;
+  },
   projectLifecycleSignal(rawPayload: Record<string, unknown>) {
     return projectGithubLifecycleSignal(rawPayload);
   },
@@ -435,6 +488,27 @@ const GITHUB_REPO_CI_MODULE: RemoteSourceModule = {
     }
 
     return parts.join(" ");
+  },
+  deriveNotificationGrouping(item: ActivationItem): NotificationGrouping | null {
+    const workflowRunId = typeof item.metadata.workflowRunId === "number" ? item.metadata.workflowRunId : null;
+    if (!workflowRunId) {
+      return null;
+    }
+    const conclusion = asNonEmptyString(item.metadata.conclusion);
+    const status = asNonEmptyString(item.metadata.status);
+    return {
+      groupable: true,
+      resourceRef: `workflow_run:${workflowRunId}`,
+      eventFamily: "ci_updates",
+      summaryHint: `CI updates for run #${workflowRunId}`,
+      flushClass: conclusion || status === "completed" ? "immediate" : "normal",
+    };
+  },
+  summarizeDigestThread(items: ActivationItem[], _source: SubscriptionSource, grouping: NotificationGrouping): string | null {
+    if (!grouping.summaryHint || items.length === 0) {
+      return null;
+    }
+    return `${items.length} ${grouping.summaryHint}`;
   },
   validateConfig(source: SubscriptionSource): void {
     parseGithubCiSourceConfig(source);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1352,14 +1352,31 @@ export class AgentInboxStore {
       filters.push("acked_at is null");
       filters.push("superseded_at is null");
     }
-    const afterRef = options?.afterEntryId ?? options?.afterItemId ?? undefined;
-    if (afterRef) {
+    if (options?.afterEntryId) {
       const anchor = this.getOne(
         "select sequence from inbox_entries where inbox_id = ? and entry_id = ?",
-        [inboxId, parseEntryRef(afterRef)],
+        [inboxId, parseEntryRef(options.afterEntryId)],
       );
       if (!anchor) {
-        throw new Error(`unknown inbox entry: ${afterRef}`);
+        throw new Error(`unknown inbox entry: ${options.afterEntryId}`);
+      }
+      filters.push("sequence > ?");
+      params.push(Number(anchor.sequence));
+    } else if (options?.afterItemId) {
+      const anchor = this.getOne(
+        `
+        select ie.sequence
+        from inbox_entries ie
+        join inbox_entry_items iei on iei.entry_id = ie.entry_id
+        where ie.inbox_id = ?
+          and iei.item_id = ?
+        order by ie.sequence desc
+        limit 1
+        `,
+        [inboxId, options.afterItemId],
+      );
+      if (!anchor) {
+        throw new Error(`unknown inbox item: ${options.afterItemId}`);
       }
       filters.push("sequence > ?");
       params.push(Number(anchor.sequence));
@@ -1368,7 +1385,7 @@ export class AgentInboxStore {
       `select * from inbox_entries where ${filters.join(" and ")} order by sequence asc`,
       params,
     );
-    return rows.map((row) => this.mapInboxEntry(row));
+    return this.mapInboxEntries(rows);
   }
 
   getInboxEntry(entryId: string): InboxEntry | null {
@@ -1695,36 +1712,38 @@ export class AgentInboxStore {
   }
 
   deleteAckedInboxItems(inboxId: string, olderThan: string): number {
-    this.db.run(
+    const itemIds = this.getAll(
       `
-      delete from inbox_items
+      select item_id
+      from inbox_items
       where inbox_id = ?
         and acked_at is not null
         and acked_at < ?
-    `,
+      `,
       [inboxId, olderThan],
-    );
-    const changes = this.changes();
-    if (changes > 0) {
-      this.persist();
+    ).map((row) => String(row.item_id));
+    if (itemIds.length === 0) {
+      return 0;
     }
-    return changes;
+    this.deleteInboxItemsAndEntryArtifacts(itemIds);
+    return itemIds.length;
   }
 
   deleteAckedInboxItemsGlobal(olderThan: string): number {
-    this.db.run(
+    const itemIds = this.getAll(
       `
-      delete from inbox_items
+      select item_id
+      from inbox_items
       where acked_at is not null
         and acked_at < ?
-    `,
+      `,
       [olderThan],
-    );
-    const changes = this.changes();
-    if (changes > 0) {
-      this.persist();
+    ).map((row) => String(row.item_id));
+    if (itemIds.length === 0) {
+      return 0;
     }
-    return changes;
+    this.deleteInboxItemsAndEntryArtifacts(itemIds);
+    return itemIds.length;
   }
 
   countInboxItems(inboxId: string, includeAcked: boolean): number {
@@ -2327,7 +2346,7 @@ export class AgentInboxStore {
     };
   }
 
-  private mapInboxEntry(row: Record<string, unknown>): InboxEntry {
+  private mapInboxEntry(row: Record<string, unknown>, itemIds: string[]): InboxEntry {
     const base = {
       entryId: formatEntryRef(Number(row.entry_id)),
       inboxId: String(row.inbox_id),
@@ -2335,7 +2354,7 @@ export class AgentInboxStore {
       itemId: "",
       summary: String(row.summary),
       count: Number(row.count),
-      itemIds: this.listEntryItemIds(Number(row.entry_id)),
+      itemIds,
       sourceIds: parseJson<string[]>(row.source_ids_json as string),
       subscriptionIds: parseJson<string[]>(row.subscription_ids_json as string),
       firstItemAt: String(row.first_item_at),
@@ -2428,8 +2447,8 @@ export class AgentInboxStore {
   }
 
   private getInboxEntryByNumericId(entryId: number): InboxEntry | null {
-    const row = this.getOne("select * from inbox_entries where entry_id = ?", [entryId]);
-    return row ? this.mapInboxEntry(row) : null;
+    const rows = this.getAll("select * from inbox_entries where entry_id = ?", [entryId]);
+    return this.mapInboxEntries(rows)[0] ?? null;
   }
 
   private resolveInboxEntryNumericId(inboxId: string, refOrItemId: string): number {
@@ -2515,10 +2534,41 @@ export class AgentInboxStore {
 
   private listEntryItemIds(entryId: number): string[] {
     const rows = this.getAll(
-      "select item_id from inbox_entry_items where entry_id = ? order by item_id asc",
+      `
+      select iei.item_id
+      from inbox_entry_items iei
+      left join inbox_items ii on ii.item_id = iei.item_id
+      where iei.entry_id = ?
+      order by coalesce(ii.inbox_sequence, ii.rowid, iei.rowid) asc
+      `,
       [entryId],
     );
     return rows.map((row) => String(row.item_id));
+  }
+
+  private listEntryItemIdsBulk(entryIds: number[]): Map<number, string[]> {
+    const result = new Map<number, string[]>();
+    if (entryIds.length === 0) {
+      return result;
+    }
+    const placeholders = entryIds.map(() => "?").join(", ");
+    const rows = this.getAll(
+      `
+      select iei.entry_id, iei.item_id
+      from inbox_entry_items iei
+      left join inbox_items ii on ii.item_id = iei.item_id
+      where iei.entry_id in (${placeholders})
+      order by iei.entry_id asc, coalesce(ii.inbox_sequence, ii.rowid, iei.rowid) asc
+      `,
+      entryIds,
+    );
+    for (const row of rows) {
+      const entryId = Number(row.entry_id);
+      const itemIds = result.get(entryId) ?? [];
+      itemIds.push(String(row.item_id));
+      result.set(entryId, itemIds);
+    }
+    return result;
   }
 
   private getRawItemIdsForEntryIds(entryIds: number[]): string[] {
@@ -2529,6 +2579,11 @@ export class AgentInboxStore {
       }
     }
     return [...itemIds];
+  }
+
+  private mapInboxEntries(rows: Array<Record<string, unknown>>): InboxEntry[] {
+    const itemIdsByEntry = this.listEntryItemIdsBulk(rows.map((row) => Number(row.entry_id)));
+    return rows.map((row) => this.mapInboxEntry(row, itemIdsByEntry.get(Number(row.entry_id)) ?? []));
   }
 
   private syncInboxEntryAckState(inboxId: string, ackedAt: string): void {
@@ -2561,6 +2616,82 @@ export class AgentInboxStore {
       [...entryIds, ackedAt],
     );
     return Number(row?.count ?? 0);
+  }
+
+  private deleteInboxItemsAndEntryArtifacts(itemIds: string[]): void {
+    const placeholders = itemIds.map(() => "?").join(", ");
+    this.inTransaction(() => {
+      this.db.run(
+        `delete from digest_thread_items where item_id in (${placeholders})`,
+        itemIds,
+      );
+      this.db.run(
+        `delete from inbox_items where item_id in (${placeholders})`,
+        itemIds,
+      );
+      this.db.run(
+        `
+        delete from inbox_entries
+        where entry_id in (
+          select e.entry_id
+          from inbox_entries e
+          where not exists (
+            select 1
+            from inbox_entry_items ee
+            where ee.entry_id = e.entry_id
+              and exists (
+                select 1
+                from inbox_items ii
+                where ii.item_id = ee.item_id
+              )
+          )
+        )
+        `,
+      );
+      this.db.run(
+        `
+        delete from inbox_entry_items
+        where not exists (
+          select 1
+          from inbox_items ii
+          where ii.item_id = inbox_entry_items.item_id
+        )
+        `,
+      );
+      this.db.run(
+        `
+        update digest_threads
+        set latest_entry_id = (
+              select e.entry_id
+              from inbox_entries e
+              where e.thread_id = digest_threads.thread_id
+              order by coalesce(e.revision, 0) desc, e.entry_id desc
+              limit 1
+            ),
+            latest_revision = coalesce((
+              select max(coalesce(e.revision, 0))
+              from inbox_entries e
+              where e.thread_id = digest_threads.thread_id
+            ), 0)
+        `,
+      );
+      this.db.run(
+        `
+        delete from digest_threads
+        where not exists (
+          select 1
+          from digest_thread_items dti
+          where dti.thread_id = digest_threads.thread_id
+        )
+          and not exists (
+            select 1
+            from inbox_entries e
+            where e.thread_id = digest_threads.thread_id
+          )
+        `,
+      );
+    });
+    this.persist();
   }
 
   private mapStream(row: Record<string, unknown>): StreamRecord {

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,6 +9,7 @@ import type {
 } from "./backend";
 import {
   Activation,
+  ActivationItem,
   ActivationDispatchState,
   ActivationTarget,
   AddWebhookActivationTargetInput,
@@ -18,8 +19,11 @@ import {
   CleanupPolicy,
   DeliveryAttempt,
   Inbox,
+  InboxAggregationPolicy,
+  InboxEntry,
   InboxItem,
   ListInboxItemsOptions,
+  NotificationGrouping,
   AgentTimer,
   RegisterAgentInput,
   SourceHost,
@@ -32,7 +36,7 @@ import {
   TerminalActivationTarget,
   WebhookActivationTarget,
 } from "./model";
-import { generateId, nowIso } from "./util";
+import { formatEntryRef, formatThreadRef, generateId, nowIso, parseEntryRef } from "./util";
 
 const LEGACY_SCHEMA_VERSION = 12;
 const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
@@ -41,6 +45,24 @@ type SqlBindParams = unknown[];
 interface SqlMigration {
   tag: string;
   sql: string;
+}
+
+interface DigestThreadRecord {
+  threadId: number;
+  inboxId: string;
+  sourceId: string;
+  groupKey: string;
+  resourceRef: string | null;
+  eventFamily: string | null;
+  latestRevision: number;
+  latestEntryId: number | null;
+  status: "open" | "closed";
+  summary: string;
+  firstItemAt: string;
+  lastItemAt: string;
+  flushAfterAt: string | null;
+  createdAt: string;
+  updatedAt: string;
 }
 
 function parseJson<T>(value: string | null): T {
@@ -126,6 +148,8 @@ export class AgentInboxStore {
         this.applyMigration(migration);
       }
     }
+
+    this.ensureInboxEntryBackfill();
 
     this.setUserVersion(migrations.length);
   }
@@ -237,6 +261,63 @@ export class AgentInboxStore {
       [name],
     );
     return Boolean(row);
+  }
+
+  private ensureInboxEntryBackfill(): void {
+    if (!this.tableExists("inbox_entries") || !this.tableExists("inbox_items")) {
+      return;
+    }
+    const existing = this.getOne("select count(*) as count from inbox_entries");
+    if (existing && Number(existing.count ?? 0) > 0) {
+      return;
+    }
+    const rows = this.getAll(`
+      select *
+      from inbox_items
+      order by inbox_id asc, coalesce(inbox_sequence, rowid) asc
+    `);
+    if (rows.length === 0) {
+      return;
+    }
+    this.inTransaction(() => {
+      for (const row of rows) {
+        const item = this.mapInboxItem(row);
+        const entryId = this.insertInboxEntryRecord({
+          inboxId: item.inboxId,
+          kind: "item",
+          threadId: null,
+          revision: null,
+          groupKey: null,
+          resourceRef: null,
+          eventFamily: null,
+          itemJson: JSON.stringify({
+            itemId: item.itemId,
+            sourceId: item.sourceId,
+            sourceNativeId: item.sourceNativeId,
+            eventVariant: item.eventVariant,
+            inboxId: item.inboxId,
+            occurredAt: item.occurredAt,
+            metadata: item.metadata,
+            rawPayload: item.rawPayload,
+            deliveryHandle: item.deliveryHandle ?? null,
+          }),
+          count: 1,
+          summary: summarizeBackfilledItemEntry(item),
+          firstItemAt: item.occurredAt,
+          lastItemAt: item.occurredAt,
+          sourceIdsJson: JSON.stringify([item.sourceId]),
+          subscriptionIdsJson: JSON.stringify([]),
+          deliveryHandleJson: item.deliveryHandle ? JSON.stringify(item.deliveryHandle) : null,
+          ackedAt: item.ackedAt ?? null,
+          supersededAt: null,
+          createdAt: item.occurredAt,
+        });
+        this.db.run(
+          "insert or ignore into inbox_entry_items (entry_id, item_id) values (?, ?)",
+          [entryId, item.itemId],
+        );
+      }
+    });
   }
 
   getSourceHostByKey(hostType: string, hostKey: string): SourceHost | null {
@@ -577,10 +658,49 @@ export class AgentInboxStore {
 
   insertInbox(inbox: Inbox): void {
     this.db.run(
-      "insert into inboxes (inbox_id, owner_agent_id, created_at) values (?, ?, ?)",
-      [inbox.inboxId, inbox.ownerAgentId, inbox.createdAt],
+      `
+      insert into inboxes (
+        inbox_id, owner_agent_id, aggregation_enabled, aggregation_window_ms,
+        aggregation_max_items, aggregation_max_thread_age_ms, created_at
+      ) values (?, ?, ?, ?, ?, ?, ?)
+      `,
+      [
+        inbox.inboxId,
+        inbox.ownerAgentId,
+        inbox.aggregationEnabled ? 1 : 0,
+        inbox.aggregationWindowMs ?? null,
+        inbox.aggregationMaxItems ?? null,
+        inbox.aggregationMaxThreadAgeMs ?? null,
+        inbox.createdAt,
+      ],
     );
     this.persist();
+  }
+
+  updateInboxAggregationPolicy(inboxId: string, policy: InboxAggregationPolicy): Inbox {
+    const current = this.getInbox(inboxId);
+    if (!current) {
+      throw new Error(`unknown inbox: ${inboxId}`);
+    }
+    this.db.run(
+      `
+      update inboxes
+      set aggregation_enabled = ?,
+          aggregation_window_ms = ?,
+          aggregation_max_items = ?,
+          aggregation_max_thread_age_ms = ?
+      where inbox_id = ?
+      `,
+      [
+        policy.enabled === undefined ? (current.aggregationEnabled ? 1 : 0) : (policy.enabled ? 1 : 0),
+        Object.prototype.hasOwnProperty.call(policy, "windowMs") ? policy.windowMs ?? null : current.aggregationWindowMs ?? null,
+        Object.prototype.hasOwnProperty.call(policy, "maxItems") ? policy.maxItems ?? null : current.aggregationMaxItems ?? null,
+        Object.prototype.hasOwnProperty.call(policy, "maxThreadAgeMs") ? policy.maxThreadAgeMs ?? null : current.aggregationMaxThreadAgeMs ?? null,
+        inboxId,
+      ],
+    );
+    this.persist();
+    return this.getInbox(inboxId)!;
   }
 
   listInboxes(): Inbox[] {
@@ -1178,6 +1298,330 @@ export class AgentInboxStore {
     return inserted;
   }
 
+  createInboxItemEntry(
+    inboxId: string,
+    item: InboxItem,
+    input: {
+      summary: string;
+      subscriptionIds: string[];
+    },
+  ): InboxEntry {
+    const entryId = this.insertInboxEntryRecord({
+      inboxId,
+      kind: "item",
+      threadId: null,
+      revision: null,
+      groupKey: null,
+      resourceRef: null,
+      eventFamily: null,
+      itemJson: JSON.stringify({
+        itemId: item.itemId,
+        sourceId: item.sourceId,
+        sourceNativeId: item.sourceNativeId,
+        eventVariant: item.eventVariant,
+        inboxId: item.inboxId,
+        occurredAt: item.occurredAt,
+        metadata: item.metadata,
+        rawPayload: item.rawPayload,
+        deliveryHandle: item.deliveryHandle ?? null,
+      }),
+      count: 1,
+      summary: input.summary,
+      firstItemAt: item.occurredAt,
+      lastItemAt: item.occurredAt,
+      sourceIdsJson: JSON.stringify([item.sourceId]),
+      subscriptionIdsJson: JSON.stringify(uniqueSorted(input.subscriptionIds)),
+      deliveryHandleJson: item.deliveryHandle ? JSON.stringify(item.deliveryHandle) : null,
+      ackedAt: item.ackedAt ?? null,
+      supersededAt: null,
+      createdAt: nowIso(),
+    });
+    this.db.run(
+      "insert or ignore into inbox_entry_items (entry_id, item_id) values (?, ?)",
+      [entryId, item.itemId],
+    );
+    this.persist();
+    return this.getInboxEntryByNumericId(entryId)!;
+  }
+
+  listInboxEntries(inboxId: string, options?: ListInboxItemsOptions): InboxEntry[] {
+    const includeAcked = options?.includeAcked ?? false;
+    const filters = ["inbox_id = ?"];
+    const params: Array<string | number | null> = [inboxId];
+    if (!includeAcked) {
+      filters.push("acked_at is null");
+      filters.push("superseded_at is null");
+    }
+    const afterRef = options?.afterEntryId ?? options?.afterItemId ?? undefined;
+    if (afterRef) {
+      const anchor = this.getOne(
+        "select sequence from inbox_entries where inbox_id = ? and entry_id = ?",
+        [inboxId, parseEntryRef(afterRef)],
+      );
+      if (!anchor) {
+        throw new Error(`unknown inbox entry: ${afterRef}`);
+      }
+      filters.push("sequence > ?");
+      params.push(Number(anchor.sequence));
+    }
+    const rows = this.getAll(
+      `select * from inbox_entries where ${filters.join(" and ")} order by sequence asc`,
+      params,
+    );
+    return rows.map((row) => this.mapInboxEntry(row));
+  }
+
+  getInboxEntry(entryId: string): InboxEntry | null {
+    return this.getInboxEntryByNumericId(parseEntryRef(entryId));
+  }
+
+  ackInboxEntries(inboxId: string, entryIds: string[], ackedAt: string): { ackedEntries: number; ackedItems: number } {
+    const numericIds = uniqueSorted(entryIds).map((entryId) => this.resolveInboxEntryNumericId(inboxId, entryId));
+    const itemIds = this.getRawItemIdsForEntryIds(numericIds);
+    const ackedItems = itemIds.length > 0 ? this.ackItems(inboxId, itemIds, ackedAt) : 0;
+    if (ackedItems > 0) {
+      this.syncInboxEntryAckState(inboxId, ackedAt);
+    }
+    const ackedEntries = this.countAckedEntries(numericIds, ackedAt);
+    return { ackedEntries, ackedItems };
+  }
+
+  ackInboxEntriesThrough(inboxId: string, entryId: string, ackedAt: string): { ackedEntries: number; ackedItems: number } {
+    const anchor = this.getOne(
+      "select sequence from inbox_entries where inbox_id = ? and entry_id = ?",
+      [inboxId, this.resolveInboxEntryNumericId(inboxId, entryId)],
+    );
+    if (!anchor) {
+      throw new Error(`unknown inbox entry: ${entryId}`);
+    }
+    const rows = this.getAll(
+      `
+      select entry_id
+      from inbox_entries
+      where inbox_id = ?
+        and acked_at is null
+        and superseded_at is null
+        and sequence <= ?
+      order by sequence asc
+      `,
+      [inboxId, Number(anchor.sequence)],
+    );
+    return this.ackInboxEntries(inboxId, rows.map((row) => formatEntryRef(Number(row.entry_id))), ackedAt);
+  }
+
+  getOpenDigestThread(inboxId: string, groupKey: string): DigestThreadRecord | null {
+    const row = this.getOne(
+      `
+      select * from digest_threads
+      where inbox_id = ? and group_key = ? and status = 'open'
+      order by thread_id desc
+      limit 1
+      `,
+      [inboxId, groupKey],
+    );
+    return row ? this.mapDigestThread(row) : null;
+  }
+
+  createDigestThread(input: {
+    inboxId: string;
+    sourceId: string;
+    groupKey: string;
+    resourceRef?: string | null;
+    eventFamily?: string | null;
+    summary: string;
+    firstItemAt: string;
+    flushAfterAt?: string | null;
+    createdAt: string;
+  }): DigestThreadRecord {
+    this.db.run(
+      `
+      insert into digest_threads (
+        inbox_id, source_id, group_key, resource_ref, event_family, latest_revision,
+        latest_entry_id, status, summary, first_item_at, last_item_at, flush_after_at,
+        created_at, updated_at
+      ) values (?, ?, ?, ?, ?, 0, null, 'open', ?, ?, ?, ?, ?, ?)
+      `,
+      [
+        input.inboxId,
+        input.sourceId,
+        input.groupKey,
+        input.resourceRef ?? null,
+        input.eventFamily ?? null,
+        input.summary,
+        input.firstItemAt,
+        input.firstItemAt,
+        input.flushAfterAt ?? null,
+        input.createdAt,
+        input.createdAt,
+      ],
+    );
+    const threadId = this.lastInsertRowId();
+    this.persist();
+    return this.getDigestThread(threadId)!;
+  }
+
+  getDigestThread(threadId: number): DigestThreadRecord | null {
+    const row = this.getOne("select * from digest_threads where thread_id = ?", [threadId]);
+    return row ? this.mapDigestThread(row) : null;
+  }
+
+  addItemToDigestThread(threadId: number, itemId: string, occurredAt: string, summary: string, flushAfterAt: string | null): DigestThreadRecord {
+    this.inTransaction(() => {
+      this.db.run(
+        "insert or ignore into digest_thread_items (thread_id, item_id) values (?, ?)",
+        [threadId, itemId],
+      );
+      this.db.run(
+        `
+        update digest_threads
+        set summary = ?, last_item_at = ?, flush_after_at = ?, updated_at = ?
+        where thread_id = ?
+        `,
+        [summary, occurredAt, flushAfterAt, nowIso(), threadId],
+      );
+    });
+    this.persist();
+    return this.getDigestThread(threadId)!;
+  }
+
+  listDueDigestThreads(now: string): DigestThreadRecord[] {
+    const rows = this.getAll(
+      `
+      select *
+      from digest_threads
+      where status = 'open'
+        and flush_after_at is not null
+        and flush_after_at <= ?
+      order by flush_after_at asc, thread_id asc
+      `,
+      [now],
+    );
+    return rows.map((row) => this.mapDigestThread(row));
+  }
+
+  listUnackedInboxItemsForDigestThread(threadId: number): InboxItem[] {
+    const rows = this.getAll(
+      `
+      select i.*
+      from digest_thread_items t
+      join inbox_items i on i.item_id = t.item_id
+      where t.thread_id = ?
+        and i.acked_at is null
+      order by coalesce(i.inbox_sequence, i.rowid) asc
+      `,
+      [threadId],
+    );
+    return rows.map((row) => this.mapInboxItem(row));
+  }
+
+  listOpenDigestThreadsForInbox(inboxId: string): DigestThreadRecord[] {
+    const rows = this.getAll(
+      "select * from digest_threads where inbox_id = ? and status = 'open' order by thread_id asc",
+      [inboxId],
+    );
+    return rows.map((row) => this.mapDigestThread(row));
+  }
+
+  listOpenDigestThreads(): DigestThreadRecord[] {
+    const rows = this.getAll(
+      "select * from digest_threads where status = 'open' order by thread_id asc",
+    );
+    return rows.map((row) => this.mapDigestThread(row));
+  }
+
+  materializeDigestSnapshot(input: {
+    threadId: number;
+    inboxId: string;
+    groupKey: string;
+    resourceRef?: string | null;
+    eventFamily?: string | null;
+    summary: string;
+    sourceIds: string[];
+    subscriptionIds: string[];
+    itemIds: string[];
+    firstItemAt: string;
+    lastItemAt: string;
+    deliveryHandleJson?: string | null;
+    createdAt: string;
+  }): InboxEntry {
+    const thread = this.getDigestThread(input.threadId);
+    if (!thread) {
+      throw new Error(`unknown digest thread: ${input.threadId}`);
+    }
+    this.inTransaction(() => {
+      if (thread.latestEntryId != null) {
+        this.db.run(
+          "update inbox_entries set superseded_at = ? where entry_id = ? and superseded_at is null",
+          [input.createdAt, thread.latestEntryId],
+        );
+      }
+      const nextRevision = thread.latestRevision + 1;
+      const entryId = this.insertInboxEntryRecord({
+        inboxId: input.inboxId,
+        kind: "digest_snapshot",
+        threadId: input.threadId,
+        revision: nextRevision,
+        groupKey: input.groupKey,
+        resourceRef: input.resourceRef ?? null,
+        eventFamily: input.eventFamily ?? null,
+        itemJson: null,
+        count: input.itemIds.length,
+        summary: input.summary,
+        firstItemAt: input.firstItemAt,
+        lastItemAt: input.lastItemAt,
+        sourceIdsJson: JSON.stringify(uniqueSorted(input.sourceIds)),
+        subscriptionIdsJson: JSON.stringify(uniqueSorted(input.subscriptionIds)),
+        deliveryHandleJson: input.deliveryHandleJson ?? null,
+        ackedAt: null,
+        supersededAt: null,
+        createdAt: input.createdAt,
+      });
+      for (const itemId of input.itemIds) {
+        this.db.run(
+          "insert or ignore into inbox_entry_items (entry_id, item_id) values (?, ?)",
+          [entryId, itemId],
+        );
+      }
+      this.db.run(
+        `
+        update digest_threads
+        set latest_revision = ?, latest_entry_id = ?, summary = ?, first_item_at = ?, last_item_at = ?,
+            flush_after_at = null, updated_at = ?
+        where thread_id = ?
+        `,
+        [nextRevision, entryId, input.summary, input.firstItemAt, input.lastItemAt, input.createdAt, input.threadId],
+      );
+    });
+    this.persist();
+    return this.getInboxEntryByNumericId(this.getDigestThread(input.threadId)!.latestEntryId!)!;
+  }
+
+  closeDigestThread(threadId: number, updatedAt: string): void {
+    this.db.run(
+      "update digest_threads set status = 'closed', flush_after_at = null, updated_at = ? where thread_id = ?",
+      [updatedAt, threadId],
+    );
+    this.persist();
+  }
+
+  listDigestThreadsForRawItems(itemIds: string[]): DigestThreadRecord[] {
+    if (itemIds.length === 0) {
+      return [];
+    }
+    const placeholders = itemIds.map(() => "?").join(", ");
+    const rows = this.getAll(
+      `
+      select distinct t.*
+      from digest_threads t
+      join digest_thread_items i on i.thread_id = t.thread_id
+      where i.item_id in (${placeholders})
+      order by t.thread_id asc
+      `,
+      itemIds,
+    );
+    return rows.map((row) => this.mapDigestThread(row));
+  }
+
   listInboxItems(inboxId: string, options?: ListInboxItemsOptions): InboxItem[] {
     const includeAcked = options?.includeAcked ?? false;
     const filters = ["inbox_id = ?"];
@@ -1315,7 +1759,7 @@ export class AgentInboxStore {
         JSON.stringify(activation.sourceIds),
         activation.newItemCount,
         activation.summary,
-        activation.items ? JSON.stringify(activation.items) : null,
+        activation.entries ? JSON.stringify(activation.entries) : (activation.items ? JSON.stringify(activation.items) : null),
         activation.createdAt,
         activation.deliveredAt ?? null,
       ],
@@ -1737,6 +2181,10 @@ export class AgentInboxStore {
     return {
       inboxId: String(row.inbox_id),
       ownerAgentId: String(row.owner_agent_id),
+      aggregationEnabled: Number(row.aggregation_enabled ?? 0) > 0,
+      aggregationWindowMs: row.aggregation_window_ms == null ? null : Number(row.aggregation_window_ms),
+      aggregationMaxItems: row.aggregation_max_items == null ? null : Number(row.aggregation_max_items),
+      aggregationMaxThreadAgeMs: row.aggregation_max_thread_age_ms == null ? null : Number(row.aggregation_max_thread_age_ms),
       createdAt: String(row.created_at),
     };
   }
@@ -1879,6 +2327,72 @@ export class AgentInboxStore {
     };
   }
 
+  private mapInboxEntry(row: Record<string, unknown>): InboxEntry {
+    const base = {
+      entryId: formatEntryRef(Number(row.entry_id)),
+      inboxId: String(row.inbox_id),
+      sequence: Number(row.sequence),
+      itemId: "",
+      summary: String(row.summary),
+      count: Number(row.count),
+      itemIds: this.listEntryItemIds(Number(row.entry_id)),
+      sourceIds: parseJson<string[]>(row.source_ids_json as string),
+      subscriptionIds: parseJson<string[]>(row.subscription_ids_json as string),
+      firstItemAt: String(row.first_item_at),
+      lastItemAt: String(row.last_item_at),
+      deliveryHandle: row.delivery_handle_json
+        ? parseJson<InboxEntry["deliveryHandle"]>(row.delivery_handle_json as string)
+        : null,
+      ackedAt: row.acked_at ? String(row.acked_at) : null,
+      supersededAt: row.superseded_at ? String(row.superseded_at) : null,
+    };
+    if (String(row.kind) === "item") {
+      const item = parseJson<ActivationItem>(row.item_json as string);
+      return {
+        ...base,
+        kind: "item",
+        itemId: item.itemId,
+        sourceId: item.sourceId,
+        sourceNativeId: item.sourceNativeId,
+        eventVariant: item.eventVariant,
+        occurredAt: item.occurredAt,
+        metadata: item.metadata,
+        rawPayload: item.rawPayload,
+        item,
+      } as InboxEntry;
+    }
+    return {
+      ...base,
+      kind: "digest_snapshot",
+      itemId: base.itemIds[0] ?? formatEntryRef(Number(row.entry_id)),
+      threadId: formatThreadRef(Number(row.thread_id)),
+      revision: Number(row.revision),
+      groupKey: String(row.group_key),
+      resourceRef: row.resource_ref ? String(row.resource_ref) : null,
+      eventFamily: row.event_family ? String(row.event_family) : null,
+    };
+  }
+
+  private mapDigestThread(row: Record<string, unknown>): DigestThreadRecord {
+    return {
+      threadId: Number(row.thread_id),
+      inboxId: String(row.inbox_id),
+      sourceId: String(row.source_id),
+      groupKey: String(row.group_key),
+      resourceRef: row.resource_ref ? String(row.resource_ref) : null,
+      eventFamily: row.event_family ? String(row.event_family) : null,
+      latestRevision: Number(row.latest_revision),
+      latestEntryId: row.latest_entry_id == null ? null : Number(row.latest_entry_id),
+      status: String(row.status) as DigestThreadRecord["status"],
+      summary: String(row.summary),
+      firstItemAt: String(row.first_item_at),
+      lastItemAt: String(row.last_item_at),
+      flushAfterAt: row.flush_after_at ? String(row.flush_after_at) : null,
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
+    };
+  }
+
   private mapActivation(row: Record<string, unknown>): Activation {
     return {
       kind: "agentinbox.activation",
@@ -1889,9 +2403,10 @@ export class AgentInboxStore {
       targetKind: row.target_kind as Activation["targetKind"],
       subscriptionIds: parseJson<string[]>(row.subscription_ids_json as string),
       sourceIds: parseJson<string[]>(row.source_ids_json as string),
+      newEntryCount: row.items_json ? parseJson<Activation["entries"]>(row.items_json as string)?.length ?? 0 : Number(row.new_item_count),
       newItemCount: Number(row.new_item_count),
       summary: String(row.summary),
-      items: row.items_json ? parseJson<Activation["items"]>(row.items_json as string) : undefined,
+      entries: row.items_json ? parseJson<Activation["entries"]>(row.items_json as string) : undefined,
       createdAt: String(row.created_at),
       deliveredAt: row.delivered_at ? String(row.delivered_at) : null,
     };
@@ -1910,6 +2425,142 @@ export class AgentInboxStore {
       status: row.status as DeliveryAttempt["status"],
       createdAt: String(row.created_at),
     };
+  }
+
+  private getInboxEntryByNumericId(entryId: number): InboxEntry | null {
+    const row = this.getOne("select * from inbox_entries where entry_id = ?", [entryId]);
+    return row ? this.mapInboxEntry(row) : null;
+  }
+
+  private resolveInboxEntryNumericId(inboxId: string, refOrItemId: string): number {
+    try {
+      return parseEntryRef(refOrItemId);
+    } catch {
+      const row = this.getOne(
+        `
+        select e.entry_id
+        from inbox_entries e
+        join inbox_entry_items i on i.entry_id = e.entry_id
+        where e.inbox_id = ?
+          and i.item_id = ?
+        order by e.sequence desc
+        limit 1
+        `,
+        [inboxId, refOrItemId],
+      );
+      if (!row) {
+        throw new Error(`unknown inbox entry: ${refOrItemId}`);
+      }
+      return Number(row.entry_id);
+    }
+  }
+
+  private insertInboxEntryRecord(input: {
+    inboxId: string;
+    kind: InboxEntry["kind"];
+    threadId: number | null;
+    revision: number | null;
+    groupKey: string | null;
+    resourceRef: string | null;
+    eventFamily: string | null;
+    itemJson: string | null;
+    count: number;
+    summary: string;
+    firstItemAt: string;
+    lastItemAt: string;
+    sourceIdsJson: string;
+    subscriptionIdsJson: string;
+    deliveryHandleJson: string | null;
+    ackedAt: string | null;
+    supersededAt: string | null;
+    createdAt: string;
+  }): number {
+    this.db.run(
+      `
+      insert into inbox_entries (
+        inbox_id, kind, sequence, thread_id, revision, group_key, resource_ref, event_family,
+        item_json, count, summary, first_item_at, last_item_at, source_ids_json,
+        subscription_ids_json, delivery_handle_json, acked_at, superseded_at, created_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      [
+        input.inboxId,
+        input.kind,
+        this.nextInboxEntrySequence(),
+        input.threadId,
+        input.revision,
+        input.groupKey,
+        input.resourceRef,
+        input.eventFamily,
+        input.itemJson,
+        input.count,
+        input.summary,
+        input.firstItemAt,
+        input.lastItemAt,
+        input.sourceIdsJson,
+        input.subscriptionIdsJson,
+        input.deliveryHandleJson,
+        input.ackedAt,
+        input.supersededAt,
+        input.createdAt,
+      ],
+    );
+    return this.lastInsertRowId();
+  }
+
+  private nextInboxEntrySequence(): number {
+    const row = this.getOne("select coalesce(max(sequence), 0) + 1 as next_sequence from inbox_entries");
+    return Number(row?.next_sequence ?? 1);
+  }
+
+  private listEntryItemIds(entryId: number): string[] {
+    const rows = this.getAll(
+      "select item_id from inbox_entry_items where entry_id = ? order by item_id asc",
+      [entryId],
+    );
+    return rows.map((row) => String(row.item_id));
+  }
+
+  private getRawItemIdsForEntryIds(entryIds: number[]): string[] {
+    const itemIds = new Set<string>();
+    for (const entryId of entryIds) {
+      for (const itemId of this.listEntryItemIds(entryId)) {
+        itemIds.add(itemId);
+      }
+    }
+    return [...itemIds];
+  }
+
+  private syncInboxEntryAckState(inboxId: string, ackedAt: string): void {
+    this.db.run(
+      `
+      update inbox_entries
+      set acked_at = ?
+      where inbox_id = ?
+        and acked_at is null
+        and not exists (
+          select 1
+          from inbox_entry_items e
+          join inbox_items i on i.item_id = e.item_id
+          where e.entry_id = inbox_entries.entry_id
+            and i.acked_at is null
+        )
+      `,
+      [ackedAt, inboxId],
+    );
+    this.persist();
+  }
+
+  private countAckedEntries(entryIds: number[], ackedAt: string): number {
+    if (entryIds.length === 0) {
+      return 0;
+    }
+    const placeholders = entryIds.map(() => "?").join(", ");
+    const row = this.getOne(
+      `select count(*) as count from inbox_entries where entry_id in (${placeholders}) and acked_at = ?`,
+      [...entryIds, ackedAt],
+    );
+    return Number(row?.count ?? 0);
   }
 
   private mapStream(row: Record<string, unknown>): StreamRecord {
@@ -1962,4 +2613,12 @@ function requiredText(row: Record<string, unknown>, key: string): string {
     throw new Error(`missing required column: ${key}`);
   }
   return String(value);
+}
+
+function uniqueSorted(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => typeof value === "string" && value.length > 0))].sort();
+}
+
+function summarizeBackfilledItemEntry(item: InboxItem): string {
+  return `${item.eventVariant} from ${item.sourceId}`;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,3 +50,27 @@ export function asObject(value: unknown): Record<string, unknown> {
 export function jsonResponse(data: unknown): string {
   return JSON.stringify(data, null, 2);
 }
+
+export function formatEntryRef(entryId: number): string {
+  return `ent_${entryId}`;
+}
+
+export function parseEntryRef(ref: string): number {
+  const match = /^ent_(\d+)$/.exec(ref.trim());
+  if (!match) {
+    throw new Error(`invalid inbox entry id: ${ref}`);
+  }
+  return Number(match[1]);
+}
+
+export function formatThreadRef(threadId: number): string {
+  return `thr_${threadId}`;
+}
+
+export function parseThreadRef(ref: string): number {
+  const match = /^thr_(\d+)$/.exec(ref.trim());
+  if (!match) {
+    throw new Error(`invalid digest thread id: ${ref}`);
+  }
+  return Number(match[1]);
+}

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2040,7 +2040,7 @@ test("inbox read defaults to unacked items and ack through clears a processed ba
     const allItems = service.listInboxItems(alpha.agentId, { includeAcked: true });
     assert.equal(allItems.length, 3);
 
-    const ack = service.ackInboxItemsThrough(alpha.agentId, allItems[1].itemId);
+    const ack = await service.ackInboxItemsThrough(alpha.agentId, allItems[1].itemId);
     assert.equal(ack.acked, 2);
 
     const unread = service.listInboxItems(alpha.agentId);
@@ -2087,7 +2087,7 @@ test("ack through matches visible inbox order for same-timestamp items", async (
     const allItems = service.listInboxItems(alpha.agentId, { includeAcked: true });
     assert.deepEqual(allItems.map((item) => item.sourceNativeId), ["evt-1", "evt-2", "evt-3", "evt-4"]);
 
-    const ack = service.ackInboxItemsThrough(alpha.agentId, allItems[2]!.itemId);
+    const ack = await service.ackInboxItemsThrough(alpha.agentId, allItems[2]!.itemId);
     assert.equal(ack.acked, 3);
 
     const unread = service.listInboxItems(alpha.agentId);
@@ -2137,7 +2137,7 @@ test("ack through still follows visible order when older binaries left inbox_seq
     const visible = reopened.service.listInboxItems(alpha.agentId);
     assert.deepEqual(visible.map((item) => item.sourceNativeId), ["evt-1", "evt-2", "evt-3"]);
 
-    const ack = reopened.service.ackInboxItemsThrough(alpha.agentId, visible[1]!.itemId);
+    const ack = await reopened.service.ackInboxItemsThrough(alpha.agentId, visible[1]!.itemId);
     assert.equal(ack.acked, 2);
 
     const unread = reopened.service.listInboxItems(alpha.agentId);
@@ -2153,6 +2153,134 @@ test("ack through still follows visible order when older binaries left inbox_seq
       store.close();
     } catch {}
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("github bursts materialize digest snapshot entries when inbox aggregation is enabled", async () => {
+  const { service, store } = await makeService();
+  try {
+    const agent = await service.registerAgent({
+      runtimeKind: "codex",
+      backend: "tmux",
+      tmuxPaneId: "%agg",
+    });
+    service.updateInboxAggregationPolicy(agent.agent.agentId, {
+      enabled: true,
+      windowMs: 30_000,
+      maxItems: 20,
+      maxThreadAgeMs: 60_000,
+    });
+    const source = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox" },
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      filter: {},
+      cleanupPolicy: { mode: "manual" },
+      startPolicy: "earliest",
+    });
+
+    for (let index = 1; index <= 3; index += 1) {
+      await service.appendSourceEvent({
+        sourceId: source.sourceId,
+        sourceNativeId: `github-review-${index}`,
+        eventVariant: "PullRequestReviewCommentEvent.created",
+        metadata: {
+          number: 135,
+          isPullRequest: true,
+          repoFullName: "holon-run/agentinbox",
+        },
+        rawPayload: { id: index, type: "PullRequestReviewCommentEvent", action: "created" },
+      });
+    }
+
+    await service.pollSubscription(subscription.subscriptionId);
+    await (service as any).syncPendingDigestThreads(true);
+
+    const entries = service.listInboxItems(agent.agent.agentId);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.kind, "digest_snapshot");
+    assert.equal(entries[0]?.count, 3);
+    assert.equal(entries[0]?.itemIds.length, 3);
+    assert.match(entries[0]?.summary ?? "", /review comments on PR #135/);
+  } finally {
+    await service.stop();
+    store.close();
+  }
+});
+
+test("acking an older digest snapshot rematerializes a newer visible snapshot", async () => {
+  const { service, store } = await makeService();
+  try {
+    const agent = await service.registerAgent({
+      runtimeKind: "codex",
+      backend: "tmux",
+      tmuxPaneId: "%agg-ack",
+    });
+    service.updateInboxAggregationPolicy(agent.agent.agentId, {
+      enabled: true,
+      windowMs: 30_000,
+      maxItems: 20,
+      maxThreadAgeMs: 60_000,
+    });
+    const source = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox" },
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      filter: {},
+      cleanupPolicy: { mode: "manual" },
+      startPolicy: "earliest",
+    });
+
+    for (let index = 1; index <= 2; index += 1) {
+      await service.appendSourceEvent({
+        sourceId: source.sourceId,
+        sourceNativeId: `github-review-a-${index}`,
+        eventVariant: "PullRequestReviewCommentEvent.created",
+        metadata: { number: 136, isPullRequest: true },
+        rawPayload: { id: index, type: "PullRequestReviewCommentEvent", action: "created" },
+      });
+    }
+    await service.pollSubscription(subscription.subscriptionId);
+    await (service as any).syncPendingDigestThreads(true);
+
+    await service.appendSourceEvent({
+      sourceId: source.sourceId,
+      sourceNativeId: "github-review-a-3",
+      eventVariant: "PullRequestReviewCommentEvent.created",
+      metadata: { number: 136, isPullRequest: true },
+      rawPayload: { id: 3, type: "PullRequestReviewCommentEvent", action: "created" },
+    });
+    await service.pollSubscription(subscription.subscriptionId);
+    await (service as any).syncPendingDigestThreads(true);
+
+    const inbox = store.getInboxByAgentId(agent.agent.agentId)!;
+    const history = store.listInboxEntries(inbox.inboxId, { includeAcked: true })
+      .filter((entry) => entry.kind === "digest_snapshot");
+    assert.equal(history.length >= 2, true);
+    const older = history[0]!;
+    const visibleBefore = service.listInboxItems(agent.agent.agentId);
+    assert.equal(visibleBefore.length, 1);
+    assert.equal(visibleBefore[0]?.count, 3);
+
+    const ack = await service.ackInboxItems(agent.agent.agentId, [older.entryId]);
+    assert.equal(ack.acked, 1);
+
+    const visibleAfter = service.listInboxItems(agent.agent.agentId);
+    assert.equal(visibleAfter.length, 1);
+    assert.equal(visibleAfter[0]?.kind, "digest_snapshot");
+    assert.equal(visibleAfter[0]?.count, 1);
+    assert.equal(visibleAfter[0]?.itemIds.length, 1);
+  } finally {
+    await service.stop();
+    store.close();
   }
 });
 
@@ -2529,7 +2657,7 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
     assert.equal(dispatcher.calls.length, 1);
     assert.equal(terminalDispatcher.calls.length, 1);
 
-    const ack = service.ackAllInboxItems(registered.agent.agentId);
+    const ack = await service.ackAllInboxItems(registered.agent.agentId);
     assert.equal(ack.acked, 2);
 
     await service.appendSourceEventByCaller(source.sourceId, {
@@ -2769,7 +2897,7 @@ test("terminal activation prompts use the current unacked inbox total", async ()
     const allItems = service.listInboxItems(registered.agent.agentId, { includeAcked: false });
     assert.equal(allItems.length, 2);
 
-    const ack = service.ackInboxItemsThrough(registered.agent.agentId, allItems[0]!.itemId);
+    const ack = await service.ackInboxItemsThrough(registered.agent.agentId, allItems[0]!.itemId);
     assert.equal(ack.acked, 1);
     await sleep(40);
 
@@ -3423,7 +3551,7 @@ test("terminal reminder fingerprints use the canonical unacked item set", async 
 
     const allItems = service.listInboxItems(registered.agent.agentId, { includeAcked: false });
     assert.equal(allItems.length, 2);
-    service.ackInboxItemsThrough(registered.agent.agentId, allItems[0]!.itemId);
+    await service.ackInboxItemsThrough(registered.agent.agentId, allItems[0]!.itemId);
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 2);

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2156,6 +2156,54 @@ test("ack through still follows visible order when older binaries left inbox_seq
   }
 });
 
+test("legacy afterItemId paging still works against entry-backed inbox reads", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "after-item");
+    const inboxId = (service.getInboxDetailsByAgent(alpha.agentId) as { inbox: { inboxId: string } }).inbox.inboxId;
+
+    store.insertInboxItem({
+      itemId: "item-after-1",
+      sourceId: "src-after",
+      sourceNativeId: "evt-after-1",
+      eventVariant: "message.created",
+      inboxId,
+      occurredAt: "2026-04-01T00:00:00Z",
+      metadata: {},
+      rawPayload: { message: "first" },
+      deliveryHandle: null,
+      ackedAt: null,
+    });
+    store.insertInboxItem({
+      itemId: "item-after-2",
+      sourceId: "src-after",
+      sourceNativeId: "evt-after-2",
+      eventVariant: "message.created",
+      inboxId,
+      occurredAt: "2026-04-01T00:00:01Z",
+      metadata: {},
+      rawPayload: { message: "second" },
+      deliveryHandle: null,
+      ackedAt: null,
+    });
+    (store as unknown as { ensureInboxEntryBackfill(): void }).ensureInboxEntryBackfill();
+
+    const visible = service.listInboxItems(alpha.agentId, { includeAcked: true });
+    assert.equal(visible.length, 2);
+
+    const afterFirst = service.listInboxItems(alpha.agentId, {
+      includeAcked: true,
+      afterItemId: visible[0]!.itemId,
+    });
+    assert.equal(afterFirst.length, 1);
+    assert.equal(afterFirst[0]!.itemId, "item-after-2");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("github bursts materialize digest snapshot entries when inbox aggregation is enabled", async () => {
   const { service, store } = await makeService();
   try {
@@ -2585,13 +2633,13 @@ test("compact and gc remove only acked inbox items older than retention", async 
 
     const compact = service.compactInbox(alpha.agentId);
     assert.equal(compact.deleted, 1);
-    assert.equal(service.listInboxItems(alpha.agentId, { includeAcked: true }).length, 1);
-    assert.equal(service.listInboxItems(beta.agentId, { includeAcked: true }).length, 1);
+    assert.equal(service.listRawInboxItems(alpha.agentId, { includeAcked: true }).length, 1);
+    assert.equal(service.listRawInboxItems(beta.agentId, { includeAcked: true }).length, 1);
 
     const gc = service.gcAckedInboxItems();
     assert.equal(gc.deleted, 1);
-    assert.equal(service.listInboxItems(beta.agentId, { includeAcked: true }).length, 0);
-    assert.equal(service.listInboxItems(alpha.agentId).length, 1);
+    assert.equal(service.listRawInboxItems(beta.agentId, { includeAcked: true }).length, 0);
+    assert.equal(service.listRawInboxItems(alpha.agentId).length, 1);
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1003,10 +1003,10 @@ test("cli inbox send writes a direct text message into the target inbox", () => 
 
     const read = runCli(["inbox", "read", "--agent-id", registered.agent.agentId, "--include-acked"], env);
     assert.equal(read.status, 0, read.stderr);
-    const payload = JSON.parse(read.stdout) as { items: Array<{ itemId: string; rawPayload: Record<string, unknown> }> };
-    assert.equal(payload.items.length, 1);
-    assert.equal(payload.items[0].itemId, delivered.itemId);
-    assert.deepEqual(payload.items[0].rawPayload, {
+    const payload = JSON.parse(read.stdout) as { entries: Array<{ itemId: string; rawPayload: Record<string, unknown> }> };
+    assert.equal(payload.entries.length, 1);
+    assert.equal(payload.entries[0].itemId, delivered.itemId);
+    assert.deepEqual(payload.entries[0].rawPayload, {
       type: "direct_text_message",
       message: "Review PR #51 CI failure and push a fix.",
       sender: "local-script",

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -963,7 +963,7 @@ test("cli inbox read rejects unsupported flags like --ack", () => {
   try {
     const read = runCli(["inbox", "read", "--ack"], env);
     assert.notEqual(read.status, 0);
-    assert.match(read.stderr, /usage: agentinbox inbox read \[--agent-id ID] \[--after-item ID] \[--include-acked]/);
+    assert.match(read.stderr, /usage: agentinbox inbox read \[--agent-id ID] \[--after-entry ID] \[--include-acked]/);
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });
@@ -2003,36 +2003,36 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(activation.targetKind, "webhook");
       assert.equal(activation.newItemCount, 1);
 
-      const inboxResponse = await client.request<{ items: InboxItem[] }>(
-        `/agents/${encodeURIComponent(agentId)}/inbox/items`,
+      const inboxResponse = await client.request<{ entries: Array<{ entryId: string }> }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/entries`,
         undefined,
         "GET",
       );
       assert.equal(inboxResponse.statusCode, 200);
-      assert.equal(inboxResponse.data.items.length, 1);
+      assert.equal(inboxResponse.data.entries.length, 1);
 
       const ackResponse = await client.request<{ acked: number }>(
         `/agents/${encodeURIComponent(agentId)}/inbox/ack`,
-        { throughItemId: inboxResponse.data.items[0].itemId },
+        { throughEntryId: inboxResponse.data.entries[0].entryId },
       );
       assert.equal(ackResponse.statusCode, 200);
       assert.equal(ackResponse.data.acked, 1);
 
-      const unreadAfterAck = await client.request<{ items: InboxItem[] }>(
-        `/agents/${encodeURIComponent(agentId)}/inbox/items`,
+      const unreadAfterAck = await client.request<{ entries: Array<{ entryId: string }> }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/entries`,
         undefined,
         "GET",
       );
       assert.equal(unreadAfterAck.statusCode, 200);
-      assert.equal(unreadAfterAck.data.items.length, 0);
+      assert.equal(unreadAfterAck.data.entries.length, 0);
 
-      const historyAfterAck = await client.request<{ items: InboxItem[] }>(
-        `/agents/${encodeURIComponent(agentId)}/inbox/items?include_acked=true`,
+      const historyAfterAck = await client.request<{ entries: Array<{ entryId: string }> }>(
+        `/agents/${encodeURIComponent(agentId)}/inbox/entries?include_acked=true`,
         undefined,
         "GET",
       );
       assert.equal(historyAfterAck.statusCode, 200);
-      assert.equal(historyAfterAck.data.items.length, 1);
+      assert.equal(historyAfterAck.data.entries.length, 1);
 
       const removeSubscriptionResponse = await client.request<{ removed: boolean; subscriptionId: string }>(
         `/subscriptions/${encodeURIComponent(subscriptionResponse.data.subscriptionId)}`,
@@ -2157,7 +2157,7 @@ test("control plane accepts direct inbox text messages and rejects blank payload
       assert.equal(activation.items?.[0]?.eventVariant, "agentinbox.direct_text_message");
 
       const inboxResponse = await client.request<{ items: InboxItem[] }>(
-        `/agents/${encodeURIComponent(agentId)}/inbox/items?include_acked=true`,
+        `/agents/${encodeURIComponent(agentId)}/inbox/raw-items?include_acked=true`,
         undefined,
         "GET",
       );
@@ -2327,7 +2327,7 @@ test("control plane exposes timer lifecycle endpoints and timer firing writes in
 
       await (service as unknown as { syncTimers(): Promise<void> }).syncTimers();
       const inboxResponse = await client.request<{ items: InboxItem[] }>(
-        `/agents/${encodeURIComponent(agentId)}/inbox/items?include_acked=true`,
+        `/agents/${encodeURIComponent(agentId)}/inbox/raw-items?include_acked=true`,
         undefined,
         "GET",
       );
@@ -2435,7 +2435,7 @@ test("control plane exposes inbox compact and global gc endpoints", async () => 
       assert.equal(compactResponse.data.deleted, 1);
 
       const compactRead = await client.request<{ items: InboxItem[] }>(
-        `/agents/${encodeURIComponent(agentId)}/inbox/items?include_acked=true`,
+        `/agents/${encodeURIComponent(agentId)}/inbox/raw-items?include_acked=true`,
         undefined,
         "GET",
       );


### PR DESCRIPTION
## Summary
- add durable inbox entry and digest-thread tables plus migration/backfill from raw inbox items
- cut inbox read/watch/ack to entry semantics, add raw debug reads, and expose inbox aggregation policy
- materialize grouped GitHub/GitHub CI bursts into digest snapshots with snapshot-based ack/rematerialization

## Testing
- npm run build
- node --require ts-node/register --test --test-force-exit --test-name-pattern "github bursts materialize digest snapshot entries when inbox aggregation is enabled|acking an older digest snapshot rematerializes a newer visible snapshot|inbox read defaults to unacked items and ack through clears a processed batch|ack through still follows visible order when older binaries left inbox_sequence null" test/agentinbox.test.ts
- node --require ts-node/register --test --test-force-exit --test-name-pattern "control plane accepts notification policy thresholds for agent and webhook targets|cli agent register accepts min-unacked-items|direct inbox text messages create inbox items and trigger activation" test/control_plane.test.ts test/agentinbox.test.ts
- node --require ts-node/register --test --test-force-exit --test-name-pattern "webhook and terminal targets share ack-gated notification flow|terminal activation prompts use the current unacked inbox total|lease expiry does not repeat identical terminal prompts for unchanged inbox state|dirty terminal reminders re-notify only when the effective prompt changes" test/agentinbox.test.ts
- node --require ts-node/register --test --test-force-exit --test-name-pattern "cli inbox read rejects unsupported flags like --ack" test/control_plane.test.ts
- node --require ts-node/register --test --test-force-exit --test-name-pattern "control plane accepts direct inbox text messages and rejects blank payloads|control plane exposes timer lifecycle endpoints and timer firing writes inbox items|control plane exposes inbox compact and global gc endpoints" test/control_plane.test.ts
