### PR TITLE
feat: support github pr shortcut with --withCi

### DIFF
--- a/drizzle/migrations/0000_v1_initial.sql
+++ b/drizzle/migrations/0000_v1_initial.sql
@@ -182,7 +182,7 @@ create table if not exists consumer_commits (
 
 create table if not exists subscription_lifecycle_retirements (
   subscription_id text primary key,
-  source_id text not null,
+  host_id text not null,
   tracked_resource_ref text not null,
   retire_at text not null,
   terminal_state text,

--- a/drizzle/migrations/0000_v1_initial.sql
+++ b/drizzle/migrations/0000_v1_initial.sql
@@ -182,7 +182,7 @@ create table if not exists consumer_commits (
 
 create table if not exists subscription_lifecycle_retirements (
   subscription_id text primary key,
-  host_id text not null,
+  source_id text not null,
   tracked_resource_ref text not null,
   retire_at text not null,
   terminal_state text,

--- a/drizzle/migrations/0002_host_scoped_lifecycle_retirements.sql
+++ b/drizzle/migrations/0002_host_scoped_lifecycle_retirements.sql
@@ -1,0 +1,42 @@
+pragma foreign_keys=off;
+
+create table if not exists subscription_lifecycle_retirements__new (
+  subscription_id text primary key,
+  host_id text not null,
+  tracked_resource_ref text not null,
+  retire_at text not null,
+  terminal_state text,
+  terminal_result text,
+  terminal_occurred_at text not null,
+  created_at text not null,
+  updated_at text not null
+);
+
+insert into subscription_lifecycle_retirements__new (
+  subscription_id,
+  host_id,
+  tracked_resource_ref,
+  retire_at,
+  terminal_state,
+  terminal_result,
+  terminal_occurred_at,
+  created_at,
+  updated_at
+)
+select
+  retirement.subscription_id,
+  coalesce(source.host_id, retirement.source_id),
+  retirement.tracked_resource_ref,
+  retirement.retire_at,
+  retirement.terminal_state,
+  retirement.terminal_result,
+  retirement.terminal_occurred_at,
+  retirement.created_at,
+  retirement.updated_at
+from subscription_lifecycle_retirements as retirement
+left join sources as source on source.source_id = retirement.source_id;
+
+drop table subscription_lifecycle_retirements;
+alter table subscription_lifecycle_retirements__new rename to subscription_lifecycle_retirements;
+
+pragma foreign_keys=on;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -101,7 +101,7 @@ export const subscriptions = sqliteTable("subscriptions", {
 
 export const subscriptionLifecycleRetirements = sqliteTable("subscription_lifecycle_retirements", {
   subscriptionId: text("subscription_id").primaryKey(),
-  sourceId: text("source_id").notNull(),
+  hostId: text("host_id").notNull(),
   trackedResourceRef: text("tracked_resource_ref").notNull(),
   retireAt: text("retire_at").notNull(),
   terminalState: text("terminal_state"),

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -17,7 +17,7 @@ import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubDeliveryAdapter } from "./sources/github";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
-import { ExpandedSubscriptionInput, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry } from "./sources/remote_modules";
+import { ExpandedSubscriptionPlan, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry } from "./sources/remote_modules";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
 
 export interface SourceAdapter {
@@ -190,7 +190,7 @@ export class AdapterRegistry {
   async expandSubscriptionShortcut(
     source: SourceStream,
     input: { name: string; args?: Record<string, unknown> },
-  ): Promise<ExpandedSubscriptionInput | null> {
+  ): Promise<ExpandedSubscriptionPlan | null> {
     if (source.sourceType === "local_event") {
       return null;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -494,7 +494,10 @@ async function main(): Promise<void> {
       startOffset: parseOptionalNumber(takeFlagValue(normalized, "--start-offset")),
       startTime: takeFlagValue(normalized, "--start-time") ?? undefined,
     });
-    console.log(jsonResponse(withCommandMetadata(response.data, selection)));
+    console.log(jsonResponse(withCommandMetadata(
+      normalizeSubscriptionAddOutput(response.data, Boolean(shortcutName)),
+      selection,
+    )));
     return;
   }
 
@@ -1190,6 +1193,22 @@ function withCommandMetadata<T extends Record<string, unknown>>(data: T, selecti
     ...(selection.autoRegistered ? { autoRegistered: true as const } : {}),
     ...(selection.warnings.length > 0 ? { warnings: selection.warnings } : {}),
   };
+}
+
+function normalizeSubscriptionAddOutput(data: Record<string, unknown>, shortcutUsed: boolean): Record<string, unknown> {
+  if (shortcutUsed) {
+    return data;
+  }
+  const subscriptions = data.subscriptions;
+  if (
+    Array.isArray(subscriptions) &&
+    subscriptions.length === 1 &&
+    subscriptions[0] &&
+    typeof subscriptions[0] === "object"
+  ) {
+    return subscriptions[0] as Record<string, unknown>;
+  }
+  return data;
 }
 
 function getRequiredTerminalContext() {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1177,10 +1177,7 @@ function buildFastifyServer(service: AgentInboxService) {
       startOffset: typeof body.startOffset === "number" ? body.startOffset : undefined,
       startTime: optionalString(body.startTime) ?? undefined,
     };
-    if (input.shortcut) {
-      return { subscriptions: await service.registerSubscriptions(input) };
-    }
-    return service.registerSubscription(input);
+    return { subscriptions: await service.registerSubscriptions(input) };
   });
 
   app.get("/subscriptions/:subscriptionId", {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1159,7 +1159,7 @@ function buildFastifyServer(service: AgentInboxService) {
     },
   }, async (request) => {
     const body = request.body as Record<string, unknown>;
-    return service.registerSubscription({
+    const input = {
       agentId: String(body.agentId),
       sourceId: String(body.sourceId),
       shortcut: body.shortcut && typeof body.shortcut === "object"
@@ -1176,7 +1176,11 @@ function buildFastifyServer(service: AgentInboxService) {
       startPolicy: optionalString(body.startPolicy) as never,
       startOffset: typeof body.startOffset === "number" ? body.startOffset : undefined,
       startTime: optionalString(body.startTime) ?? undefined,
-    });
+    };
+    if (input.shortcut) {
+      return { subscriptions: await service.registerSubscriptions(input) };
+    }
+    return service.registerSubscription(input);
   });
 
   app.get("/subscriptions/:subscriptionId", {

--- a/src/model.ts
+++ b/src/model.ts
@@ -102,7 +102,7 @@ export interface Subscription {
 
 export interface SubscriptionLifecycleRetirement {
   subscriptionId: string;
-  sourceId: string;
+  hostId: string;
   trackedResourceRef: string;
   retireAt: string;
   terminalState?: string | null;

--- a/src/service.ts
+++ b/src/service.ts
@@ -69,7 +69,7 @@ import {
   renderAgentPrompt,
   TerminalDispatcher,
 } from "./terminal";
-import { LifecycleSignal } from "./sources/remote_modules";
+import { ExpandedSubscriptionMember, ExpandedSubscriptionPlan, LifecycleSignal } from "./sources/remote_modules";
 import { ActivationGate, DefaultActivationGate, GatingPolicy } from "./runtime_gate";
 import { Logger, NoopLogger } from "./logging";
 import { resolveSourceRegistration } from "./source_hosts";
@@ -889,6 +889,11 @@ export class AgentInboxService {
   }
 
   async registerSubscription(input: RegisterSubscriptionInput): Promise<Subscription> {
+    const subscriptions = await this.registerSubscriptions(input);
+    return subscriptions[0]!;
+  }
+
+  async registerSubscriptions(input: RegisterSubscriptionInput): Promise<Subscription[]> {
     if (input.shortcut) {
       const source = this.store.getSource(input.sourceId);
       if (!source) {
@@ -901,14 +906,58 @@ export class AgentInboxService {
       if (!expanded) {
         throw new Error(`unknown subscription shortcut ${input.shortcut.name} for source ${input.sourceId}`);
       }
-      return this.registerSubscription({
-        ...input,
-        shortcut: undefined,
-        filter: expanded.filter,
-        trackedResourceRef: expanded.trackedResourceRef ?? null,
-        cleanupPolicy: expanded.cleanupPolicy,
-      });
+      return this.registerExpandedShortcutSubscriptions(input, source, expanded);
     }
+    return [await this.registerSingleSubscription(input)];
+  }
+
+  private async registerExpandedShortcutSubscriptions(
+    input: RegisterSubscriptionInput,
+    source: SourceStream,
+    plan: ExpandedSubscriptionPlan,
+  ): Promise<Subscription[]> {
+    if (plan.members.length === 0) {
+      throw new Error(`subscription shortcut ${input.shortcut?.name ?? "unknown"} did not produce any subscriptions`);
+    }
+    const resolvedMembers = plan.members.map((member) => ({
+      source: this.resolveShortcutMemberSource(source, member),
+      member,
+    }));
+    const created: Subscription[] = [];
+    for (const { source: memberSource, member } of resolvedMembers) {
+      created.push(await this.registerSingleSubscription({
+        ...input,
+        sourceId: memberSource.sourceId,
+        shortcut: undefined,
+        filter: member.filter,
+        trackedResourceRef: member.trackedResourceRef ?? null,
+        cleanupPolicy: member.cleanupPolicy ?? null,
+      }));
+    }
+    return created;
+  }
+
+  private resolveShortcutMemberSource(source: SourceStream, member: ExpandedSubscriptionMember): SourceStream {
+    if (!member.streamKind || member.streamKind === source.streamKind) {
+      return source;
+    }
+    if (!source.hostId || !source.streamKey) {
+      throw new Error(`subscription shortcut ${source.sourceId} requires a host-scoped source to resolve ${member.streamKind}`);
+    }
+    const sibling = this.store.listSources().find((candidate) =>
+      candidate.hostId === source.hostId &&
+      candidate.streamKind === member.streamKind &&
+      candidate.streamKey === source.streamKey,
+    );
+    if (!sibling) {
+      throw new Error(
+        `subscription shortcut ${source.sourceId} requires an existing sibling ${member.streamKind} stream under host ${source.hostId} with streamKey ${source.streamKey}`,
+      );
+    }
+    return sibling;
+  }
+
+  private async registerSingleSubscription(input: RegisterSubscriptionInput): Promise<Subscription> {
     this.getAgent(input.agentId);
     const source = this.store.getSource(input.sourceId);
     if (!source) {
@@ -1600,7 +1649,7 @@ export class AgentInboxService {
         });
       }
       for (const signal of lifecycleSignals.values()) {
-        this.scheduleLifecycleRetirements(source, subscription, signal);
+        this.scheduleLifecycleRetirements(source, signal);
       }
 
       return {
@@ -1786,35 +1835,40 @@ export class AgentInboxService {
     }
   }
 
-  private scheduleLifecycleRetirements(
-    source: SourceStream,
-    subscription: Subscription,
-    signal: LifecycleSignal,
-  ): void {
+  private scheduleLifecycleRetirements(source: SourceStream, signal: LifecycleSignal): void {
     if (!signal.terminal) {
       return;
     }
-    if (!subscription.trackedResourceRef || subscription.trackedResourceRef !== signal.ref) {
+    if (!source.hostId) {
       return;
     }
     const signalOccurredAt = signal.occurredAt ?? nowIso();
     const signalOccurredAtMs = Date.parse(signalOccurredAt);
-    const retireAt = lifecycleRetireAtForSignal(subscription.cleanupPolicy, signalOccurredAtMs);
-    if (!retireAt) {
-      return;
+    for (const subscription of this.store.listSubscriptions()) {
+      if (!subscription.trackedResourceRef || subscription.trackedResourceRef !== signal.ref) {
+        continue;
+      }
+      const subscriptionSource = this.store.getSource(subscription.sourceId);
+      if (!subscriptionSource || subscriptionSource.hostId !== source.hostId) {
+        continue;
+      }
+      const retireAt = lifecycleRetireAtForSignal(subscription.cleanupPolicy, signalOccurredAtMs);
+      if (!retireAt) {
+        continue;
+      }
+      const now = nowIso();
+      this.store.upsertSubscriptionLifecycleRetirement({
+        subscriptionId: subscription.subscriptionId,
+        hostId: source.hostId,
+        trackedResourceRef: signal.ref,
+        retireAt,
+        terminalState: signal.state ?? null,
+        terminalResult: signal.result ?? null,
+        terminalOccurredAt: signalOccurredAt,
+        createdAt: now,
+        updatedAt: now,
+      });
     }
-    const now = nowIso();
-    this.store.upsertSubscriptionLifecycleRetirement({
-      subscriptionId: subscription.subscriptionId,
-      sourceId: source.sourceId,
-      trackedResourceRef: signal.ref,
-      retireAt,
-      terminalState: signal.state ?? null,
-      terminalResult: signal.result ?? null,
-      terminalOccurredAt: signalOccurredAt,
-      createdAt: now,
-      updatedAt: now,
-    });
   }
 
   private notifyInboxWatchers(agentId: string, items: InboxEntry[]): void {

--- a/src/service.ts
+++ b/src/service.ts
@@ -889,26 +889,45 @@ export class AgentInboxService {
   }
 
   async registerSubscription(input: RegisterSubscriptionInput): Promise<Subscription> {
-    const subscriptions = await this.registerSubscriptions(input);
+    const expanded = await this.expandShortcutRegistration(input);
+    if (!expanded) {
+      return this.registerSingleSubscription(input);
+    }
+    if (expanded.plan.members.length !== 1) {
+      throw new Error(
+        `subscription shortcut ${input.shortcut?.name ?? "unknown"} for source ${input.sourceId} expands to ${expanded.plan.members.length} subscriptions; use registerSubscriptions() instead`,
+      );
+    }
+    const subscriptions = await this.registerExpandedShortcutSubscriptions(input, expanded.source, expanded.plan);
     return subscriptions[0]!;
   }
 
   async registerSubscriptions(input: RegisterSubscriptionInput): Promise<Subscription[]> {
-    if (input.shortcut) {
-      const source = this.store.getSource(input.sourceId);
-      if (!source) {
-        throw new Error(`unknown source: ${input.sourceId}`);
-      }
-      if (hasSubscriptionFieldOverride(input)) {
-        throw new Error("subscription add shortcut does not allow filter, trackedResourceRef, or cleanupPolicy overrides");
-      }
-      const expanded = await this.adapters.expandSubscriptionShortcut(source, input.shortcut);
-      if (!expanded) {
-        throw new Error(`unknown subscription shortcut ${input.shortcut.name} for source ${input.sourceId}`);
-      }
-      return this.registerExpandedShortcutSubscriptions(input, source, expanded);
+    const expanded = await this.expandShortcutRegistration(input);
+    if (expanded) {
+      return this.registerExpandedShortcutSubscriptions(input, expanded.source, expanded.plan);
     }
     return [await this.registerSingleSubscription(input)];
+  }
+
+  private async expandShortcutRegistration(
+    input: RegisterSubscriptionInput,
+  ): Promise<{ source: SourceStream; plan: ExpandedSubscriptionPlan } | null> {
+    if (!input.shortcut) {
+      return null;
+    }
+    const source = this.store.getSource(input.sourceId);
+    if (!source) {
+      throw new Error(`unknown source: ${input.sourceId}`);
+    }
+    if (hasSubscriptionFieldOverride(input)) {
+      throw new Error("subscription add shortcut does not allow filter, trackedResourceRef, or cleanupPolicy overrides");
+    }
+    const plan = await this.adapters.expandSubscriptionShortcut(source, input.shortcut);
+    if (!plan) {
+      throw new Error(`unknown subscription shortcut ${input.shortcut.name} for source ${input.sourceId}`);
+    }
+    return { source, plan };
   }
 
   private async registerExpandedShortcutSubscriptions(
@@ -924,17 +943,32 @@ export class AgentInboxService {
       member,
     }));
     const created: Subscription[] = [];
-    for (const { source: memberSource, member } of resolvedMembers) {
-      created.push(await this.registerSingleSubscription({
-        ...input,
-        sourceId: memberSource.sourceId,
-        shortcut: undefined,
-        filter: member.filter,
-        trackedResourceRef: member.trackedResourceRef ?? null,
-        cleanupPolicy: member.cleanupPolicy ?? null,
-      }));
+    try {
+      for (const { source: memberSource, member } of resolvedMembers) {
+        created.push(await this.registerSingleSubscription({
+          ...input,
+          sourceId: memberSource.sourceId,
+          shortcut: undefined,
+          filter: member.filter,
+          trackedResourceRef: member.trackedResourceRef ?? null,
+          cleanupPolicy: member.cleanupPolicy ?? null,
+        }));
+      }
+    } catch (error) {
+      await this.rollbackRegisteredSubscriptions(created);
+      throw error;
     }
     return created;
+  }
+
+  private async rollbackRegisteredSubscriptions(subscriptions: Subscription[]): Promise<void> {
+    for (const subscription of [...subscriptions].reverse()) {
+      try {
+        await this.removeSubscription(subscription.subscriptionId);
+      } catch (error) {
+        console.warn(`failed to roll back subscription ${subscription.subscriptionId}:`, error);
+      }
+    }
   }
 
   private resolveShortcutMemberSource(source: SourceStream, member: ExpandedSubscriptionMember): SourceStream {
@@ -985,18 +1019,24 @@ export class AgentInboxService {
     };
     this.ensureInboxForAgent(subscription.agentId);
     this.store.insertSubscription(subscription);
-
-    const stream = await this.ensureStreamForSource(source);
-    await this.backend.ensureConsumer({
-      streamId: stream.streamId,
-      subscriptionId: subscription.subscriptionId,
-      consumerKey: `subscription:${subscription.subscriptionId}`,
-      startPolicy: subscription.startPolicy,
-      startOffset: subscription.startOffset ?? null,
-      startTime: subscription.startTime ?? null,
-    });
-    this.store.deleteSourceIdleState(source.sourceId);
-    return subscription;
+    try {
+      const stream = await this.ensureStreamForSource(source);
+      await this.backend.ensureConsumer({
+        streamId: stream.streamId,
+        subscriptionId: subscription.subscriptionId,
+        consumerKey: `subscription:${subscription.subscriptionId}`,
+        startPolicy: subscription.startPolicy,
+        startOffset: subscription.startOffset ?? null,
+        startTime: subscription.startTime ?? null,
+      });
+      this.store.deleteSourceIdleState(source.sourceId);
+      return subscription;
+    } catch (error) {
+      this.store.deleteSubscription(subscription.subscriptionId);
+      this.clearSubscriptionRuntimeState(subscription);
+      this.refreshSourceIdleState(source.sourceId);
+      throw error;
+    }
   }
 
   async removeSubscription(subscriptionId: string): Promise<{ removed: boolean; subscriptionId: string }> {
@@ -1844,12 +1884,18 @@ export class AgentInboxService {
     }
     const signalOccurredAt = signal.occurredAt ?? nowIso();
     const signalOccurredAtMs = Date.parse(signalOccurredAt);
+    const sourceHostIdBySourceId = new Map<string, string | null>();
     for (const subscription of this.store.listSubscriptions()) {
       if (!subscription.trackedResourceRef || subscription.trackedResourceRef !== signal.ref) {
         continue;
       }
-      const subscriptionSource = this.store.getSource(subscription.sourceId);
-      if (!subscriptionSource || subscriptionSource.hostId !== source.hostId) {
+      let subscriptionHostId = sourceHostIdBySourceId.get(subscription.sourceId);
+      if (subscriptionHostId === undefined) {
+        const subscriptionSource = this.store.getSource(subscription.sourceId);
+        subscriptionHostId = subscriptionSource?.hostId ?? null;
+        sourceHostIdBySourceId.set(subscription.sourceId, subscriptionHostId);
+      }
+      if (subscriptionHostId !== source.hostId) {
         continue;
       }
       const retireAt = lifecycleRetireAtForSignal(subscription.cleanupPolicy, signalOccurredAtMs);

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -334,7 +334,12 @@ export function normalizeGithubRepoEvent(
   };
 }
 
-export function deriveGithubTrackedResource(filter: SubscriptionFilter): { ref: string } | null {
+export function canonicalGithubPullRequestRef(source: SourceStream, number: number): string {
+  const config = parseGithubSourceConfig(source);
+  return `repo:${config.owner}/${config.repo}:pr:${number}`;
+}
+
+export function deriveGithubTrackedResource(filter: SubscriptionFilter, source: SourceStream): { ref: string } | null {
   const metadata = asRecord(filter.metadata);
   const payload = asRecord(filter.payload);
   const number = asNumber(metadata.number) ?? asNumber(payload.number) ?? asNumber(payload.ref);
@@ -342,7 +347,7 @@ export function deriveGithubTrackedResource(filter: SubscriptionFilter): { ref: 
   if (!number || isPullRequest !== true) {
     return null;
   }
-  return { ref: `pr:${number}` };
+  return { ref: canonicalGithubPullRequestRef(source, number) };
 }
 
 export function githubSubscriptionShortcutSpec(): Array<{
@@ -353,17 +358,24 @@ export function githubSubscriptionShortcutSpec(): Array<{
   return [{
     name: "pr",
     description: "Follow one pull request and auto-retire when it closes.",
-    argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+    argsSchema: [
+      { name: "number", type: "number", required: true, description: "Pull request number." },
+      { name: "withCi", type: "boolean", required: false, description: "Also create a sibling ci_runs subscription under the same host and stream key." },
+    ],
   }];
 }
 
 export function expandGithubSubscriptionShortcut(input: {
   name: string;
   args?: Record<string, unknown>;
+  source: SourceStream;
 }): {
-  filter: SubscriptionFilter;
-  trackedResourceRef: string;
-  cleanupPolicy: { mode: "on_terminal" };
+  members: Array<{
+    streamKind?: string | null;
+    filter?: SubscriptionFilter;
+    trackedResourceRef: string;
+    cleanupPolicy: { mode: "on_terminal" };
+  }>;
 } | null {
   if (input.name !== "pr") {
     return null;
@@ -372,19 +384,33 @@ export function expandGithubSubscriptionShortcut(input: {
   if (!number || !Number.isInteger(number) || number <= 0) {
     throw new Error("subscription shortcut pr requires a positive integer number");
   }
+  const trackedResourceRef = canonicalGithubPullRequestRef(input.source, number);
+  const withCi = input.args?.withCi === true;
   return {
-    filter: {
-      metadata: {
-        number,
-        isPullRequest: true,
+    members: [
+      {
+        streamKind: "repo_events",
+        filter: {
+          metadata: {
+            number,
+            isPullRequest: true,
+          },
+        },
+        trackedResourceRef,
+        cleanupPolicy: { mode: "on_terminal" },
       },
-    },
-    trackedResourceRef: `pr:${number}`,
-    cleanupPolicy: { mode: "on_terminal" },
+      ...(withCi
+        ? [{
+            streamKind: "ci_runs",
+            trackedResourceRef,
+            cleanupPolicy: { mode: "on_terminal" as const },
+          }]
+        : []),
+    ],
   };
 }
 
-export function projectGithubLifecycleSignal(rawPayload: Record<string, unknown>): {
+export function projectGithubLifecycleSignal(rawPayload: Record<string, unknown>, source: SourceStream): {
   ref: string;
   terminal: boolean;
   state: string;
@@ -405,7 +431,7 @@ export function projectGithubLifecycleSignal(rawPayload: Record<string, unknown>
   }
   const merged = action === "merged" || asBoolean(rawPayload.merged) === true || asBoolean(pullRequest.merged) === true;
   return {
-    ref: `pr:${number}`,
+    ref: canonicalGithubPullRequestRef(source, number),
     terminal: true,
     state: "closed",
     result: merged ? "merged" : "closed",

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -3,7 +3,13 @@ import { ActivationItem, AppendSourceEventInput, NotificationGrouping, SourcePol
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
 import { nowIso } from "../util";
-import { ExpandedSubscriptionInput, LifecycleSignal, ManagedSourceSpec, RemoteSourceModuleRegistry } from "./remote_modules";
+import {
+  ExpandedSubscriptionInput,
+  ExpandedSubscriptionPlan,
+  LifecycleSignal,
+  ManagedSourceSpec,
+  RemoteSourceModuleRegistry,
+} from "./remote_modules";
 
 const REMOTE_SOURCE_TYPES = new Set<SourceStream["sourceType"]>([
   "remote_source",
@@ -226,7 +232,7 @@ export class RemoteSourceRuntime {
   async expandSubscriptionShortcut(
     source: SourceStream,
     input: { name: string; args?: Record<string, unknown> },
-  ): Promise<ExpandedSubscriptionInput | null> {
+  ): Promise<ExpandedSubscriptionPlan | null> {
     if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
       return null;
     }
@@ -234,11 +240,12 @@ export class RemoteSourceRuntime {
     if (typeof module.expandSubscriptionShortcut !== "function") {
       return null;
     }
-    return module.expandSubscriptionShortcut({
+    const expanded = module.expandSubscriptionShortcut({
       name: input.name,
       args: input.args,
       source: moduleInputSource(source),
     });
+    return normalizeExpandedSubscriptionPlan(expanded);
   }
 
   async deriveInlinePreview(source: SourceStream, item: ActivationItem): Promise<string | null> {
@@ -426,6 +433,38 @@ export class RemoteSourceRuntime {
       this.inFlight.delete(sourceId);
     }
   }
+}
+
+function normalizeExpandedSubscriptionPlan(
+  value: ExpandedSubscriptionInput | ExpandedSubscriptionPlan | null,
+): ExpandedSubscriptionPlan | null {
+  if (!value) {
+    return null;
+  }
+  if (isExpandedSubscriptionPlan(value)) {
+    return {
+      members: value.members.map((member) => ({
+        streamKind: typeof member.streamKind === "string" ? member.streamKind : null,
+        filter: member.filter,
+        trackedResourceRef: member.trackedResourceRef ?? null,
+        cleanupPolicy: member.cleanupPolicy ?? null,
+      })),
+    };
+  }
+  return {
+    members: [{
+      streamKind: null,
+      filter: value.filter,
+      trackedResourceRef: value.trackedResourceRef ?? null,
+      cleanupPolicy: value.cleanupPolicy ?? null,
+    }],
+  };
+}
+
+function isExpandedSubscriptionPlan(
+  value: ExpandedSubscriptionInput | ExpandedSubscriptionPlan,
+): value is ExpandedSubscriptionPlan {
+  return "members" in value && Array.isArray(value.members);
 }
 
 function moduleInputSource(source: SourceStream): SourceStream {

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -84,6 +84,14 @@ export interface ExpandedSubscriptionInput {
   cleanupPolicy?: CleanupPolicy | null;
 }
 
+export interface ExpandedSubscriptionMember extends ExpandedSubscriptionInput {
+  streamKind?: string | null;
+}
+
+export interface ExpandedSubscriptionPlan {
+  members: ExpandedSubscriptionMember[];
+}
+
 export interface ExpandSubscriptionShortcutInput {
   name: string;
   args?: Record<string, unknown>;
@@ -119,7 +127,7 @@ export interface RemoteSourceModule {
   // Optional capability hooks used by resolved schema and future subscription ergonomics.
   describeCapabilities?(source: SourceStream): RemoteSourceCapabilityDescription;
   listSubscriptionShortcuts?(source: SourceStream): SubscriptionShortcutSpec[];
-  expandSubscriptionShortcut?(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | null;
+  expandSubscriptionShortcut?(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | ExpandedSubscriptionPlan | null;
   deriveTrackedResource?(filter: SubscriptionFilter, source: SourceStream): { ref: string } | null;
   projectLifecycleSignal?(rawPayload: Record<string, unknown>, source: SourceStream): LifecycleSignal | null;
   deriveInlinePreview?(item: ActivationItem, source: SourceStream): string | null;
@@ -327,11 +335,11 @@ const GITHUB_REPO_MODULE: RemoteSourceModule = {
   listSubscriptionShortcuts(): SubscriptionShortcutSpec[] {
     return githubSubscriptionShortcutSpec();
   },
-  expandSubscriptionShortcut(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | null {
+  expandSubscriptionShortcut(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | ExpandedSubscriptionPlan | null {
     return expandGithubSubscriptionShortcut(input);
   },
-  deriveTrackedResource(filter: SubscriptionFilter): { ref: string } | null {
-    return deriveGithubTrackedResource(filter);
+  deriveTrackedResource(filter: SubscriptionFilter, source: SourceStream): { ref: string } | null {
+    return deriveGithubTrackedResource(filter, source);
   },
   deriveNotificationGrouping(item: ActivationItem): NotificationGrouping | null {
     const number = typeof item.metadata.number === "number" ? item.metadata.number : null;
@@ -381,8 +389,8 @@ const GITHUB_REPO_MODULE: RemoteSourceModule = {
     const count = items.length;
     return `${count} ${grouping.summaryHint}`;
   },
-  projectLifecycleSignal(rawPayload: Record<string, unknown>) {
-    return projectGithubLifecycleSignal(rawPayload);
+  projectLifecycleSignal(rawPayload: Record<string, unknown>, source: SourceStream) {
+    return projectGithubLifecycleSignal(rawPayload, source);
   },
   validateConfig(source: SourceStream): void {
     parseGithubSourceConfig(source);

--- a/src/store.ts
+++ b/src/store.ts
@@ -844,10 +844,10 @@ export class AgentInboxStore {
     this.db.run(
       `
       insert into subscription_lifecycle_retirements (
-        subscription_id, source_id, tracked_resource_ref, retire_at, terminal_state, terminal_result, terminal_occurred_at, created_at, updated_at
+        subscription_id, host_id, tracked_resource_ref, retire_at, terminal_state, terminal_result, terminal_occurred_at, created_at, updated_at
       ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
       on conflict(subscription_id) do update set
-        source_id = excluded.source_id,
+        host_id = excluded.host_id,
         tracked_resource_ref = excluded.tracked_resource_ref,
         retire_at = excluded.retire_at,
         terminal_state = excluded.terminal_state,
@@ -858,7 +858,7 @@ export class AgentInboxStore {
     `,
       [
         next.subscriptionId,
-        next.sourceId,
+        next.hostId,
         next.trackedResourceRef,
         next.retireAt,
         next.terminalState ?? null,
@@ -2221,7 +2221,7 @@ export class AgentInboxStore {
   private mapSubscriptionLifecycleRetirement(row: Record<string, unknown>): SubscriptionLifecycleRetirement {
     return {
       subscriptionId: String(row.subscription_id),
-      sourceId: String(row.source_id),
+      hostId: String(row.host_id),
       trackedResourceRef: String(row.tracked_resource_ref),
       retireAt: String(row.retire_at),
       terminalState: row.terminal_state ? String(row.terminal_state) : null,

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -715,7 +715,15 @@ test("builtin remote-backed source details expose resolved remote identity", asy
       shortcuts: [{
         name: "pr",
         description: "Follow one pull request and auto-retire when it closes.",
-        argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+        argsSchema: [
+          { name: "number", type: "number", required: true, description: "Pull request number." },
+          {
+            name: "withCi",
+            type: "boolean",
+            required: false,
+            description: "Also create a sibling ci_runs subscription under the same host and stream key.",
+          },
+        ],
       }],
     });
   } finally {
@@ -802,7 +810,15 @@ test("stream schema preview supports builtin remote-backed aliases without persi
     assert.deepEqual(preview.subscriptionSchema?.shortcuts, [{
       name: "pr",
       description: "Follow one pull request and auto-retire when it closes.",
-      argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+      argsSchema: [
+        { name: "number", type: "number", required: true, description: "Pull request number." },
+        {
+          name: "withCi",
+          type: "boolean",
+          required: false,
+          description: "Also create a sibling ci_runs subscription under the same host and stream key.",
+        },
+      ],
     }]);
     assert.equal(store.listSources().length, 0);
   } finally {
@@ -1069,6 +1085,88 @@ test("subscription add can expand a remote module shortcut into standard subscri
     assert.equal(subscription.trackedResourceRef, "ticket:A-42");
     assert.deepEqual(subscription.cleanupPolicy, { mode: "manual" });
     assert.equal(subscription.startPolicy, "earliest");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("github pr shortcut with withCi creates repo and sibling ci subscriptions", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const repoSource = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const ciSource = await service.registerSource({
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "github-pr-with-ci-thread",
+      tmuxPaneId: "%945",
+    });
+
+    const subscriptions = await service.registerSubscriptions({
+      agentId: agent.agent.agentId,
+      sourceId: repoSource.sourceId,
+      shortcut: {
+        name: "pr",
+        args: { number: 93, withCi: true },
+      },
+    });
+
+    assert.equal(subscriptions.length, 2);
+    assert.deepEqual(
+      subscriptions.map((subscription) => subscription.sourceId).sort(),
+      [ciSource.sourceId, repoSource.sourceId].sort(),
+    );
+    assert.deepEqual(
+      subscriptions.map((subscription) => subscription.trackedResourceRef),
+      ["repo:holon-run/agentinbox:pr:93", "repo:holon-run/agentinbox:pr:93"],
+    );
+    assert.deepEqual(subscriptions.map((subscription) => subscription.cleanupPolicy), [
+      { mode: "on_terminal" },
+      { mode: "on_terminal" },
+    ]);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("github pr shortcut with withCi fails clearly when sibling ci stream is missing", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const repoSource = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "github-pr-with-ci-missing-thread",
+      tmuxPaneId: "%946",
+    });
+
+    await assert.rejects(
+      service.registerSubscriptions({
+        agentId: agent.agent.agentId,
+        sourceId: repoSource.sourceId,
+        shortcut: {
+          name: "pr",
+          args: { number: 93, withCi: true },
+        },
+      }),
+      /requires an existing sibling ci_runs stream/,
+    );
   } finally {
     await service.stop();
     store.close();
@@ -4371,6 +4469,68 @@ test("resumeAgent partially recovers mixed offline targets and reconciles agent 
   }
 });
 
+test("github repo terminal lifecycle fanout retires sibling repo and ci subscriptions by host-scoped trackedResourceRef", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const repoSource = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const ciSource = await service.registerSource({
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const agentA = await registerTmuxAgent(service, "github-fanout-a");
+    const agentB = await registerTmuxAgent(service, "github-fanout-b");
+    const repoSubscription = await service.registerSubscription({
+      agentId: agentA.agentId,
+      sourceId: repoSource.sourceId,
+      trackedResourceRef: "repo:holon-run/agentinbox:pr:93",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: { metadata: { number: 93, isPullRequest: true } },
+      startPolicy: "earliest",
+    });
+    const ciSubscription = await service.registerSubscription({
+      agentId: agentB.agentId,
+      sourceId: ciSource.sourceId,
+      trackedResourceRef: "repo:holon-run/agentinbox:pr:93",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: {},
+      startPolicy: "earliest",
+    });
+
+    await service.appendSourceEvent({
+      sourceId: repoSource.sourceId,
+      sourceNativeId: "evt-github-terminal-1",
+      eventVariant: "PullRequestEvent.closed",
+      metadata: { number: 93, isPullRequest: true },
+      rawPayload: {
+        type: "PullRequestEvent",
+        action: "closed",
+        pull_request: { number: 93, merged: true },
+      },
+      occurredAt: "2026-04-19T00:00:00.000Z",
+    });
+
+    await service.pollSubscription(repoSubscription.subscriptionId);
+
+    const repoRetirement = store.getSubscriptionLifecycleRetirement(repoSubscription.subscriptionId);
+    const ciRetirement = store.getSubscriptionLifecycleRetirement(ciSubscription.subscriptionId);
+    assert.ok(repoRetirement);
+    assert.ok(ciRetirement);
+    assert.equal(repoRetirement?.hostId, repoSource.hostId);
+    assert.equal(ciRetirement?.hostId, repoSource.hostId);
+    assert.equal(repoRetirement?.trackedResourceRef, "repo:holon-run/agentinbox:pr:93");
+    assert.equal(ciRetirement?.trackedResourceRef, "repo:holon-run/agentinbox:pr:93");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("gc does not retire subscriptions before they consume a terminal event", async () => {
   const { store, service, dir } = await makeService();
   try {
@@ -4446,7 +4606,7 @@ test("gc does not retire subscriptions before they consume a terminal event", as
   }
 });
 
-test("gc does not retire sibling subscriptions sharing a trackedResourceRef before they consume the terminal event", async () => {
+test("gc retires sibling subscriptions sharing a host-scoped trackedResourceRef from one terminal signal", async () => {
   const { store, service, dir } = await makeService();
   try {
     const moduleDir = path.join(dir, "source-modules");
@@ -4514,19 +4674,55 @@ test("gc does not retire sibling subscriptions sharing a trackedResourceRef befo
 
     await service.pollSubscription(subscriptionA.subscriptionId);
     assert.ok(store.getSubscriptionLifecycleRetirement(subscriptionA.subscriptionId));
-    assert.equal(store.getSubscriptionLifecycleRetirement(subscriptionB.subscriptionId), null);
-
-    const firstGc = service.gc();
-    assert.equal(firstGc.removedSubscriptions, 1);
-    assert.equal(store.getSubscription(subscriptionA.subscriptionId), null);
-    assert.ok(store.getSubscription(subscriptionB.subscriptionId));
-
-    await service.pollSubscription(subscriptionB.subscriptionId);
     assert.ok(store.getSubscriptionLifecycleRetirement(subscriptionB.subscriptionId));
 
-    const secondGc = service.gc();
-    assert.equal(secondGc.removedSubscriptions, 1);
+    const firstGc = service.gc();
+    assert.equal(firstGc.removedSubscriptions, 2);
+    assert.equal(store.getSubscription(subscriptionA.subscriptionId), null);
     assert.equal(store.getSubscription(subscriptionB.subscriptionId), null);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("subscription remove does not cascade across sibling subscriptions sharing a host-scoped trackedResourceRef", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const repoSource = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const ciSource = await service.registerSource({
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const agent = await registerTmuxAgent(service, "github-remove-local");
+    const repoSubscription = await service.registerSubscription({
+      agentId: agent.agentId,
+      sourceId: repoSource.sourceId,
+      trackedResourceRef: "repo:holon-run/agentinbox:pr:93",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: { metadata: { number: 93, isPullRequest: true } },
+      startPolicy: "earliest",
+    });
+    const ciSubscription = await service.registerSubscription({
+      agentId: agent.agentId,
+      sourceId: ciSource.sourceId,
+      trackedResourceRef: "repo:holon-run/agentinbox:pr:93",
+      cleanupPolicy: { mode: "on_terminal" },
+      filter: {},
+      startPolicy: "earliest",
+    });
+
+    const removed = await service.removeSubscription(repoSubscription.subscriptionId);
+
+    assert.equal(removed.removed, true);
+    assert.equal(store.getSubscription(repoSubscription.subscriptionId), null);
+    assert.ok(store.getSubscription(ciSubscription.subscriptionId));
   } finally {
     await service.stop();
     store.close();

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -5,7 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import initSqlJs from "sql.js";
 import { AdapterRegistry } from "../src/adapters";
-import { SqliteEventBusBackend } from "../src/backend";
+import { EventBusBackend, SqliteEventBusBackend } from "../src/backend";
 import { Activation, ActivationTarget, AppendSourceEventInput, Subscription, TerminalActivationTarget } from "../src/model";
 import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { ActivationGate } from "../src/runtime_gate";
@@ -124,12 +124,29 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   }
 }
 
+class FailOnNthEnsureConsumerBackend extends SqliteEventBusBackend {
+  private ensureConsumerCalls = 0;
+
+  constructor(store: AgentInboxStore, private readonly failAtCall: number) {
+    super(store);
+  }
+
+  override async ensureConsumer(input: Parameters<SqliteEventBusBackend["ensureConsumer"]>[0]) {
+    this.ensureConsumerCalls += 1;
+    if (this.ensureConsumerCalls === this.failAtCall) {
+      throw new Error("ensureConsumer failed for test");
+    }
+    return super.ensureConsumer(input);
+  }
+}
+
 async function makeService(options?: {
   dispatcher?: ActivationDispatcher;
   terminalDispatcher?: TerminalDispatcher;
   activationGate?: ActivationGate;
   activationWindowMs?: number;
   activationMaxItems?: number;
+  backend?: EventBusBackend;
 }): Promise<{ store: AgentInboxStore; service: AgentInboxService; dir: string }> {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-test-"));
   const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
@@ -142,7 +159,7 @@ async function makeService(options?: {
     store,
     adapters,
     options?.dispatcher,
-    new SqliteEventBusBackend(store),
+    options?.backend ?? new SqliteEventBusBackend(store),
     {
       windowMs: options?.activationWindowMs,
       maxItems: options?.activationMaxItems,
@@ -165,6 +182,7 @@ async function makeServiceFromDbPath(
     activationGate?: ActivationGate;
     activationWindowMs?: number;
     activationMaxItems?: number;
+    backend?: EventBusBackend;
   },
 ): Promise<{ store: AgentInboxStore; service: AgentInboxService }> {
   const store = await AgentInboxStore.open(dbPath);
@@ -177,7 +195,7 @@ async function makeServiceFromDbPath(
     store,
     adapters,
     options?.dispatcher,
-    new SqliteEventBusBackend(store),
+    options?.backend ?? new SqliteEventBusBackend(store),
     {
       windowMs: options?.activationWindowMs,
       maxItems: options?.activationMaxItems,
@@ -283,7 +301,42 @@ async function createLegacyDb(dbPath: string): Promise<void> {
   db.close();
 }
 
-async function readMigrationState(dbPath: string): Promise<{ appliedTags: string[]; hasNewIndex: boolean }> {
+async function createV1BaselineDbWithSourceScopedLifecycleRetirement(dbPath: string): Promise<void> {
+  const SQL = await initSqlJs({
+    locateFile: (file: string) => require.resolve(`sql.js/dist/${file}`),
+  });
+  const db = new SQL.Database();
+  const baselineSql = fs.readFileSync(path.resolve(__dirname, "../drizzle/migrations/0000_v1_initial.sql"), "utf8");
+  db.exec(`
+    create table if not exists __drizzle_migrations (
+      id integer primary key autoincrement,
+      tag text not null unique,
+      applied_at text not null
+    );
+  `);
+  db.exec(baselineSql);
+  db.exec(`
+    insert into __drizzle_migrations (tag, applied_at) values ('0000_v1_initial', '2026-04-19T00:00:00.000Z');
+    insert into source_hosts (host_id, host_type, host_key, config_ref, config_json, status, created_at, updated_at)
+    values ('hst_legacy_github', 'github', 'uxcAuth:default', null, '{}', 'active', '2026-04-19T00:00:00.000Z', '2026-04-19T00:00:00.000Z');
+    insert into sources (
+      source_id, host_id, stream_kind, stream_key, source_type, source_key, config_ref, config_json, status, checkpoint, created_at, updated_at
+    ) values (
+      'src_legacy_github', 'hst_legacy_github', 'repo_events', 'holon-run/agentinbox', 'github_repo', 'holon-run/agentinbox', null, '{}', 'active', null,
+      '2026-04-19T00:00:00.000Z', '2026-04-19T00:00:00.000Z'
+    );
+    insert into subscription_lifecycle_retirements (
+      subscription_id, source_id, tracked_resource_ref, retire_at, terminal_state, terminal_result, terminal_occurred_at, created_at, updated_at
+    ) values (
+      'sub_legacy_retirement', 'src_legacy_github', 'repo:holon-run/agentinbox:pr:72', '2026-04-19T01:00:00.000Z', 'closed', 'merged',
+      '2026-04-19T00:30:00.000Z', '2026-04-19T00:30:00.000Z', '2026-04-19T00:30:00.000Z'
+    );
+  `);
+  fs.writeFileSync(dbPath, Buffer.from(db.export()));
+  db.close();
+}
+
+async function readMigrationState(dbPath: string): Promise<{ appliedTags: string[]; hasNewIndex: boolean; retirementColumns: string[] }> {
   const SQL = await initSqlJs({
     locateFile: (file: string) => require.resolve(`sql.js/dist/${file}`),
   });
@@ -294,8 +347,10 @@ async function readMigrationState(dbPath: string): Promise<{ appliedTags: string
   const hasNewIndex = indexResult.some((set) =>
     set.values.some((row) => String(row[1]) === "idx_inbox_items_source_occurred_at"),
   );
+  const retirementColumnsResult = db.exec("pragma table_info('subscription_lifecycle_retirements');") as Array<{ values: unknown[][] }>;
+  const retirementColumns = (retirementColumnsResult[0]?.values ?? []).map((row) => String(row[1]));
   db.close();
-  return { appliedTags, hasNewIndex };
+  return { appliedTags, hasNewIndex, retirementColumns };
 }
 
 test("store migrates a new database using drizzle SQL migrations", async () => {
@@ -304,8 +359,9 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, ["0000_v1_initial"]);
+    assert.deepEqual(state.appliedTags, ["0000_v1_initial", "0002_host_scoped_lifecycle_retirements"]);
     assert.equal(state.hasNewIndex, true);
+    assert.deepEqual(state.retirementColumns.includes("host_id"), true);
     const backups = fs.readdirSync(dir).filter((name) => name.includes(".pre-v1."));
     assert.equal(backups.length, 0);
   } finally {
@@ -328,7 +384,7 @@ test("store reopens an existing v1 database without archiving it", async () => {
   const reopened = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, ["0000_v1_initial"]);
+    assert.deepEqual(state.appliedTags, ["0000_v1_initial", "0002_host_scoped_lifecycle_retirements"]);
     assert.equal(warnings.length, 0);
     const backups = fs.readdirSync(dir).filter((name) => name.includes(".pre-v1."));
     assert.equal(backups.length, 0);
@@ -351,7 +407,7 @@ test("store archives a pre-v1 database and starts fresh with the v1 baseline", a
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, ["0000_v1_initial"]);
+    assert.deepEqual(state.appliedTags, ["0000_v1_initial", "0002_host_scoped_lifecycle_retirements"]);
     assert.equal(state.hasNewIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.includes(".pre-v1."));
     assert.equal(backups.length, 1);
@@ -360,6 +416,25 @@ test("store archives a pre-v1 database and starts fresh with the v1 baseline", a
     assert.match(warnings[0] ?? "", /no data imported/);
   } finally {
     console.warn = originalWarn;
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("store upgrades source-scoped lifecycle retirements to host-scoped retirements for existing v1 databases", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-migrate-lifecycle-host-"));
+  const dbPath = path.join(dir, "agentinbox.sqlite");
+  await createV1BaselineDbWithSourceScopedLifecycleRetirement(dbPath);
+  const store = await AgentInboxStore.open(dbPath);
+  try {
+    const state = await readMigrationState(dbPath);
+    assert.deepEqual(state.appliedTags, ["0000_v1_initial", "0002_host_scoped_lifecycle_retirements"]);
+    assert.deepEqual(state.retirementColumns.includes("host_id"), true);
+    assert.deepEqual(state.retirementColumns.includes("source_id"), false);
+    const retirement = store.getSubscriptionLifecycleRetirement("sub_legacy_retirement");
+    assert.equal(retirement?.hostId, "hst_legacy_github");
+    assert.equal(retirement?.trackedResourceRef, "repo:holon-run/agentinbox:pr:72");
+  } finally {
     store.close();
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -1167,6 +1242,92 @@ test("github pr shortcut with withCi fails clearly when sibling ci stream is mis
       }),
       /requires an existing sibling ci_runs stream/,
     );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("registerSubscription rejects multi-member shortcuts and directs callers to registerSubscriptions", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const repoSource = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    await service.registerSource({
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "github-pr-register-single-thread",
+      tmuxPaneId: "%947",
+    });
+
+    await assert.rejects(
+      service.registerSubscription({
+        agentId: agent.agent.agentId,
+        sourceId: repoSource.sourceId,
+        shortcut: {
+          name: "pr",
+          args: { number: 93, withCi: true },
+        },
+      }),
+      /use registerSubscriptions\(\) instead/,
+    );
+    assert.equal(store.listSubscriptions().length, 0);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("registerSubscriptions rolls back earlier shortcut members when a later member fails", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-shortcut-rollback-"));
+  const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
+  let service: AgentInboxService;
+  const backend = new FailOnNthEnsureConsumerBackend(store, 2);
+  const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input), {
+    homeDir: dir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, backend);
+  try {
+    const repoSource = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    await service.registerSource({
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "github-pr-rollback-thread",
+      tmuxPaneId: "%948",
+    });
+
+    await assert.rejects(
+      service.registerSubscriptions({
+        agentId: agent.agent.agentId,
+        sourceId: repoSource.sourceId,
+        shortcut: {
+          name: "pr",
+          args: { number: 93, withCi: true },
+        },
+      }),
+      /ensureConsumer failed for test/,
+    );
+    assert.equal(store.listSubscriptions().length, 0);
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -2187,9 +2187,11 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.ok(schemaResponse.data.metadataFields.length > 0);
 
       const subscriptionResponse = await client.request<{
-        subscriptionId: string;
-        trackedResourceRef: string | null;
-        cleanupPolicy: Record<string, unknown>;
+        subscriptions: Array<{
+          subscriptionId: string;
+          trackedResourceRef: string | null;
+          cleanupPolicy: Record<string, unknown>;
+        }>;
       }>("/subscriptions", {
         agentId,
         sourceId: sourceResponse.data.sourceId,
@@ -2203,8 +2205,9 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
         startPolicy: "earliest",
       });
       assert.equal(subscriptionResponse.statusCode, 200);
-      assert.equal(subscriptionResponse.data.trackedResourceRef, "pr:69");
-      assert.deepEqual(subscriptionResponse.data.cleanupPolicy, {
+      assert.equal(subscriptionResponse.data.subscriptions.length, 1);
+      assert.equal(subscriptionResponse.data.subscriptions[0]?.trackedResourceRef, "pr:69");
+      assert.deepEqual(subscriptionResponse.data.subscriptions[0]?.cleanupPolicy, {
         mode: "on_terminal_or_at",
         at: "2026-05-01T00:00:00.000Z",
         gracePeriodSecs: 120,
@@ -2221,7 +2224,7 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(appendResponse.data.appended, 1);
 
       const pollResponse = await client.request<SubscriptionPollResult>(
-        `/subscriptions/${subscriptionResponse.data.subscriptionId}/poll`,
+        `/subscriptions/${subscriptionResponse.data.subscriptions[0]?.subscriptionId}/poll`,
         {},
       );
       assert.equal(pollResponse.statusCode, 200);
@@ -2264,7 +2267,7 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(historyAfterAck.data.entries.length, 1);
 
       const removeSubscriptionResponse = await client.request<{ removed: boolean; subscriptionId: string }>(
-        `/subscriptions/${encodeURIComponent(subscriptionResponse.data.subscriptionId)}`,
+        `/subscriptions/${encodeURIComponent(subscriptionResponse.data.subscriptions[0]?.subscriptionId ?? "")}`,
         undefined,
         "DELETE",
       );
@@ -3382,7 +3385,7 @@ test("control plane source remove accepts with_subscriptions for explicit cascad
         runtimeSessionId: "control-plane-remove-cascade-thread",
         tmuxPaneId: "%320",
       });
-      const subscription = await client.request<{ subscriptionId: string }>("/subscriptions", {
+      const subscription = await client.request<{ subscriptions: Array<{ subscriptionId: string }> }>("/subscriptions", {
         agentId: registered.data.agent.agentId,
         sourceId: source.data.sourceId,
       });
@@ -3401,7 +3404,7 @@ test("control plane source remove accepts with_subscriptions for explicit cascad
       assert.equal(removed.data.pausedSource, false);
 
       const missingSubscription = await client.request(
-        `/subscriptions/${encodeURIComponent(subscription.data.subscriptionId)}`,
+        `/subscriptions/${encodeURIComponent(subscription.data.subscriptions[0]?.subscriptionId ?? "")}`,
         undefined,
         "GET",
       );

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1455,13 +1455,16 @@ test("cli subscription add supports generic shortcut invocation", async () => {
     ], env);
     assert.equal(added.status, 0, added.stderr);
     const payload = JSON.parse(added.stdout) as {
-      filter: Record<string, unknown>;
-      trackedResourceRef: string | null;
-      cleanupPolicy: Record<string, unknown>;
+      subscriptions: Array<{
+        filter: Record<string, unknown>;
+        trackedResourceRef: string | null;
+        cleanupPolicy: Record<string, unknown>;
+      }>;
     };
-    assert.deepEqual(payload.filter, { metadata: { ticketId: "A-7" } });
-    assert.equal(payload.trackedResourceRef, "ticket:A-7");
-    assert.deepEqual(payload.cleanupPolicy, { mode: "manual" });
+    assert.equal(payload.subscriptions.length, 1);
+    assert.deepEqual(payload.subscriptions[0]?.filter, { metadata: { ticketId: "A-7" } });
+    assert.equal(payload.subscriptions[0]?.trackedResourceRef, "ticket:A-7");
+    assert.deepEqual(payload.subscriptions[0]?.cleanupPolicy, { mode: "manual" });
 
     const conflicting = runCli([
       "subscription",
@@ -1476,6 +1479,87 @@ test("cli subscription add supports generic shortcut invocation", async () => {
     ], env);
     assert.notEqual(conflicting.status, 0);
     assert.match(conflicting.stderr, /shortcut does not allow filter, trackedResourceRef, or cleanupPolicy flags/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli github pr shortcut with withCi returns created sibling subscriptions", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-github-shortcut-"));
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%933",
+    CODEX_THREAD_ID: "thread-github-shortcut",
+  };
+
+  try {
+    const store = await AgentInboxStore.open(dbPath);
+    store.insertSource({
+      sourceId: "src_cli_github_repo",
+      hostId: "hst_cli_github",
+      streamKind: "repo_events",
+      streamKey: "holon-run/agentinbox",
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      configRef: null,
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+      status: "active",
+      checkpoint: null,
+      createdAt: "2026-04-14T00:00:00.000Z",
+      updatedAt: "2026-04-14T00:00:00.000Z",
+    });
+    store.insertSource({
+      sourceId: "src_cli_github_ci",
+      hostId: "hst_cli_github",
+      streamKind: "ci_runs",
+      streamKey: "holon-run/agentinbox",
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      configRef: null,
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+      status: "active",
+      checkpoint: null,
+      createdAt: "2026-04-14T00:00:00.000Z",
+      updatedAt: "2026-04-14T00:00:00.000Z",
+    });
+    store.close();
+
+    const added = runCli([
+      "subscription",
+      "add",
+      "src_cli_github_repo",
+      "--shortcut",
+      "pr",
+      "--shortcut-args-json",
+      "{\"number\":93,\"withCi\":true}",
+    ], env);
+    assert.equal(added.status, 0, added.stderr);
+    const payload = JSON.parse(added.stdout) as {
+      subscriptions: Array<{
+        sourceId: string;
+        trackedResourceRef: string | null;
+        cleanupPolicy: Record<string, unknown>;
+      }>;
+    };
+    assert.equal(payload.subscriptions.length, 2);
+    assert.deepEqual(
+      payload.subscriptions.map((subscription) => subscription.sourceId).sort(),
+      ["src_cli_github_ci", "src_cli_github_repo"],
+    );
+    assert.deepEqual(
+      payload.subscriptions.map((subscription) => subscription.trackedResourceRef),
+      ["repo:holon-run/agentinbox:pr:93", "repo:holon-run/agentinbox:pr:93"],
+    );
+    assert.deepEqual(payload.subscriptions.map((subscription) => subscription.cleanupPolicy), [
+      { mode: "on_terminal" },
+      { mode: "on_terminal" },
+    ]);
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });
@@ -1565,9 +1649,11 @@ test("control plane subscriptions accept generic shortcut invocation", async () 
         tmuxPaneId: "%950",
       });
       const subscription = await client.request<{
-        filter: Record<string, unknown>;
-        trackedResourceRef: string | null;
-        cleanupPolicy: Record<string, unknown>;
+        subscriptions: Array<{
+          filter: Record<string, unknown>;
+          trackedResourceRef: string | null;
+          cleanupPolicy: Record<string, unknown>;
+        }>;
       }>("/subscriptions", {
         agentId: registered.data.agent.agentId,
         sourceId: source.data.sourceId,
@@ -1577,9 +1663,92 @@ test("control plane subscriptions accept generic shortcut invocation", async () 
         },
       });
       assert.equal(subscription.statusCode, 200);
-      assert.deepEqual(subscription.data.filter, { metadata: { ticketId: "A-9" } });
-      assert.equal(subscription.data.trackedResourceRef, "ticket:A-9");
-      assert.deepEqual(subscription.data.cleanupPolicy, { mode: "manual" });
+      assert.equal(subscription.data.subscriptions.length, 1);
+      assert.deepEqual(subscription.data.subscriptions[0]?.filter, { metadata: { ticketId: "A-9" } });
+      assert.equal(subscription.data.subscriptions[0]?.trackedResourceRef, "ticket:A-9");
+      assert.deepEqual(subscription.data.subscriptions[0]?.cleanupPolicy, { mode: "manual" });
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane github pr shortcut with withCi returns created sibling subscriptions", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-github-shortcut-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const repoSource = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const ciSource = await service.registerSource({
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const registered = await client.request<{ agent: { agentId: string } }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "http-github-shortcut-thread",
+        tmuxPaneId: "%951",
+      });
+      const subscription = await client.request<{
+        subscriptions: Array<{
+          sourceId: string;
+          trackedResourceRef: string | null;
+          cleanupPolicy: Record<string, unknown>;
+        }>;
+      }>("/subscriptions", {
+        agentId: registered.data.agent.agentId,
+        sourceId: repoSource.sourceId,
+        shortcut: {
+          name: "pr",
+          args: { number: 93, withCi: true },
+        },
+      });
+      assert.equal(subscription.statusCode, 200);
+      assert.equal(subscription.data.subscriptions.length, 2);
+      assert.deepEqual(
+        subscription.data.subscriptions.map((created) => created.sourceId).sort(),
+        [ciSource.sourceId, repoSource.sourceId].sort(),
+      );
+      assert.deepEqual(
+        subscription.data.subscriptions.map((created) => created.trackedResourceRef),
+        ["repo:holon-run/agentinbox:pr:93", "repo:holon-run/agentinbox:pr:93"],
+      );
+      assert.deepEqual(subscription.data.subscriptions.map((created) => created.cleanupPolicy), [
+        { mode: "on_terminal" },
+        { mode: "on_terminal" },
+      ]);
     } finally {
       await started.close();
     }

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -156,22 +156,36 @@ test("normalizeGithubRepoEvent preserves pull request merged state for lifecycle
 });
 
 test("github pull request helpers derive tracked resources and terminal lifecycle results", async () => {
+  const source: SourceStream = {
+    sourceId: "src_pr_helpers",
+    hostId: "hst_pr_helpers",
+    streamKind: "repo_events",
+    streamKey: "holon-run/agentinbox",
+    sourceType: "github_repo",
+    sourceKey: "holon-run/agentinbox",
+    config: { owner: "holon-run", repo: "agentinbox" },
+    configRef: null,
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
   const filter: SubscriptionFilter = {
     metadata: {
       number: 72,
       isPullRequest: true,
     },
   };
-  assert.deepEqual(deriveGithubTrackedResource(filter), { ref: "pr:72" });
-  assert.equal(deriveGithubTrackedResource({ metadata: { number: 72 } }), null);
-  assert.equal(deriveGithubTrackedResource({ metadata: { number: 72, isPullRequest: false } }), null);
+  assert.deepEqual(deriveGithubTrackedResource(filter, source), { ref: "repo:holon-run/agentinbox:pr:72" });
+  assert.equal(deriveGithubTrackedResource({ metadata: { number: 72 } }, source), null);
+  assert.equal(deriveGithubTrackedResource({ metadata: { number: 72, isPullRequest: false } }, source), null);
 
   assert.deepEqual(projectGithubLifecycleSignal({
     type: "PullRequestEvent",
     action: "closed",
     pull_request: { number: 72, merged: true },
-  }), {
-    ref: "pr:72",
+  }, source), {
+    ref: "repo:holon-run/agentinbox:pr:72",
     terminal: true,
     state: "closed",
     result: "merged",
@@ -180,8 +194,8 @@ test("github pull request helpers derive tracked resources and terminal lifecycl
     type: "PullRequestEvent",
     action: "closed",
     pull_request: { number: 73, merged: false },
-  }), {
-    ref: "pr:73",
+  }, source), {
+    ref: "repo:holon-run/agentinbox:pr:73",
     terminal: true,
     state: "closed",
     result: "closed",
@@ -190,27 +204,72 @@ test("github pull request helpers derive tracked resources and terminal lifecycl
     type: "PullRequestEvent",
     action: "opened",
     pull_request: { number: 74 },
-  }), null);
+  }, source), null);
 });
 
 test("github subscription shortcut helpers expose and expand the builtin pr shortcut", async () => {
   assert.deepEqual(githubSubscriptionShortcutSpec(), [{
     name: "pr",
     description: "Follow one pull request and auto-retire when it closes.",
-    argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+    argsSchema: [
+      { name: "number", type: "number", required: true, description: "Pull request number." },
+      { name: "withCi", type: "boolean", required: false, description: "Also create a sibling ci_runs subscription under the same host and stream key." },
+    ],
   }]);
+  const source: SourceStream = {
+    sourceId: "src_pr_shortcut",
+    hostId: "hst_pr_shortcut",
+    streamKind: "repo_events",
+    streamKey: "holon-run/agentinbox",
+    sourceType: "github_repo",
+    sourceKey: "holon-run/agentinbox",
+    config: { owner: "holon-run", repo: "agentinbox" },
+    configRef: null,
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
   assert.deepEqual(expandGithubSubscriptionShortcut({
     name: "pr",
     args: { number: 74 },
+    source,
   }), {
-    filter: {
-      metadata: {
-        number: 74,
-        isPullRequest: true,
+    members: [{
+      streamKind: "repo_events",
+      filter: {
+        metadata: {
+          number: 74,
+          isPullRequest: true,
+        },
       },
-    },
-    trackedResourceRef: "pr:74",
-    cleanupPolicy: { mode: "on_terminal" },
+      trackedResourceRef: "repo:holon-run/agentinbox:pr:74",
+      cleanupPolicy: { mode: "on_terminal" },
+    }],
+  });
+  assert.deepEqual(expandGithubSubscriptionShortcut({
+    name: "pr",
+    args: { number: 74, withCi: true },
+    source,
+  }), {
+    members: [
+      {
+        streamKind: "repo_events",
+        filter: {
+          metadata: {
+            number: 74,
+            isPullRequest: true,
+          },
+        },
+        trackedResourceRef: "repo:holon-run/agentinbox:pr:74",
+        cleanupPolicy: { mode: "on_terminal" },
+      },
+      {
+        streamKind: "ci_runs",
+        trackedResourceRef: "repo:holon-run/agentinbox:pr:74",
+        cleanupPolicy: { mode: "on_terminal" },
+      },
+    ],
   });
 });
 

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -371,7 +371,7 @@ test("github_repo pull request subscriptions retire through the generic lifecycl
     const subscription = await service.registerSubscription({
       agentId: agent.agent.agentId,
       sourceId: source.sourceId,
-      trackedResourceRef: "pr:72",
+      trackedResourceRef: "repo:holon-run/agentinbox:pr:72",
       cleanupPolicy: { mode: "on_terminal" },
       filter: { metadata: { number: 72, isPullRequest: true } },
       startPolicy: "earliest",
@@ -404,7 +404,7 @@ test("github_repo pull request subscriptions retire through the generic lifecycl
     assert.equal(items[0]?.eventVariant, "PullRequestEvent.closed");
     assert.equal(items[0]?.metadata?.number, 72);
     assert.ok(retirement);
-    assert.equal(retirement?.trackedResourceRef, "pr:72");
+    assert.equal(retirement?.trackedResourceRef, "repo:holon-run/agentinbox:pr:72");
     assert.equal(retirement?.terminalState, "closed");
     assert.equal(retirement?.terminalResult, "merged");
 


### PR DESCRIPTION
## Summary
- expand the builtin GitHub `pr` shortcut into a multi-subscription plan and add optional `withCi` support for sibling `ci_runs` streams
- switch lifecycle retirement fanout to host-scoped `trackedResourceRef` matching and persist retirements by `hostId` instead of `sourceId`
- return `subscriptions[]` for shortcut-based control-plane/CLI creation and cover the new GitHub flow in service, CLI, HTTP, and helper tests

## Verification
- `npm run build`
- `node --require ts-node/register --test --test-force-exit test/github.test.ts`
- `node --require ts-node/register --test --test-force-exit test/agentinbox.test.ts --test-name-pattern "builtin remote-backed source details expose resolved remote identity|stream schema preview supports builtin remote-backed aliases without persisting a source|github pr shortcut with withCi|host-scoped trackedResourceRef|gc retires sibling subscriptions"`
- `timeout 120 node --require ts-node/register --test --test-force-exit --test-name-pattern='generic shortcut invocation|github pr shortcut with withCi' test/control_plane.test.ts`

Closes #153
