### PR TITLE
test: seed terminal context in CLI JSON compat test

### DIFF
--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -134,6 +134,11 @@ test("cli accepts --json as a no-op compatibility flag on default JSON commands"
   const env = {
     ...process.env,
     AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%962",
+    CODEX_THREAD_ID: "thread-json-compat",
   };
 
   try {


### PR DESCRIPTION
## Summary
- add the same synthetic terminal env used by other CLI tests to the --json compat test
- keep the test focused on --json compatibility instead of depending on ambient terminal detection
- fix the main CI failure from run 24622857748

## Verification
- npm run build
- timeout 90 node --require ts-node/register --test --test-force-exit --test-name-pattern='cli accepts --json as a no-op compatibility flag on default JSON commands' test/control_plane.test.ts
- manual CLI reproduction of status --json, agent register, and inbox read --json with seeded tmux env