### PR TITLE
refactor: adopt canonical short durable ids

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -25,6 +25,7 @@ webhook targets.
 
 - [Event Filtering RFC](./rfcs/event-filtering.md)
 - [Inbox Digests And Threaded Notification Entries](./rfcs/inbox-digests-and-threaded-notification-entries.md)
+- [Public And Internal Identifier Strategy](./rfcs/public-and-internal-identifier-strategy.md)
 
 ## Current Status
 

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -115,11 +115,11 @@ Use exactly one of `at`, `every`, or `cron`. `every` is an interval in milliseco
 `POST /agents/{agentId}/inbox/ack` accepts exactly one of:
 
 ```json
-{ "throughItemId": "item_..." }
+{ "throughItemId": "itm_..." }
 ```
 
 ```json
-{ "itemIds": ["item_..."] }
+{ "itemIds": ["itm_..."] }
 ```
 
 ```json

--- a/docs/site/rfcs/README.md
+++ b/docs/site/rfcs/README.md
@@ -4,6 +4,7 @@
 - [Source Kinds And Resolved Schemas](./source-kinds-and-resolved-schemas.md)
 - [Subscription Lifecycle And Terminal Auto-Retire](./subscription-lifecycle-and-terminal-retire.md)
 - [Inbox Digests And Threaded Notification Entries](./inbox-digests-and-threaded-notification-entries.md)
+- [Public And Internal Identifier Strategy](./public-and-internal-identifier-strategy.md)
 
 <!-- INDEX:START -->
 
@@ -17,6 +18,10 @@
 
 - [Inbox Digests And Threaded Notification Entries](./inbox-digests-and-threaded-notification-entries.md)
   2026-04-17 · Reduce bursty notification noise by keeping raw inbox items immutable, while materializing agent-facing digest threads and immutable digest snapshots for read, activation, and ack.
+  <!-- mdorigin:index kind=article -->
+
+- [Public And Internal Identifier Strategy](./public-and-internal-identifier-strategy.md)
+  2026-04-18 · Replace long prefix_uuid identifiers with canonical short IDs, move entry/thread to stored string IDs, and standardize how AgentInbox creates and persists durable identifiers before v1 release.
   <!-- mdorigin:index kind=article -->
 
 - [Source Hosts And Streams](./source-hosts-and-streams.md)

--- a/docs/site/rfcs/current-agent-resolution.md
+++ b/docs/site/rfcs/current-agent-resolution.md
@@ -112,7 +112,7 @@ Suggested JSON response:
 
 ```json
 {
-  "agentId": "agent_codex_...",
+  "agentId": "agt_copper-fox",
   "bindingKind": "session_bound",
   "matchesCurrentTerminal": true,
   "matchesCurrentRuntime": true,
@@ -181,7 +181,7 @@ Suggested JSON response extension:
 
 ```json
 {
-  "agentId": "agent_codex_...",
+  "agentId": "agt_copper-fox",
   "autoRegistered": true
 }
 ```

--- a/docs/site/rfcs/public-and-internal-identifier-strategy.md
+++ b/docs/site/rfcs/public-and-internal-identifier-strategy.md
@@ -1,0 +1,258 @@
+---
+title: Public And Internal Identifier Strategy
+date: 2026-04-18
+type: page
+summary: Replace long prefix_uuid identifiers with canonical short IDs, keep only sequence and revision as numeric ordering fields, and align fresh v1 databases on one identifier scheme before release.
+---
+
+# Public And Internal Identifier Strategy
+
+## Summary
+
+Before v1 release, `AgentInbox` should stop using long `prefix_uuid`
+identifiers for durable records and move to one canonical short-ID scheme.
+
+This is a pre-release cleanup, not a compatibility exercise.
+
+The intended outcome is:
+
+- fresh v1 databases create only short canonical IDs
+- pre-v1 local databases remain handled by the reset/archive boundary from
+  `#139/#140`
+- there is no requirement to preserve old long-form `prefix_uuid` IDs
+- `entryId` and `threadId` also become canonical stored string IDs instead of
+  integer-only database keys with formatted boundary wrappers
+
+After this change, the repository should use only two identifier styles:
+
+- readable generated names for `agentId`
+- short prefixed string IDs for every other durable identifier
+
+Numeric fields remain only where they are truly ordering or revision fields,
+such as `sequence`, `revision`, and event offsets.
+
+## Problem
+
+Today the repository mixes several identifier schemes:
+
+- long `prefix_uuid` strings for most durable rows
+- integer-backed `ent_<n>` and `thr_<n>` refs for inbox entries and digest
+  threads
+- a few user-supplied IDs such as explicit `agentId`
+
+That has several costs:
+
+- verbose CLI and HTTP payloads
+- worse readability in logs, tests, docs, and LLM workflows
+- extra token cost for agents
+- no single answer to “what form should a new durable ID take?”
+
+Because v1 has not yet shipped, this is the right time to cleanly reset the
+identifier rules instead of preserving pre-release compatibility.
+
+## Goals
+
+- define one canonical ID scheme for fresh v1 databases
+- shorten durable IDs used in CLI, HTTP, docs, tests, and agent workflows
+- make database storage shape match public API shape for durable IDs
+- keep explicit user-supplied `agentId` support
+- remove UUID-backed durable IDs from normal product paths
+
+## Non-Goals
+
+- do not preserve compatibility with old long-form `prefix_uuid` IDs
+- do not add alias tables or dual-ID support
+- do not change provider-native identifiers such as `DeliveryHandle.targetRef`
+- do not turn ordering fields such as `sequence` into string IDs
+
+## Core Design
+
+## 1. Fresh v1 Databases Use The New Scheme Only
+
+`#139/#140` already defined the storage reset boundary for pre-v1 data.
+
+That means this RFC can be simpler:
+
+- pre-v1 local databases are outside the compatibility boundary
+- fresh v1 databases should be created directly with the new identifier scheme
+- there is no requirement to support in-place rewrite of released v1 databases
+
+This RFC therefore defines the canonical ID rules for the database shape that
+ships as v1.
+
+## 2. Canonical Prefix Table
+
+The repository should standardize on these canonical prefixes:
+
+- `agt_` agent
+- `inb_` inbox
+- `hst_` source host
+- `src_` source stream
+- `sub_` subscription
+- `tgt_` activation target
+- `sch_` timer schedule
+- `str_` event-bus stream
+- `itm_` inbox item
+- `act_` activation
+- `dlv_` delivery
+- `evt_` stream event
+- `con_` consumer
+- `cmt_` consumer commit
+- `ent_` inbox entry
+- `thr_` digest thread
+
+This is not just documentation. The code should be updated to use these
+prefixes consistently.
+
+In particular, this RFC intentionally changes current implementation prefixes
+such as:
+
+- `sched` -> `sch`
+- `item` -> `itm`
+- `strevt` -> `evt`
+- `commit` -> `cmt`
+
+## 3. Agent IDs Use Readable Names
+
+`agentId` is the one durable identifier that should default to a readable name
+instead of a random token.
+
+Default generated shape:
+
+- `agt_<word>-<word>`
+
+Example:
+
+- `agt_copper-fox`
+
+Generation rules:
+
+- lowercase words only
+- two-word combination from a fixed word list
+- collisions resolved by regeneration
+- if repeated collisions exceed a fixed retry budget, fall back to:
+  - `agt_<word>-<word>-<short>`
+
+This preserves:
+
+- readability in logs and CLI
+- short references for humans and agents
+- deterministic conflict handling
+
+Explicit user-supplied `agentId` remains supported and is not rewritten.
+
+## 4. All Other Durable IDs Use Short Random Tokens
+
+All other durable identifiers should use one short-token family:
+
+- `prefix_<token>`
+
+Recommended token properties:
+
+- lowercase only
+- visually conservative alphabet
+- fixed length
+- collision handling via regenerate-and-retry
+
+Examples:
+
+- `src_7k2f9m3qw1bx`
+- `sub_d4n8xr1w6pqt`
+- `itm_b6tj4r8pm2vk`
+- `ent_m7q4x2p9d8rv`
+
+The exact token generator can be an implementation choice, but the product rule
+is:
+
+- all non-agent durable IDs are short canonical strings with the stable prefix
+  vocabulary above
+
+## 5. Database Storage Matches Public Shape
+
+Durable IDs should be stored in the database exactly as they are exposed through
+CLI and HTTP.
+
+That means:
+
+- `source_id` stores `src_<token>`
+- `subscription_id` stores `sub_<token>`
+- `entry_id` stores `ent_<token>`
+- `thread_id` stores `thr_<token>`
+
+The repository should no longer maintain a special “integer in DB, prefixed ref
+at the boundary” path for durable IDs.
+
+This simplifies:
+
+- SQL inspection
+- joins and debugging
+- JSON payload persistence
+- documentation and tests
+
+## 6. Entry And Thread Keep Numeric Ordering Fields, Not Numeric IDs
+
+`InboxEntry` and `DigestThread` no longer need special integer identity rules.
+
+Instead:
+
+- `entryId` is a canonical string ID: `ent_<token>`
+- `threadId` is a canonical string ID: `thr_<token>`
+
+If ordering is needed, keep it in dedicated numeric fields:
+
+- `inbox_entries.sequence`
+- `inbox_entries.revision`
+- stream/event offsets
+
+This preserves the useful part of the current design:
+
+- stable numeric order and ack boundaries
+
+without preserving the confusing part:
+
+- durable IDs whose stored database shape differs from their public form
+
+## 7. Internal Durable IDs Follow The Same Short-ID Family
+
+The following internal-but-durable IDs should also move off UUIDs and use the
+same canonical short-ID family:
+
+- `streamId`
+- `itemId`
+- `activationId`
+- `deliveryId`
+- `streamEventId`
+- `consumerId`
+- `commitId`
+
+They do not need readable names, but they should still follow the same prefix +
+short-token rule as other durable IDs.
+
+This keeps the system from mixing:
+
+- readable names
+- short IDs
+- UUIDs
+- special ref-only wrappers
+
+for durable records.
+
+## Operational Consequences
+
+Once implemented:
+
+- docs and examples should stop showing `prefix_uuid` forms
+- fresh v1 databases should never create UUID-backed durable IDs
+- `entryId` and `threadId` should look the same in storage and in API output
+- the codebase should have one canonical answer for “how do I create a new
+  durable ID?”
+
+## Open Coding Rule
+
+After this RFC:
+
+- new durable records must use either:
+  - readable agent IDs, or
+  - canonical short prefixed string IDs
+- numeric fields should be used only for ordering/revision semantics, not as
+  hidden durable identities that are reformatted later

--- a/drizzle/migrations/0000_v1_initial.sql
+++ b/drizzle/migrations/0000_v1_initial.sql
@@ -230,14 +230,14 @@ create table if not exists source_hosts (
 );
 
 create table if not exists digest_threads (
-  thread_id integer primary key autoincrement,
+  thread_id text primary key,
   inbox_id text not null,
   source_id text not null,
   group_key text not null,
   resource_ref text,
   event_family text,
   latest_revision integer not null,
-  latest_entry_id integer,
+  latest_entry_id text,
   status text not null,
   summary text not null,
   first_item_at text not null,
@@ -248,11 +248,11 @@ create table if not exists digest_threads (
 );
 
 create table if not exists inbox_entries (
-  entry_id integer primary key autoincrement,
+  entry_id text primary key,
   inbox_id text not null,
   kind text not null,
   sequence integer not null unique,
-  thread_id integer,
+  thread_id text,
   revision integer,
   group_key text,
   resource_ref text,
@@ -271,13 +271,13 @@ create table if not exists inbox_entries (
 );
 
 create table if not exists inbox_entry_items (
-  entry_id integer not null,
+  entry_id text not null,
   item_id text not null,
   primary key (entry_id, item_id)
 );
 
 create table if not exists digest_thread_items (
-  thread_id integer not null,
+  thread_id text not null,
   item_id text not null,
   primary key (thread_id, item_id)
 );

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -184,14 +184,14 @@ export const inboxItems = sqliteTable("inbox_items", {
 }));
 
 export const digestThreads = sqliteTable("digest_threads", {
-  threadId: integer("thread_id").primaryKey({ autoIncrement: true }),
+  threadId: text("thread_id").primaryKey(),
   inboxId: text("inbox_id").notNull(),
   sourceId: text("source_id").notNull(),
   groupKey: text("group_key").notNull(),
   resourceRef: text("resource_ref"),
   eventFamily: text("event_family"),
   latestRevision: integer("latest_revision").notNull(),
-  latestEntryId: integer("latest_entry_id"),
+  latestEntryId: text("latest_entry_id"),
   status: text("status").notNull(),
   summary: text("summary").notNull(),
   firstItemAt: text("first_item_at").notNull(),
@@ -206,11 +206,11 @@ export const digestThreads = sqliteTable("digest_threads", {
 }));
 
 export const inboxEntries = sqliteTable("inbox_entries", {
-  entryId: integer("entry_id").primaryKey({ autoIncrement: true }),
+  entryId: text("entry_id").primaryKey(),
   inboxId: text("inbox_id").notNull(),
   kind: text("kind").notNull(),
   sequence: integer("sequence").notNull(),
-  threadId: integer("thread_id"),
+  threadId: text("thread_id"),
   revision: integer("revision"),
   groupKey: text("group_key"),
   resourceRef: text("resource_ref"),
@@ -233,7 +233,7 @@ export const inboxEntries = sqliteTable("inbox_entries", {
 }));
 
 export const inboxEntryItems = sqliteTable("inbox_entry_items", {
-  entryId: integer("entry_id").notNull(),
+  entryId: text("entry_id").notNull(),
   itemId: text("item_id").notNull(),
 }, (table) => ({
   pk: primaryKey({ columns: [table.entryId, table.itemId] }),
@@ -241,7 +241,7 @@ export const inboxEntryItems = sqliteTable("inbox_entry_items", {
 }));
 
 export const digestThreadItems = sqliteTable("digest_thread_items", {
-  threadId: integer("thread_id").notNull(),
+  threadId: text("thread_id").notNull(),
   itemId: text("item_id").notNull(),
 }, (table) => ({
   pk: primaryKey({ columns: [table.threadId, table.itemId] }),

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -4,7 +4,7 @@ import {
   SubscriptionStartPolicy,
 } from "./model";
 import { AgentInboxStore } from "./store";
-import { nowIso } from "./util";
+import { generateCanonicalId, nowIso } from "./util";
 
 export interface StreamRecord {
   streamId: string;
@@ -137,7 +137,7 @@ export class SqliteEventBusBackend implements EventBusBackend {
       return existing;
     }
     const stream: StreamRecord = {
-      streamId: streamIdForSource(input.sourceId),
+      streamId: generateCanonicalId("str"),
       sourceId: input.sourceId,
       streamKey: input.streamKey,
       backend: input.backend,
@@ -172,7 +172,7 @@ export class SqliteEventBusBackend implements EventBusBackend {
       input.startTime ?? null,
     );
     const consumer: ConsumerRecord = {
-      consumerId: consumerIdForSubscription(input.subscriptionId),
+      consumerId: generateCanonicalId("con"),
       streamId: input.streamId,
       subscriptionId: input.subscriptionId,
       consumerKey: input.consumerKey,
@@ -296,18 +296,6 @@ export class SqliteEventBusBackend implements EventBusBackend {
     }
     throw new Error(`unsupported start policy: ${String(startPolicy)}`);
   }
-}
-
-export function streamIdForSource(sourceId: string): string {
-  return `stream_${sourceId}`;
-}
-
-export function consumerIdForSubscription(subscriptionId: string): string {
-  return `consumer_${subscriptionId}`;
-}
-
-export function defaultInboxIdForAgent(agentId: string): string {
-  return `inbox_${agentId}`;
 }
 
 export function streamKeyForSource(sourceId: string): string {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1611,8 +1611,8 @@ function buildFastifyServer(service: AgentInboxService) {
       all?: boolean;
     };
     return service.ackInbox(decodeURIComponent(params.agentId), {
-      itemIds: body.entryIds ?? [],
-      throughItemId: body.throughEntryId ?? null,
+      entryIds: body.entryIds ?? [],
+      throughEntryId: body.throughEntryId ?? null,
       all: body.all ?? false,
     });
   });

--- a/src/service.ts
+++ b/src/service.ts
@@ -55,11 +55,10 @@ import {
   ConsumerLag,
   EventBusBackend,
   SqliteEventBusBackend,
-  defaultInboxIdForAgent,
   streamKeyForSource,
   toAppendResult,
 } from "./backend";
-import { formatEntryRef, generateId, nowIso } from "./util";
+import { formatEntryRef, generateCanonicalId, nowIso } from "./util";
 import { getSourceSchema } from "./source_schema";
 import { withResolvedIdentity } from "./source_resolution";
 import { matchSubscriptionFilter, validateSubscriptionFilter } from "./filter";
@@ -241,7 +240,7 @@ export class AgentInboxService {
     let host = this.store.getSourceHostByKey(resolved.hostType, resolved.hostKey);
     if (!host) {
       host = {
-        hostId: generateId("hst"),
+        hostId: generateCanonicalId("hst"),
         hostType: resolved.hostType,
         hostKey: resolved.hostKey,
         configRef: input.configRef ?? null,
@@ -253,7 +252,7 @@ export class AgentInboxService {
       this.store.insertSourceHost(host);
     }
     const source: SubscriptionSource = {
-      sourceId: generateId("src"),
+      sourceId: generateCanonicalId("src"),
       hostId: host.hostId,
       streamKind: resolved.streamKind,
       streamKey: resolved.streamKey,
@@ -355,7 +354,7 @@ export class AgentInboxService {
     }
     const now = nowIso();
     const host: SourceHost = {
-      hostId: generateId("hst"),
+      hostId: generateCanonicalId("hst"),
       hostType: input.hostType,
       hostKey: input.hostKey,
       configRef: input.configRef ?? null,
@@ -388,7 +387,7 @@ export class AgentInboxService {
     const compatSourceType = input.compatSourceType ?? sourceTypeForStreamRegistration(host.hostType, input.streamKind);
     const now = nowIso();
     const stream: SourceStream = {
-      sourceId: generateId("src"),
+      sourceId: generateCanonicalId("src"),
       streamId: null,
       hostId: input.hostId,
       streamKind: input.streamKind,
@@ -573,7 +572,7 @@ export class AgentInboxService {
     validateTerminalRegistration(input);
 
     const runtimeKind = input.runtimeKind ?? "unknown";
-    const agentId = input.agentId ?? assignedAgentIdFromContext({
+    const agentId = input.agentId ?? this.resolveAutoAgentId({
       runtimeKind,
       runtimeSessionId: input.runtimeSessionId ?? null,
       backend: input.backend,
@@ -696,7 +695,7 @@ export class AgentInboxService {
       restartRecovery: false,
     });
     const timer: AgentTimer = {
-      scheduleId: generateId("sched"),
+      scheduleId: generateCanonicalId("sch"),
       agentId: input.agentId,
       status: nextFireAt ? "active" : "paused",
       mode: normalized.mode,
@@ -789,7 +788,7 @@ export class AgentInboxService {
     const mode = normalizeWebhookActivationMode(input.activationMode);
     const now = nowIso();
     const target: WebhookActivationTarget = {
-      targetId: generateId("tgt"),
+      targetId: generateCanonicalId("tgt"),
       agentId,
       kind: "webhook",
       status: "active",
@@ -928,7 +927,7 @@ export class AgentInboxService {
       this.store.deleteSourceIdleState(source.sourceId);
     }
     const subscription: Subscription = {
-      subscriptionId: generateId("sub"),
+      subscriptionId: generateCanonicalId("sub"),
       agentId: input.agentId,
       sourceId: input.sourceId,
       filter: input.filter ?? {},
@@ -1106,7 +1105,7 @@ export class AgentInboxService {
     const sender = normalizeDirectInboxSender(input.sender) ?? this.detectDirectInboxSender(env);
     return this.materializeAgentInboxItem(agentId, {
       sourceId: DIRECT_INBOX_SOURCE_ID,
-      sourceNativeId: generateId("direct"),
+      sourceNativeId: generateCanonicalId("direct"),
       eventVariant: DIRECT_INBOX_EVENT_VARIANT,
       summary: summarizeDirectInboxMessage(sender),
       rawPayload: {
@@ -1167,7 +1166,7 @@ export class AgentInboxService {
     const inbox = this.ensureInboxForAgent(agentId);
     const occurredAt = input.occurredAt ?? nowIso();
     const item: InboxItem = {
-      itemId: generateId("item"),
+      itemId: generateCanonicalId("itm"),
       sourceId: input.sourceId,
       sourceNativeId: input.sourceNativeId,
       eventVariant: input.eventVariant,
@@ -1288,7 +1287,7 @@ export class AgentInboxService {
 
   private async flushDigestThread(
     source: SubscriptionSource,
-    threadId: number,
+    threadId: string,
     groupingHint?: NotificationGrouping | null,
   ): Promise<InboxEntry | null> {
     const thread = this.store.getDigestThread(threadId);
@@ -1542,7 +1541,7 @@ export class AgentInboxService {
           }
           matched += 1;
           const item: InboxItem = {
-            itemId: generateId("item"),
+            itemId: generateCanonicalId("itm"),
             sourceId: event.sourceId,
             sourceNativeId: event.sourceNativeId,
             eventVariant: event.eventVariant,
@@ -1628,7 +1627,7 @@ export class AgentInboxService {
     const handle = resolveDeliveryHandle(request);
     const source = resolveDeliverySource(this.store, request.sourceId, handle);
     const attempt: DeliveryAttempt = {
-      deliveryId: generateId("dlv"),
+      deliveryId: generateCanonicalId("dlv"),
       provider: handle.provider,
       surface: handle.surface,
       targetRef: handle.targetRef,
@@ -1666,7 +1665,7 @@ export class AgentInboxService {
     const handle = resolveDeliveryHandle(request);
     const source = resolveDeliverySource(this.store, request.sourceId, handle);
     const attempt: DeliveryAttempt = {
-      deliveryId: generateId("dlv"),
+      deliveryId: generateCanonicalId("dlv"),
       provider: handle.provider,
       surface: handle.surface,
       targetRef: handle.targetRef,
@@ -1731,7 +1730,7 @@ export class AgentInboxService {
       return existing;
     }
     const inbox: Inbox = {
-      inboxId: defaultInboxIdForAgent(agentId),
+      inboxId: generateCanonicalId("inb"),
       ownerAgentId: agentId,
       createdAt: nowIso(),
     };
@@ -1834,6 +1833,37 @@ export class AgentInboxService {
     }
   }
 
+  private resolveAutoAgentId(input: {
+    runtimeKind?: Agent["runtimeKind"] | null;
+    runtimeSessionId?: string | null;
+    backend: RegisterAgentInput["backend"];
+    tmuxPaneId?: string | null;
+    itermSessionId?: string | null;
+    tty?: string | null;
+  }): string {
+    for (let attempt = 0; attempt < 32; attempt += 1) {
+      const candidate = assignedAgentIdFromContext({
+        runtimeKind: input.runtimeKind,
+        runtimeSessionId: input.runtimeSessionId,
+        backend: input.backend,
+        tmuxPaneId: input.tmuxPaneId,
+        itermSessionId: input.itermSessionId,
+        tty: input.tty,
+      }, attempt);
+      const existing = this.store.getAgent(candidate);
+      if (!existing) {
+        return candidate;
+      }
+      const targets = this.store
+        .listActivationTargetsForAgent(candidate)
+        .filter((target): target is TerminalActivationTarget => target.kind === "terminal");
+      if (targets.length === 0 || targets.some((target) => isSameTerminalIdentity(target, input))) {
+        return candidate;
+      }
+    }
+    throw new Error("unable to derive a unique agentId from terminal context");
+  }
+
   private handleAgentRegistrationConflicts(agentId: string, input: RegisterAgentInput): void {
     const currentTarget = findExistingTerminalActivationTarget(this.store, input);
     if (currentTarget && currentTarget.agentId !== agentId) {
@@ -1889,7 +1919,7 @@ export class AgentInboxService {
     }
 
     const target: TerminalActivationTarget = {
-      targetId: generateId("tgt"),
+      targetId: generateCanonicalId("tgt"),
       agentId,
       kind: "terminal",
       status: "active",
@@ -2152,7 +2182,7 @@ export class AgentInboxService {
         this.store.closeDigestThread(thread.threadId, nowIso());
         continue;
       }
-      const head = thread.latestEntryId != null ? this.store.getInboxEntry(formatEntryRef(thread.latestEntryId)) : null;
+      const head = thread.latestEntryId != null ? this.store.getInboxEntry(thread.latestEntryId) : null;
       const currentIds = items.map((item) => item.itemId);
       const headIds = head?.itemIds ?? [];
       if (!sameStringArray(currentIds, headIds)) {
@@ -2409,7 +2439,7 @@ export class AgentInboxService {
       } else {
         const activation: Activation = {
           kind: "agentinbox.activation",
-          activationId: generateId("act"),
+          activationId: generateCanonicalId("act"),
           agentId: input.agentId,
           inboxId: inbox.inboxId,
           targetId: target.targetId,

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,7 +36,7 @@ import {
   TerminalActivationTarget,
   WebhookActivationTarget,
 } from "./model";
-import { formatEntryRef, formatThreadRef, generateId, nowIso, parseEntryRef } from "./util";
+import { formatEntryRef, formatThreadRef, generateCanonicalId, nowIso, parseEntryRef } from "./util";
 
 const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
 const V1_BASELINE_TAG = "0000_v1_initial";
@@ -48,14 +48,14 @@ interface SqlMigration {
 }
 
 interface DigestThreadRecord {
-  threadId: number;
+  threadId: string;
   inboxId: string;
   sourceId: string;
   groupKey: string;
   resourceRef: string | null;
   eventFamily: string | null;
   latestRevision: number;
-  latestEntryId: number | null;
+  latestEntryId: string | null;
   status: "open" | "closed";
   summary: string;
   firstItemAt: string;
@@ -219,13 +219,15 @@ export class AgentInboxStore {
       return false;
     }
     const applied = this.listAppliedMigrationTags();
-    if (applied.has(V1_BASELINE_TAG)) {
-      return true;
+    if (!applied.has(V1_BASELINE_TAG)) {
+      return false;
     }
     return this.tableExists("source_hosts")
       && this.tableExists("inbox_entries")
       && this.tableExists("digest_threads")
-      && this.columnExists("activation_dispatch_states", "pending_fingerprint");
+      && this.columnExists("activation_dispatch_states", "pending_fingerprint")
+      && this.columnType("inbox_entries", "entry_id") === "text"
+      && this.columnType("digest_threads", "thread_id") === "text";
   }
 
   private hasRecognizablePreV1Schema(): boolean {
@@ -291,6 +293,15 @@ export class AgentInboxStore {
     }
     const rows = this.getAll(`pragma table_info(${tableName});`);
     return rows.some((row) => String(row.name) === columnName);
+  }
+
+  private columnType(tableName: string, columnName: string): string | null {
+    if (!this.tableExists(tableName)) {
+      return null;
+    }
+    const rows = this.getAll(`pragma table_info(${tableName});`);
+    const row = rows.find((entry) => String(entry.name) === columnName);
+    return row ? String(row.type).toLowerCase() : null;
   }
 
   private ensureInboxEntryBackfill(): void {
@@ -1382,7 +1393,7 @@ export class AgentInboxStore {
       [entryId, item.itemId],
     );
     this.persist();
-    return this.getInboxEntryByNumericId(entryId)!;
+    return this.getInboxEntry(entryId)!;
   }
 
   listInboxEntries(inboxId: string, options?: ListInboxItemsOptions): InboxEntry[] {
@@ -1430,24 +1441,25 @@ export class AgentInboxStore {
   }
 
   getInboxEntry(entryId: string): InboxEntry | null {
-    return this.getInboxEntryByNumericId(parseEntryRef(entryId));
+    const rows = this.getAll("select * from inbox_entries where entry_id = ?", [parseEntryRef(entryId)]);
+    return this.mapInboxEntries(rows)[0] ?? null;
   }
 
   ackInboxEntries(inboxId: string, entryIds: string[], ackedAt: string): { ackedEntries: number; ackedItems: number } {
-    const numericIds = uniqueSorted(entryIds).map((entryId) => this.resolveInboxEntryNumericId(inboxId, entryId));
-    const itemIds = this.getRawItemIdsForEntryIds(numericIds);
+    const resolvedIds = uniqueSorted(entryIds).map((entryId) => this.resolveInboxEntryId(inboxId, entryId));
+    const itemIds = this.getRawItemIdsForEntryIds(resolvedIds);
     const ackedItems = itemIds.length > 0 ? this.ackItems(inboxId, itemIds, ackedAt) : 0;
     if (ackedItems > 0) {
       this.syncInboxEntryAckState(inboxId, ackedAt);
     }
-    const ackedEntries = this.countAckedEntries(numericIds, ackedAt);
+    const ackedEntries = this.countAckedEntries(resolvedIds, ackedAt);
     return { ackedEntries, ackedItems };
   }
 
   ackInboxEntriesThrough(inboxId: string, entryId: string, ackedAt: string): { ackedEntries: number; ackedItems: number } {
     const anchor = this.getOne(
       "select sequence from inbox_entries where inbox_id = ? and entry_id = ?",
-      [inboxId, this.resolveInboxEntryNumericId(inboxId, entryId)],
+      [inboxId, this.resolveInboxEntryId(inboxId, entryId)],
     );
     if (!anchor) {
       throw new Error(`unknown inbox entry: ${entryId}`);
@@ -1464,7 +1476,7 @@ export class AgentInboxStore {
       `,
       [inboxId, Number(anchor.sequence)],
     );
-    return this.ackInboxEntries(inboxId, rows.map((row) => formatEntryRef(Number(row.entry_id))), ackedAt);
+    return this.ackInboxEntries(inboxId, rows.map((row) => formatEntryRef(String(row.entry_id))), ackedAt);
   }
 
   getOpenDigestThread(inboxId: string, groupKey: string): DigestThreadRecord | null {
@@ -1472,7 +1484,7 @@ export class AgentInboxStore {
       `
       select * from digest_threads
       where inbox_id = ? and group_key = ? and status = 'open'
-      order by thread_id desc
+      order by created_at desc, thread_id desc
       limit 1
       `,
       [inboxId, groupKey],
@@ -1494,12 +1506,15 @@ export class AgentInboxStore {
     this.db.run(
       `
       insert into digest_threads (
-        inbox_id, source_id, group_key, resource_ref, event_family, latest_revision,
+        thread_id, inbox_id, source_id, group_key, resource_ref, event_family, latest_revision,
         latest_entry_id, status, summary, first_item_at, last_item_at, flush_after_at,
         created_at, updated_at
-      ) values (?, ?, ?, ?, ?, 0, null, 'open', ?, ?, ?, ?, ?, ?)
+      ) values (?, ?, ?, ?, ?, ?, 0, null, 'open', ?, ?, ?, ?, ?, ?)
       `,
-      [
+      (() => {
+        const threadId = generateCanonicalId("thr");
+        return [
+          threadId,
         input.inboxId,
         input.sourceId,
         input.groupKey,
@@ -1511,19 +1526,20 @@ export class AgentInboxStore {
         input.flushAfterAt ?? null,
         input.createdAt,
         input.createdAt,
-      ],
+        ];
+      })(),
     );
-    const threadId = this.lastInsertRowId();
+    const threadId = String(this.getOne("select thread_id from digest_threads order by rowid desc limit 1")?.thread_id);
     this.persist();
     return this.getDigestThread(threadId)!;
   }
 
-  getDigestThread(threadId: number): DigestThreadRecord | null {
+  getDigestThread(threadId: string): DigestThreadRecord | null {
     const row = this.getOne("select * from digest_threads where thread_id = ?", [threadId]);
     return row ? this.mapDigestThread(row) : null;
   }
 
-  addItemToDigestThread(threadId: number, itemId: string, occurredAt: string, summary: string, flushAfterAt: string | null): DigestThreadRecord {
+  addItemToDigestThread(threadId: string, itemId: string, occurredAt: string, summary: string, flushAfterAt: string | null): DigestThreadRecord {
     this.inTransaction(() => {
       this.db.run(
         "insert or ignore into digest_thread_items (thread_id, item_id) values (?, ?)",
@@ -1550,14 +1566,14 @@ export class AgentInboxStore {
       where status = 'open'
         and flush_after_at is not null
         and flush_after_at <= ?
-      order by flush_after_at asc, thread_id asc
+      order by flush_after_at asc, created_at asc, thread_id asc
       `,
       [now],
     );
     return rows.map((row) => this.mapDigestThread(row));
   }
 
-  listUnackedInboxItemsForDigestThread(threadId: number): InboxItem[] {
+  listUnackedInboxItemsForDigestThread(threadId: string): InboxItem[] {
     const rows = this.getAll(
       `
       select i.*
@@ -1574,7 +1590,7 @@ export class AgentInboxStore {
 
   listOpenDigestThreadsForInbox(inboxId: string): DigestThreadRecord[] {
     const rows = this.getAll(
-      "select * from digest_threads where inbox_id = ? and status = 'open' order by thread_id asc",
+      "select * from digest_threads where inbox_id = ? and status = 'open' order by created_at asc, thread_id asc",
       [inboxId],
     );
     return rows.map((row) => this.mapDigestThread(row));
@@ -1582,13 +1598,13 @@ export class AgentInboxStore {
 
   listOpenDigestThreads(): DigestThreadRecord[] {
     const rows = this.getAll(
-      "select * from digest_threads where status = 'open' order by thread_id asc",
+      "select * from digest_threads where status = 'open' order by created_at asc, thread_id asc",
     );
     return rows.map((row) => this.mapDigestThread(row));
   }
 
   materializeDigestSnapshot(input: {
-    threadId: number;
+    threadId: string;
     inboxId: string;
     groupKey: string;
     resourceRef?: string | null;
@@ -1651,10 +1667,10 @@ export class AgentInboxStore {
       );
     });
     this.persist();
-    return this.getInboxEntryByNumericId(this.getDigestThread(input.threadId)!.latestEntryId!)!;
+    return this.getInboxEntry(this.getDigestThread(input.threadId)!.latestEntryId!)!;
   }
 
-  closeDigestThread(threadId: number, updatedAt: string): void {
+  closeDigestThread(threadId: string, updatedAt: string): void {
     this.db.run(
       "update digest_threads set status = 'closed', flush_after_at = null, updated_at = ? where thread_id = ?",
       [updatedAt, threadId],
@@ -1673,7 +1689,7 @@ export class AgentInboxStore {
       from digest_threads t
       join digest_thread_items i on i.thread_id = t.thread_id
       where i.item_id in (${placeholders})
-      order by t.thread_id asc
+      order by t.created_at asc, t.thread_id asc
       `,
       itemIds,
     );
@@ -1894,7 +1910,7 @@ export class AgentInboxStore {
       ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
-        generateId("strevt"),
+        generateCanonicalId("evt"),
         streamId,
         event.sourceId,
         event.sourceNativeId,
@@ -2033,7 +2049,7 @@ export class AgentInboxStore {
           commit_id, consumer_id, stream_id, committed_offset, committed_at
         ) values (?, ?, ?, ?, ?)
       `,
-        [generateId("commit"), consumerId, consumer.streamId, committedOffset, updatedAt],
+        [generateCanonicalId("cmt"), consumerId, consumer.streamId, committedOffset, updatedAt],
       );
     });
     this.persist();
@@ -2172,7 +2188,7 @@ export class AgentInboxStore {
     }
     const now = nowIso();
     const host: SourceHost = {
-      hostId: generateId("hst"),
+      hostId: generateCanonicalId("hst"),
       hostType: hostType as SourceHost["hostType"],
       hostKey,
       configRef: source.configRef ?? null,
@@ -2394,7 +2410,7 @@ export class AgentInboxStore {
 
   private mapInboxEntry(row: Record<string, unknown>, itemIds: string[]): InboxEntry {
     const base = {
-      entryId: formatEntryRef(Number(row.entry_id)),
+      entryId: formatEntryRef(requiredText(row, "entry_id")),
       inboxId: String(row.inbox_id),
       sequence: Number(row.sequence),
       itemId: "",
@@ -2429,8 +2445,8 @@ export class AgentInboxStore {
     return {
       ...base,
       kind: "digest_snapshot",
-      itemId: base.itemIds[0] ?? formatEntryRef(Number(row.entry_id)),
-      threadId: formatThreadRef(Number(row.thread_id)),
+      itemId: base.itemIds[0] ?? formatEntryRef(requiredText(row, "entry_id")),
+      threadId: formatThreadRef(requiredText(row, "thread_id")),
       revision: Number(row.revision),
       groupKey: String(row.group_key),
       resourceRef: row.resource_ref ? String(row.resource_ref) : null,
@@ -2440,14 +2456,14 @@ export class AgentInboxStore {
 
   private mapDigestThread(row: Record<string, unknown>): DigestThreadRecord {
     return {
-      threadId: Number(row.thread_id),
+      threadId: requiredText(row, "thread_id"),
       inboxId: String(row.inbox_id),
       sourceId: String(row.source_id),
       groupKey: String(row.group_key),
       resourceRef: row.resource_ref ? String(row.resource_ref) : null,
       eventFamily: row.event_family ? String(row.event_family) : null,
       latestRevision: Number(row.latest_revision),
-      latestEntryId: row.latest_entry_id == null ? null : Number(row.latest_entry_id),
+      latestEntryId: row.latest_entry_id == null ? null : String(row.latest_entry_id),
       status: String(row.status) as DigestThreadRecord["status"],
       summary: String(row.summary),
       firstItemAt: String(row.first_item_at),
@@ -2492,12 +2508,7 @@ export class AgentInboxStore {
     };
   }
 
-  private getInboxEntryByNumericId(entryId: number): InboxEntry | null {
-    const rows = this.getAll("select * from inbox_entries where entry_id = ?", [entryId]);
-    return this.mapInboxEntries(rows)[0] ?? null;
-  }
-
-  private resolveInboxEntryNumericId(inboxId: string, refOrItemId: string): number {
+  private resolveInboxEntryId(inboxId: string, refOrItemId: string): string {
     try {
       return parseEntryRef(refOrItemId);
     } catch {
@@ -2516,14 +2527,14 @@ export class AgentInboxStore {
       if (!row) {
         throw new Error(`unknown inbox entry: ${refOrItemId}`);
       }
-      return Number(row.entry_id);
+      return String(row.entry_id);
     }
   }
 
   private insertInboxEntryRecord(input: {
     inboxId: string;
     kind: InboxEntry["kind"];
-    threadId: number | null;
+    threadId: string | null;
     revision: number | null;
     groupKey: string | null;
     resourceRef: string | null;
@@ -2539,16 +2550,18 @@ export class AgentInboxStore {
     ackedAt: string | null;
     supersededAt: string | null;
     createdAt: string;
-  }): number {
+  }): string {
+    const entryId = generateCanonicalId("ent");
     this.db.run(
       `
       insert into inbox_entries (
-        inbox_id, kind, sequence, thread_id, revision, group_key, resource_ref, event_family,
+        entry_id, inbox_id, kind, sequence, thread_id, revision, group_key, resource_ref, event_family,
         item_json, count, summary, first_item_at, last_item_at, source_ids_json,
         subscription_ids_json, delivery_handle_json, acked_at, superseded_at, created_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
       [
+        entryId,
         input.inboxId,
         input.kind,
         this.nextInboxEntrySequence(),
@@ -2570,7 +2583,7 @@ export class AgentInboxStore {
         input.createdAt,
       ],
     );
-    return this.lastInsertRowId();
+    return entryId;
   }
 
   private nextInboxEntrySequence(): number {
@@ -2578,7 +2591,7 @@ export class AgentInboxStore {
     return Number(row?.next_sequence ?? 1);
   }
 
-  private listEntryItemIds(entryId: number): string[] {
+  private listEntryItemIds(entryId: string): string[] {
     const rows = this.getAll(
       `
       select iei.item_id
@@ -2592,8 +2605,8 @@ export class AgentInboxStore {
     return rows.map((row) => String(row.item_id));
   }
 
-  private listEntryItemIdsBulk(entryIds: number[]): Map<number, string[]> {
-    const result = new Map<number, string[]>();
+  private listEntryItemIdsBulk(entryIds: string[]): Map<string, string[]> {
+    const result = new Map<string, string[]>();
     if (entryIds.length === 0) {
       return result;
     }
@@ -2609,7 +2622,7 @@ export class AgentInboxStore {
       entryIds,
     );
     for (const row of rows) {
-      const entryId = Number(row.entry_id);
+      const entryId = String(row.entry_id);
       const itemIds = result.get(entryId) ?? [];
       itemIds.push(String(row.item_id));
       result.set(entryId, itemIds);
@@ -2617,7 +2630,7 @@ export class AgentInboxStore {
     return result;
   }
 
-  private getRawItemIdsForEntryIds(entryIds: number[]): string[] {
+  private getRawItemIdsForEntryIds(entryIds: string[]): string[] {
     const itemIds = new Set<string>();
     for (const entryId of entryIds) {
       for (const itemId of this.listEntryItemIds(entryId)) {
@@ -2628,8 +2641,8 @@ export class AgentInboxStore {
   }
 
   private mapInboxEntries(rows: Array<Record<string, unknown>>): InboxEntry[] {
-    const itemIdsByEntry = this.listEntryItemIdsBulk(rows.map((row) => Number(row.entry_id)));
-    return rows.map((row) => this.mapInboxEntry(row, itemIdsByEntry.get(Number(row.entry_id)) ?? []));
+    const itemIdsByEntry = this.listEntryItemIdsBulk(rows.map((row) => String(row.entry_id)));
+    return rows.map((row) => this.mapInboxEntry(row, itemIdsByEntry.get(String(row.entry_id)) ?? []));
   }
 
   private syncInboxEntryAckState(inboxId: string, ackedAt: string): void {
@@ -2652,7 +2665,7 @@ export class AgentInboxStore {
     this.persist();
   }
 
-  private countAckedEntries(entryIds: number[], ackedAt: string): number {
+  private countAckedEntries(entryIds: string[], ackedAt: string): number {
     if (entryIds.length === 0) {
       return 0;
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1484,7 +1484,7 @@ export class AgentInboxStore {
       `
       select * from digest_threads
       where inbox_id = ? and group_key = ? and status = 'open'
-      order by created_at desc, thread_id desc
+      order by created_at desc, rowid desc
       limit 1
       `,
       [inboxId, groupKey],
@@ -1503,6 +1503,7 @@ export class AgentInboxStore {
     flushAfterAt?: string | null;
     createdAt: string;
   }): DigestThreadRecord {
+    const threadId = generateCanonicalId("thr");
     this.db.run(
       `
       insert into digest_threads (
@@ -1511,10 +1512,8 @@ export class AgentInboxStore {
         created_at, updated_at
       ) values (?, ?, ?, ?, ?, ?, 0, null, 'open', ?, ?, ?, ?, ?, ?)
       `,
-      (() => {
-        const threadId = generateCanonicalId("thr");
-        return [
-          threadId,
+      [
+        threadId,
         input.inboxId,
         input.sourceId,
         input.groupKey,
@@ -1526,10 +1525,8 @@ export class AgentInboxStore {
         input.flushAfterAt ?? null,
         input.createdAt,
         input.createdAt,
-        ];
-      })(),
+      ],
     );
-    const threadId = String(this.getOne("select thread_id from digest_threads order by rowid desc limit 1")?.thread_id);
     this.persist();
     return this.getDigestThread(threadId)!;
   }
@@ -1901,37 +1898,58 @@ export class AgentInboxStore {
   }
 
   insertStreamEvent(streamId: string, event: AppendSourceEventInput): AppendSourceEventResult {
-    const before = this.changes();
-    this.db.run(
-      `
-      insert or ignore into stream_events (
-        stream_event_id, stream_id, source_id, source_native_id, event_variant,
-        occurred_at, metadata_json, raw_payload_json, delivery_handle_json, created_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `,
-      [
-        generateCanonicalId("evt"),
-        streamId,
-        event.sourceId,
-        event.sourceNativeId,
-        event.eventVariant,
-        event.occurredAt ?? nowIso(),
-        JSON.stringify(event.metadata ?? {}),
-        JSON.stringify(event.rawPayload ?? {}),
-        event.deliveryHandle ? JSON.stringify(event.deliveryHandle) : null,
-        nowIso(),
-      ],
-    );
-    const inserted = this.changes() > before;
-    if (inserted) {
-      this.persist();
-      return {
-        appended: 1,
-        deduped: 0,
-        lastOffset: this.lastInsertRowId(),
-      };
+    const occurredAt = event.occurredAt ?? nowIso();
+    const metadataJson = JSON.stringify(event.metadata ?? {});
+    const rawPayloadJson = JSON.stringify(event.rawPayload ?? {});
+    const deliveryHandleJson = event.deliveryHandle ? JSON.stringify(event.deliveryHandle) : null;
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const before = this.changes();
+      this.db.run(
+        `
+        insert or ignore into stream_events (
+          stream_event_id, stream_id, source_id, source_native_id, event_variant,
+          occurred_at, metadata_json, raw_payload_json, delivery_handle_json, created_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+        [
+          generateCanonicalId("evt"),
+          streamId,
+          event.sourceId,
+          event.sourceNativeId,
+          event.eventVariant,
+          occurredAt,
+          metadataJson,
+          rawPayloadJson,
+          deliveryHandleJson,
+          nowIso(),
+        ],
+      );
+      if (this.changes() > before) {
+        this.persist();
+        return {
+          appended: 1,
+          deduped: 0,
+          lastOffset: this.lastInsertRowId(),
+        };
+      }
+
+      const existing = this.getOne(
+        `
+        select offset
+        from stream_events
+        where stream_id = ?
+          and source_native_id = ?
+          and event_variant = ?
+        limit 1
+        `,
+        [streamId, event.sourceNativeId, event.eventVariant],
+      );
+      if (existing) {
+        return { appended: 0, deduped: 1, lastOffset: null };
+      }
     }
-    return { appended: 0, deduped: 1, lastOffset: null };
+    throw new Error(`unable to allocate a unique stream_event_id for ${event.sourceNativeId}`);
   }
 
   readStreamEvents(streamId: string, nextOffset: number, limit: number): StreamEventRecord[] {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -28,6 +28,30 @@ export interface DetectedTerminalContext {
   itermSessionId?: string | null;
 }
 
+const AGENT_ADJECTIVES = [
+  "amber", "ancient", "autumn", "brisk", "bright", "bronze", "calm", "cedar",
+  "cinder", "clear", "cobalt", "cool", "copper", "crisp", "dawn", "deep",
+  "drift", "ember", "falling", "fern", "frost", "gentle", "glint", "golden",
+  "granite", "harbor", "hazel", "hidden", "hollow", "ice", "indigo", "iron",
+  "ivory", "jade", "juniper", "kind", "lake", "lively", "lunar", "maple",
+  "meadow", "misty", "moss", "night", "north", "oak", "olive", "opal",
+  "orchid", "pale", "pine", "plum", "quiet", "rapid", "river", "rose",
+  "royal", "rust", "sage", "silver", "soft", "solar", "spring", "stone",
+  "summer", "swift", "timber", "velvet", "warm", "west", "whisper", "winter",
+];
+
+const AGENT_ANIMALS = [
+  "antelope", "badger", "beaver", "bison", "bittern", "boar", "bobcat", "buffalo",
+  "canary", "cougar", "crane", "crow", "deer", "dingo", "dolphin", "dragonfly",
+  "eagle", "falcon", "finch", "firefly", "fox", "frog", "gazelle", "gecko",
+  "gull", "hare", "hawk", "heron", "ibis", "jaguar", "jay", "kingfisher",
+  "koala", "koi", "lemur", "leopard", "lizard", "lynx", "magpie", "martin",
+  "mink", "mole", "narwhal", "newt", "ocelot", "orca", "otter", "owl",
+  "panther", "parrot", "pebble", "pelican", "pika", "puma", "quail", "raven",
+  "robin", "seal", "sparrow", "stoat", "stork", "swift", "tern", "tiger",
+  "toad", "toucan", "trout", "viper", "weasel", "wren", "yak", "zebra",
+];
+
 export function detectTerminalContext(env: NodeJS.ProcessEnv = process.env): DetectedTerminalContext {
   const tmuxPaneId = normalizeOptionalString(env.TMUX_PANE);
   const termProgram = normalizeOptionalString(env.TERM_PROGRAM);
@@ -123,7 +147,7 @@ export function assignedAgentIdFromContext(input: {
   tmuxPaneId?: string | null;
   itermSessionId?: string | null;
   tty?: string | null;
-}): string {
+}, attempt = 0): string {
   const primary = normalizeOptionalString(input.runtimeSessionId)
     ?? normalizeOptionalString(input.tmuxPaneId)
     ?? normalizeOptionalString(input.itermSessionId)
@@ -131,12 +155,17 @@ export function assignedAgentIdFromContext(input: {
   if (!primary) {
     throw new Error("unable to derive agentId from terminal context");
   }
-  const normalized = primary.replace(/[^a-zA-Z0-9]+/g, "").toLowerCase();
-  if (normalized.length > 0) {
-    return `agent_${input.runtimeKind ?? "unknown"}_${normalized.slice(0, 40)}`;
+
+  const digest = crypto.createHash("sha256")
+    .update(`${input.runtimeKind ?? "unknown"}:${input.backend}:${primary}:${attempt}`)
+    .digest();
+  const adjective = AGENT_ADJECTIVES[digest[0] % AGENT_ADJECTIVES.length];
+  const animal = AGENT_ANIMALS[digest[1] % AGENT_ANIMALS.length];
+  if (attempt < 16) {
+    return `agt_${adjective}-${animal}`;
   }
-  const digest = crypto.createHash("sha256").update(primary).digest("hex").slice(0, 16);
-  return `agent_${input.runtimeKind ?? "unknown"}_${digest}`;
+  const suffix = digest.toString("hex").slice(0, 3);
+  return `agt_${adjective}-${animal}-${suffix}`;
 }
 
 export class TerminalDispatcher {

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,9 @@ import crypto from "node:crypto";
 
 const CANONICAL_ID_ALPHABET = "23456789abcdefghjkmnpqrstvwxyz";
 const CANONICAL_ID_TOKEN_LENGTH = 12;
+const ENTRY_THREAD_ID_PATTERN = new RegExp(
+  `^(ent|thr)_[${CANONICAL_ID_ALPHABET}]{${CANONICAL_ID_TOKEN_LENGTH}}$`,
+);
 
 export function nowIso(): string {
   return new Date().toISOString();
@@ -78,7 +81,7 @@ export function formatEntryRef(entryId: string): string {
 
 export function parseEntryRef(ref: string): string {
   const value = ref.trim();
-  if (!/^ent_[23456789abcdefghjkmnpqrstvwxyz]+$/.test(value)) {
+  if (!ENTRY_THREAD_ID_PATTERN.test(value) || !value.startsWith("ent_")) {
     throw new Error(`invalid inbox entry id: ${ref}`);
   }
   return value;
@@ -90,7 +93,7 @@ export function formatThreadRef(threadId: string): string {
 
 export function parseThreadRef(ref: string): string {
   const value = ref.trim();
-  if (!/^thr_[23456789abcdefghjkmnpqrstvwxyz]+$/.test(value)) {
+  if (!ENTRY_THREAD_ID_PATTERN.test(value) || !value.startsWith("thr_")) {
     throw new Error(`invalid digest thread id: ${ref}`);
   }
   return value;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,11 +1,32 @@
 import crypto from "node:crypto";
 
+const CANONICAL_ID_ALPHABET = "23456789abcdefghjkmnpqrstvwxyz";
+const CANONICAL_ID_TOKEN_LENGTH = 12;
+
 export function nowIso(): string {
   return new Date().toISOString();
 }
 
+export function generateCanonicalId(prefix: string, length = CANONICAL_ID_TOKEN_LENGTH): string {
+  return `${prefix}_${generateShortToken(length)}`;
+}
+
 export function generateId(prefix: string): string {
-  return `${prefix}_${crypto.randomUUID()}`;
+  return generateCanonicalId(prefix);
+}
+
+export function generateShortToken(length = CANONICAL_ID_TOKEN_LENGTH): string {
+  let token = "";
+  while (token.length < length) {
+    const bytes = crypto.randomBytes(length - token.length);
+    for (const byte of bytes) {
+      token += CANONICAL_ID_ALPHABET[byte % CANONICAL_ID_ALPHABET.length];
+      if (token.length >= length) {
+        break;
+      }
+    }
+  }
+  return token;
 }
 
 export function parseJsonArg(
@@ -51,26 +72,26 @@ export function jsonResponse(data: unknown): string {
   return JSON.stringify(data, null, 2);
 }
 
-export function formatEntryRef(entryId: number): string {
-  return `ent_${entryId}`;
+export function formatEntryRef(entryId: string): string {
+  return parseEntryRef(entryId);
 }
 
-export function parseEntryRef(ref: string): number {
-  const match = /^ent_(\d+)$/.exec(ref.trim());
-  if (!match) {
+export function parseEntryRef(ref: string): string {
+  const value = ref.trim();
+  if (!/^ent_[23456789abcdefghjkmnpqrstvwxyz]+$/.test(value)) {
     throw new Error(`invalid inbox entry id: ${ref}`);
   }
-  return Number(match[1]);
+  return value;
 }
 
-export function formatThreadRef(threadId: number): string {
-  return `thr_${threadId}`;
+export function formatThreadRef(threadId: string): string {
+  return parseThreadRef(threadId);
 }
 
-export function parseThreadRef(ref: string): number {
-  const match = /^thr_(\d+)$/.exec(ref.trim());
-  if (!match) {
+export function parseThreadRef(ref: string): string {
+  const value = ref.trim();
+  if (!/^thr_[23456789abcdefghjkmnpqrstvwxyz]+$/.test(value)) {
     throw new Error(`invalid digest thread id: ${ref}`);
   }
-  return Number(match[1]);
+  return value;
 }

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -11,7 +11,7 @@ import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { ActivationGate } from "../src/runtime_gate";
 import { UxcRemoteSourceClient } from "../src/sources/remote";
 import { AgentInboxStore } from "../src/store";
-import { TerminalDispatcher, TerminalProbeStatus } from "../src/terminal";
+import { assignedAgentIdFromContext, TerminalDispatcher, TerminalProbeStatus } from "../src/terminal";
 import { nowIso } from "../src/util";
 
 class RecordingActivationDispatcher extends ActivationDispatcher {
@@ -407,7 +407,13 @@ test("agent register creates a stable agent, inbox, and terminal activation targ
       tty: "/dev/ttys049",
     });
 
-    assert.equal(first.agent.agentId, "agent_codex_019d57fd65247e20a850a89e81957100");
+    assert.equal(first.agent.agentId, assignedAgentIdFromContext({
+      runtimeKind: "codex",
+      runtimeSessionId: "019d57fd-6524-7e20-a850-a89e81957100",
+      backend: "iterm2",
+      itermSessionId: "4B4CB6B2-A73B-4420-94A7-BD2CA216A285",
+      tty: "/dev/ttys049",
+    }));
     assert.equal(second.agent.agentId, first.agent.agentId);
     assert.equal(second.terminalTarget.targetId, first.terminalTarget.targetId);
     assert.equal(store.listAgents().length, 1);

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -2399,7 +2399,7 @@ test("control plane exposes inbox compact and global gc endpoints", async () => 
       });
       assert.equal(agentResponse.statusCode, 200);
       const agentId = agentResponse.data.agent.agentId;
-      const inboxId = `inbox_${agentId}`;
+      const inboxId = (service.getInboxDetailsByAgent(agentId) as { inbox: { inboxId: string } }).inbox.inboxId;
       const oldAckedAt = new Date(Date.now() - (25 * 60 * 60 * 1000)).toISOString();
 
       store.insertInboxItem({

--- a/test/runtime_gate.test.ts
+++ b/test/runtime_gate.test.ts
@@ -60,7 +60,7 @@ class RecordingLogger implements Logger {
 function makeItermTarget(): TerminalActivationTarget {
   return {
     targetId: "tgt_gate",
-    agentId: "agent_codex_demo",
+    agentId: "agt_demo-agent",
     kind: "terminal",
     status: "active",
     offlineSince: null,
@@ -86,7 +86,7 @@ function makeItermTarget(): TerminalActivationTarget {
 function makeTmuxTarget(): TerminalActivationTarget {
   return {
     targetId: "tgt_tmux",
-    agentId: "agent_codex_tmux",
+    agentId: "agt_tmux-agent",
     kind: "terminal",
     status: "active",
     offlineSince: null,

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -40,7 +40,7 @@ test("assignedAgentIdFromContext prefers runtime session ids", () => {
     itermSessionId: "4B4CB6B2-A73B-4420-94A7-BD2CA216A285",
   });
 
-  assert.equal(agentId, "agent_codex_019d57fd65247e20a850a89e81957100");
+  assert.match(agentId, /^agt_[a-z]+-[a-z]+$/);
 });
 
 test("renderAgentPrompt accepts legacy newItemCount input", () => {
@@ -83,7 +83,7 @@ test("renderAgentPrompt does not add duplicate punctuation after previews", () =
 
 test("deriveInlineItemPreview truncates short text payloads and skips structured payloads", () => {
   const preview = deriveInlineItemPreview({
-    itemId: "item_1",
+    itemId: "itm_1",
     sourceId: "src_1",
     sourceNativeId: "evt_1",
     eventVariant: "message.created",
@@ -100,7 +100,7 @@ test("deriveInlineItemPreview truncates short text payloads and skips structured
   assert.ok(preview!.endsWith("..."));
 
   const structured = deriveInlineItemPreview({
-    itemId: "item_2",
+    itemId: "itm_2",
     sourceId: "src_1",
     sourceNativeId: "evt_2",
     eventVariant: "message.created",
@@ -133,7 +133,7 @@ test("TerminalDispatcher uses two-step it2api submission for iTerm2 targets", as
 
   const target: TerminalActivationTarget = {
     targetId: "tgt_1",
-    agentId: "agent_codex_abc",
+    agentId: "agt_copper-fox",
     kind: "terminal",
     status: "active",
     offlineSince: null,
@@ -186,7 +186,7 @@ test("TerminalDispatcher uses literal text plus carriage return for tmux targets
 
   const target: TerminalActivationTarget = {
     targetId: "tgt_tmux_1",
-    agentId: "agent_codex_tmux",
+    agentId: "agt_river-otter",
     kind: "terminal",
     status: "active",
     offlineSince: null,
@@ -231,7 +231,7 @@ test("TerminalDispatcher uses literal text plus carriage return for tmux targets
 test("TerminalDispatcher probeStatus distinguishes tmux available, gone, and unknown", async () => {
   const target: TerminalActivationTarget = {
     targetId: "tgt_tmux_probe",
-    agentId: "agent_codex_tmux",
+    agentId: "agt_river-otter",
     kind: "terminal",
     status: "offline",
     offlineSince: "2026-04-07T00:00:00.000Z",


### PR DESCRIPTION
## Summary
- switch durable ids from `prefix_uuid` to canonical short ids across fresh v1 storage
- move inbox entry and digest thread ids to stored `ent_` / `thr_` string ids while keeping numeric ordering fields
- generate auto agent ids as readable `agt_<word>-<word>` names and update docs/tests to match the new identifier strategy

## Testing
- `npm run build`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern "assignedAgentIdFromContext|detectTerminalContext|TerminalDispatcher|agent register creates a stable agent, inbox, and terminal activation target|store migrates a new database using drizzle SQL migrations|store reopens an existing v1 database without archiving it" test/terminal.test.ts test/runtime_gate.test.ts test/agentinbox.test.ts`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern "inbox read defaults to unacked items and ack through clears a processed batch|ack through matches visible inbox order for same-timestamp items|ack through still follows visible order when older binaries left inbox_sequence null|github bursts materialize digest snapshot entries when inbox aggregation is enabled|acking an older digest snapshot rematerializes a newer visible snapshot|compact and gc remove only acked inbox items older than retention|single preview-friendly unacked item is inlined into the terminal prompt" test/agentinbox.test.ts test/control_plane.test.ts`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern "shared source can route one stream event to multiple agent inboxes|local_event source can act as a programmable event bus source|subscription remove deletes the subscription, its consumer, and transient runtime state" test/agentinbox.test.ts`
