### PR TITLE
fix: tighten subscription envelope and lifecycle fanout lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ agentinbox inbox read --agent-id <agent_id>
 agentinbox inbox ack --agent-id <agent_id> --through <last_entry_id>
 ```
 
+The HTTP `POST /subscriptions` endpoint always returns
+`{ "subscriptions": [...] }`, even when only one subscription is created. That
+keeps shortcut expansion consistent for external callers.
+
 When acking a reviewed batch, prefer `--through <last_entry_id>` over `--all`.
 That preserves the boundary of the items you actually inspected. Use
 `ack --all` only when you have intentionally verified that every current

--- a/docs/site/reference/cli.md
+++ b/docs/site/reference/cli.md
@@ -94,6 +94,12 @@ persisted `filter`. When any explicit filter input mode is selected
 (`--filter-json`, `--filter-file`, or `--filter-stdin`), the supplied payload
 must be a non-empty JSON object.
 
+The control-plane `POST /subscriptions` API now always returns a
+`{ "subscriptions": [...] }` envelope. The CLI keeps the historical single
+subscription JSON shape for non-shortcut calls, but shortcut-driven creates may
+print the full envelope because one shortcut can expand into multiple
+subscriptions.
+
 `--shortcut` asks the source implementation to expand a named subscription
 shortcut into the standard persisted fields. Use `agentinbox source schema
 <source_id>` first to discover whether the source exposes any shortcuts and what
@@ -101,9 +107,10 @@ arguments they require. When `--shortcut` is present, do not also pass
 `--filter-*`, `--tracked-resource-ref`, or `--cleanup-policy-json`; the
 shortcut owns those fields.
 
-`--tracked-resource-ref` persists a source-scoped opaque resource identity such
-as `pr:373`. `--cleanup-policy-json` accepts the structured cleanup policy
-object persisted with the subscription, for example `{"mode":"manual"}` or
+`--tracked-resource-ref` persists an opaque resource identity such as `pr:373`
+or `repo:holon-run/agentinbox:pr:373`, depending on the source implementation.
+`--cleanup-policy-json` accepts the structured cleanup policy object persisted
+with the subscription, for example `{"mode":"manual"}` or
 `{"mode":"on_terminal_or_at","at":"2026-05-01T00:00:00.000Z","gracePeriodSecs":300}`.
 
 ## Inbox

--- a/docs/site/reference/http-api.md
+++ b/docs/site/reference/http-api.md
@@ -127,6 +127,23 @@ Use exactly one of `at`, `every`, or `cron`. `every` is an interval in milliseco
 
 `cleanupPolicy` defaults to `{"mode":"manual"}` when omitted.
 
+`POST /subscriptions` always returns an envelope:
+
+```json
+{
+  "subscriptions": [
+    {
+      "subscriptionId": "sub_...",
+      "agentId": "agt_...",
+      "sourceId": "src_..."
+    }
+  ]
+}
+```
+
+Non-shortcut creation returns one element. A shortcut may expand into multiple
+subscriptions, so callers should always read `subscriptions[]`.
+
 ## Inbox
 
 - `GET /agents/{agentId}/inbox`

--- a/drizzle/migrations/0003_subscription_tracked_resource_indexes.sql
+++ b/drizzle/migrations/0003_subscription_tracked_resource_indexes.sql
@@ -1,0 +1,5 @@
+create index if not exists idx_subscriptions_tracked_resource_ref
+  on subscriptions(tracked_resource_ref);
+
+create index if not exists idx_subscriptions_tracked_resource_source
+  on subscriptions(tracked_resource_ref, source_id);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -97,7 +97,10 @@ export const subscriptions = sqliteTable("subscriptions", {
   startOffset: integer("start_offset"),
   startTime: text("start_time"),
   createdAt: text("created_at").notNull(),
-});
+}, (table) => ({
+  trackedResourceRefIdx: index("idx_subscriptions_tracked_resource_ref").on(table.trackedResourceRef),
+  trackedResourceRefSourceIdx: index("idx_subscriptions_tracked_resource_source").on(table.trackedResourceRef, table.sourceId),
+}));
 
 export const subscriptionLifecycleRetirements = sqliteTable("subscription_lifecycle_retirements", {
   subscriptionId: text("subscription_id").primaryKey(),

--- a/src/http.ts
+++ b/src/http.ts
@@ -29,6 +29,15 @@ const errorResponseSchema = {
   },
 } as const;
 
+const subscriptionCollectionSchema = {
+  type: "object",
+  required: ["subscriptions"],
+  additionalProperties: false,
+  properties: {
+    subscriptions: { type: "array", items: jsonObjectSchema },
+  },
+} as const;
+
 const deliveryHandleSchema = {
   type: "object",
   additionalProperties: false,
@@ -1106,13 +1115,7 @@ function buildFastifyServer(service: AgentInboxService) {
         },
       },
       response: {
-        200: {
-          type: "object",
-          required: ["subscriptions"],
-          properties: {
-            subscriptions: { type: "array", items: jsonObjectSchema },
-          },
-        },
+        200: subscriptionCollectionSchema,
       },
     },
   }, async (request) => {
@@ -1153,7 +1156,7 @@ function buildFastifyServer(service: AgentInboxService) {
         },
       },
       response: {
-        200: jsonObjectSchema,
+        200: subscriptionCollectionSchema,
         400: errorResponseSchema,
       },
     },

--- a/src/service.ts
+++ b/src/service.ts
@@ -1884,20 +1884,7 @@ export class AgentInboxService {
     }
     const signalOccurredAt = signal.occurredAt ?? nowIso();
     const signalOccurredAtMs = Date.parse(signalOccurredAt);
-    const sourceHostIdBySourceId = new Map<string, string | null>();
-    for (const subscription of this.store.listSubscriptions()) {
-      if (!subscription.trackedResourceRef || subscription.trackedResourceRef !== signal.ref) {
-        continue;
-      }
-      let subscriptionHostId = sourceHostIdBySourceId.get(subscription.sourceId);
-      if (subscriptionHostId === undefined) {
-        const subscriptionSource = this.store.getSource(subscription.sourceId);
-        subscriptionHostId = subscriptionSource?.hostId ?? null;
-        sourceHostIdBySourceId.set(subscription.sourceId, subscriptionHostId);
-      }
-      if (subscriptionHostId !== source.hostId) {
-        continue;
-      }
+    for (const subscription of this.store.listSubscriptionsForHostTrackedResourceRef(source.hostId, signal.ref)) {
       const retireAt = lifecycleRetireAtForSignal(subscription.cleanupPolicy, signalOccurredAtMs);
       if (!retireAt) {
         continue;

--- a/src/store.ts
+++ b/src/store.ts
@@ -797,6 +797,20 @@ export class AgentInboxStore {
     return rows.map((row) => this.mapSubscription(row));
   }
 
+  listSubscriptionsForHostTrackedResourceRef(hostId: string, trackedResourceRef: string): Subscription[] {
+    const rows = this.getAll(
+      `
+      select subscriptions.*
+      from subscriptions
+      inner join sources on sources.source_id = subscriptions.source_id
+      where sources.host_id = ? and subscriptions.tracked_resource_ref = ?
+      order by subscriptions.created_at asc
+    `,
+      [hostId, trackedResourceRef],
+    );
+    return rows.map((row) => this.mapSubscription(row));
+  }
+
   deleteSubscription(subscriptionId: string): Subscription | null {
     const subscription = this.getSubscription(subscriptionId);
     if (!subscription) {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -336,7 +336,12 @@ async function createV1BaselineDbWithSourceScopedLifecycleRetirement(dbPath: str
   db.close();
 }
 
-async function readMigrationState(dbPath: string): Promise<{ appliedTags: string[]; hasNewIndex: boolean; retirementColumns: string[] }> {
+async function readMigrationState(dbPath: string): Promise<{
+  appliedTags: string[];
+  hasNewIndex: boolean;
+  retirementColumns: string[];
+  hasTrackedResourceIndex: boolean;
+}> {
   const SQL = await initSqlJs({
     locateFile: (file: string) => require.resolve(`sql.js/dist/${file}`),
   });
@@ -347,10 +352,14 @@ async function readMigrationState(dbPath: string): Promise<{ appliedTags: string
   const hasNewIndex = indexResult.some((set) =>
     set.values.some((row) => String(row[1]) === "idx_inbox_items_source_occurred_at"),
   );
+  const subscriptionIndexResult = db.exec("pragma index_list('subscriptions');") as Array<{ values: unknown[][] }>;
+  const hasTrackedResourceIndex = subscriptionIndexResult.some((set) =>
+    set.values.some((row) => String(row[1]) === "idx_subscriptions_tracked_resource_source"),
+  );
   const retirementColumnsResult = db.exec("pragma table_info('subscription_lifecycle_retirements');") as Array<{ values: unknown[][] }>;
   const retirementColumns = (retirementColumnsResult[0]?.values ?? []).map((row) => String(row[1]));
   db.close();
-  return { appliedTags, hasNewIndex, retirementColumns };
+  return { appliedTags, hasNewIndex, retirementColumns, hasTrackedResourceIndex };
 }
 
 test("store migrates a new database using drizzle SQL migrations", async () => {
@@ -359,9 +368,14 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, ["0000_v1_initial", "0002_host_scoped_lifecycle_retirements"]);
+    assert.deepEqual(state.appliedTags, [
+      "0000_v1_initial",
+      "0002_host_scoped_lifecycle_retirements",
+      "0003_subscription_tracked_resource_indexes",
+    ]);
     assert.equal(state.hasNewIndex, true);
     assert.deepEqual(state.retirementColumns.includes("host_id"), true);
+    assert.equal(state.hasTrackedResourceIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.includes(".pre-v1."));
     assert.equal(backups.length, 0);
   } finally {
@@ -384,8 +398,13 @@ test("store reopens an existing v1 database without archiving it", async () => {
   const reopened = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, ["0000_v1_initial", "0002_host_scoped_lifecycle_retirements"]);
+    assert.deepEqual(state.appliedTags, [
+      "0000_v1_initial",
+      "0002_host_scoped_lifecycle_retirements",
+      "0003_subscription_tracked_resource_indexes",
+    ]);
     assert.equal(warnings.length, 0);
+    assert.equal(state.hasTrackedResourceIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.includes(".pre-v1."));
     assert.equal(backups.length, 0);
   } finally {
@@ -407,8 +426,13 @@ test("store archives a pre-v1 database and starts fresh with the v1 baseline", a
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, ["0000_v1_initial", "0002_host_scoped_lifecycle_retirements"]);
+    assert.deepEqual(state.appliedTags, [
+      "0000_v1_initial",
+      "0002_host_scoped_lifecycle_retirements",
+      "0003_subscription_tracked_resource_indexes",
+    ]);
     assert.equal(state.hasNewIndex, true);
+    assert.equal(state.hasTrackedResourceIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.includes(".pre-v1."));
     assert.equal(backups.length, 1);
     assert.match(backups[0]!, /^agentinbox\.sqlite\.pre-v1\..+\.bak(?:\.\d+)?$/);
@@ -428,9 +452,14 @@ test("store upgrades source-scoped lifecycle retirements to host-scoped retireme
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, ["0000_v1_initial", "0002_host_scoped_lifecycle_retirements"]);
+    assert.deepEqual(state.appliedTags, [
+      "0000_v1_initial",
+      "0002_host_scoped_lifecycle_retirements",
+      "0003_subscription_tracked_resource_indexes",
+    ]);
     assert.deepEqual(state.retirementColumns.includes("host_id"), true);
     assert.deepEqual(state.retirementColumns.includes("source_id"), false);
+    assert.equal(state.hasTrackedResourceIndex, true);
     const retirement = store.getSubscriptionLifecycleRetirement("sub_legacy_retirement");
     assert.equal(retirement?.hostId, "hst_legacy_github");
     assert.equal(retirement?.trackedResourceRef, "repo:holon-run/agentinbox:pr:72");

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -4692,6 +4692,106 @@ test("github repo terminal lifecycle fanout retires sibling repo and ci subscrip
   }
 });
 
+test("store can list subscriptions by host-scoped tracked resource ref", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const createdAt = "2026-04-19T00:00:00.000Z";
+    store.insertSource({
+      sourceId: "src_host_ref_repo",
+      hostId: "hst_github_a",
+      streamKind: "repo_events",
+      streamKey: "holon-run/agentinbox",
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      configRef: null,
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+      status: "active",
+      checkpoint: null,
+      createdAt,
+      updatedAt: createdAt,
+    });
+    store.insertSource({
+      sourceId: "src_host_ref_ci",
+      hostId: "hst_github_a",
+      streamKind: "ci_runs",
+      streamKey: "holon-run/agentinbox",
+      sourceType: "github_repo_ci",
+      sourceKey: "holon-run/agentinbox",
+      configRef: null,
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+      status: "active",
+      checkpoint: null,
+      createdAt,
+      updatedAt: createdAt,
+    });
+    store.insertSource({
+      sourceId: "src_host_ref_other",
+      hostId: "hst_github_b",
+      streamKind: "repo_events",
+      streamKey: "holon-run/other",
+      sourceType: "github_repo",
+      sourceKey: "holon-run/other",
+      configRef: null,
+      config: { owner: "holon-run", repo: "other", uxcAuth: "github-other" },
+      status: "active",
+      checkpoint: null,
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    store.insertSubscription({
+      subscriptionId: "sub_host_ref_repo",
+      agentId: "agt_host_ref",
+      sourceId: "src_host_ref_repo",
+      filter: {},
+      trackedResourceRef: "repo:holon-run/agentinbox:pr:93",
+      cleanupPolicy: { mode: "on_terminal" },
+      startPolicy: "earliest",
+      startOffset: null,
+      startTime: null,
+      createdAt,
+    });
+    store.insertSubscription({
+      subscriptionId: "sub_host_ref_ci",
+      agentId: "agt_host_ref",
+      sourceId: "src_host_ref_ci",
+      filter: {},
+      trackedResourceRef: "repo:holon-run/agentinbox:pr:93",
+      cleanupPolicy: { mode: "on_terminal" },
+      startPolicy: "earliest",
+      startOffset: null,
+      startTime: null,
+      createdAt: "2026-04-19T00:00:01.000Z",
+    });
+    store.insertSubscription({
+      subscriptionId: "sub_host_ref_other",
+      agentId: "agt_host_ref",
+      sourceId: "src_host_ref_other",
+      filter: {},
+      trackedResourceRef: "repo:holon-run/agentinbox:pr:93",
+      cleanupPolicy: { mode: "on_terminal" },
+      startPolicy: "earliest",
+      startOffset: null,
+      startTime: null,
+      createdAt: "2026-04-19T00:00:02.000Z",
+    });
+
+    const matches = store.listSubscriptionsForHostTrackedResourceRef(
+      "hst_github_a",
+      "repo:holon-run/agentinbox:pr:93",
+    );
+
+    assert.deepEqual(
+      matches.map((subscription) => subscription.subscriptionId),
+      ["sub_host_ref_repo", "sub_host_ref_ci"],
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("gc does not retire subscriptions before they consume a terminal event", async () => {
   const { store, service, dir } = await makeService();
   try {


### PR DESCRIPTION
## Summary
- make the `POST /subscriptions` contract explicit as a stable `{ subscriptions: [...] }` envelope in the HTTP schema and docs
- move host-scoped lifecycle retirement fanout lookup into the store instead of scanning all subscriptions in service code
- add coverage for host-scoped tracked resource lookup and refresh the public docs around subscription create responses

## Verification
- `npm run build`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern "store can list subscriptions by host-scoped tracked resource ref|github repo terminal lifecycle fanout retires sibling repo and ci subscriptions by host-scoped trackedResourceRef|gc retires sibling subscriptions sharing a host-scoped trackedResourceRef from one terminal signal" test/agentinbox.test.ts`
- `timeout 45 node --require ts-node/register --test --test-force-exit --test-name-pattern='control plane subscriptions accept generic shortcut invocation' test/control_plane.test.ts`
- `timeout 45 node --require ts-node/register --test --test-force-exit --test-name-pattern='cli github pr shortcut with withCi returns created sibling subscriptions' test/control_plane.test.ts`
