### PR TITLE
docs: clarify agentinbox async lifecycle defaults

### DIFF
--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -100,6 +100,65 @@ In practice:
 This matches the AgentInbox model: sources are shared hosting units, while
 subscriptions carry agent-specific filtering and delivery intent.
 
+## Default Async Lifecycle
+
+Default to AgentInbox when the work is not purely synchronous in the current
+session.
+
+Typical cases:
+
+- delayed follow-up that should happen after you stop actively looking at the terminal
+- waiting for PR review, CI completion, issue replies, or other external events
+- anything that must survive session boundaries instead of living only in chat memory
+- reminders that should fire at a specific time or on a recurring schedule
+
+For this kind of work, treat AgentInbox as the durable tracking layer and use a
+consistent lifecycle:
+
+1. register the current terminal session and keep the returned `agentId`
+2. reuse broad shared sources when they already exist
+3. add narrow task-scoped subscriptions or timers for the specific PR, issue, branch, or workflow you care about
+4. read inbox items in bounded batches, process them, and ack only the batch you actually reviewed
+5. clean up task-scoped subscriptions or timers after merge, closure, abandonment, or any other terminal state
+
+For PR and review workflows, prefer one shared repo source and one shared repo-
+CI source, then add PR-scoped subscriptions on top:
+
+```bash
+agentinbox agent register
+agentinbox source schema <repo_source_id>
+agentinbox subscription add <repo_source_id> --agent-id <agentId> --shortcut pr --shortcut-args-json '{"number":87,"withCi":true}'
+agentinbox inbox read --agent-id <agentId>
+agentinbox inbox ack --agent-id <agentId> --through <lastEntryId>
+agentinbox subscription list --agent-id <agentId>
+agentinbox subscription remove <subscriptionId>
+```
+
+That flow should be read as:
+
+- register once per live terminal/runtime session
+- prefer shortcut-driven PR subscriptions when the source exposes them
+- let review comments, review decisions, PR state changes, and CI updates arrive through the inbox
+- after the PR is merged, closed, or abandoned, verify that task-scoped subscriptions are gone and remove any leftovers
+
+Cleanup expectations:
+
+- subscriptions are task assets by default, not permanent infrastructure
+- if a task-specific subscription is no longer serving an active task, remove it
+- if polling-backed GitHub setup starts to accumulate, inspect old subscriptions before creating more
+- auto-retiring cleanup policies reduce cleanup debt, but they do not remove the need to verify the task is fully cleaned up
+
+Ack discipline:
+
+- prefer `agentinbox inbox ack --agent-id <agentId> --through <lastEntryId>` after reading a reviewed batch
+- avoid `ack --all` unless you explicitly verified that every current item should be cleared
+- do not ack speculative future work just because the current terminal message was seen
+
+Timer intent:
+
+- use `agentinbox timer add` when the trigger is time-based rather than source-based
+- prefer timers over inventing fake local events for reminders like "check CI in 30 minutes" or "revisit this PR tomorrow morning"
+
 ## Core Commands
 
 Create or inspect sources:

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -127,13 +127,13 @@ consistent lifecycle:
 5. clean up task-scoped subscriptions or timers after merge, closure,
    abandonment, or any other terminal state
 
-For PR and review workflows, prefer one shared repo source and one shared repo-
-CI source, then add PR-scoped subscriptions on top:
+For PR and review workflows, prefer one shared repo source and one shared
+repo-CI source, then add PR-scoped subscriptions on top:
 
 ```bash
 agentinbox agent register
-agentinbox source schema <repo_source_id>
-agentinbox subscription add <repo_source_id> --agent-id <agentId> --shortcut pr --shortcut-args-json '{"number":87,"withCi":true}'
+agentinbox source schema <sourceId>
+agentinbox subscription add <sourceId> --agent-id <agentId> --shortcut pr --shortcut-args-json '{"number":87,"withCi":true}'
 agentinbox inbox read --agent-id <agentId>
 agentinbox inbox ack --agent-id <agentId> --through <lastEntryId>
 agentinbox subscription list --agent-id <agentId>

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -107,9 +107,12 @@ session.
 
 Typical cases:
 
-- delayed follow-up that should happen after you stop actively looking at the terminal
-- waiting for PR review, CI completion, issue replies, or other external events
-- anything that must survive session boundaries instead of living only in chat memory
+- delayed follow-up that should happen after you stop actively looking at the
+  terminal
+- waiting for PR review, CI completion, issue replies, or other external
+  events
+- anything that must survive session boundaries instead of living only in chat
+  memory
 - reminders that should fire at a specific time or on a recurring schedule
 
 For this kind of work, treat AgentInbox as the durable tracking layer and use a
@@ -117,9 +120,12 @@ consistent lifecycle:
 
 1. register the current terminal session and keep the returned `agentId`
 2. reuse broad shared sources when they already exist
-3. add narrow task-scoped subscriptions or timers for the specific PR, issue, branch, or workflow you care about
-4. read inbox items in bounded batches, process them, and ack only the batch you actually reviewed
-5. clean up task-scoped subscriptions or timers after merge, closure, abandonment, or any other terminal state
+3. add narrow task-scoped subscriptions or timers for the specific PR, issue,
+   branch, or workflow you care about
+4. read inbox items in bounded batches, process them, and ack only the batch
+   you actually reviewed
+5. clean up task-scoped subscriptions or timers after merge, closure,
+   abandonment, or any other terminal state
 
 For PR and review workflows, prefer one shared repo source and one shared repo-
 CI source, then add PR-scoped subscriptions on top:
@@ -138,26 +144,35 @@ That flow should be read as:
 
 - register once per live terminal/runtime session
 - prefer shortcut-driven PR subscriptions when the source exposes them
-- let review comments, review decisions, PR state changes, and CI updates arrive through the inbox
-- after the PR is merged, closed, or abandoned, verify that task-scoped subscriptions are gone and remove any leftovers
+- let review comments, review decisions, PR state changes, and CI updates
+  arrive through the inbox
+- after the PR is merged, closed, or abandoned, verify that task-scoped
+  subscriptions are gone and remove any leftovers
 
 Cleanup expectations:
 
 - subscriptions are task assets by default, not permanent infrastructure
-- if a task-specific subscription is no longer serving an active task, remove it
-- if polling-backed GitHub setup starts to accumulate, inspect old subscriptions before creating more
-- auto-retiring cleanup policies reduce cleanup debt, but they do not remove the need to verify the task is fully cleaned up
+- if a task-specific subscription is no longer serving an active task, remove
+  it
+- if polling-backed GitHub setup starts to accumulate, inspect old
+  subscriptions before creating more
+- auto-retiring cleanup policies reduce cleanup debt, but they do not remove
+  the need to verify the task is fully cleaned up
 
 Ack discipline:
 
-- prefer `agentinbox inbox ack --agent-id <agentId> --through <lastEntryId>` after reading a reviewed batch
-- avoid `ack --all` unless you explicitly verified that every current item should be cleared
-- do not ack speculative future work just because the current terminal message was seen
+- prefer `agentinbox inbox ack --agent-id <agentId> --through <lastEntryId>`
+  after reading a reviewed batch
+- avoid `ack --all` unless you explicitly verified that every current item
+  should be cleared
+- do not ack speculative future work just because the current terminal message
+  was seen
 
 Timer intent:
 
 - use `agentinbox timer add` when the trigger is time-based rather than source-based
-- prefer timers over inventing fake local events for reminders like "check CI in 30 minutes" or "revisit this PR tomorrow morning"
+- prefer timers over inventing fake local events for reminders like "check CI
+  in 30 minutes" or "revisit this PR tomorrow morning"
 
 ## Core Commands
 

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -118,6 +118,24 @@ Typical cases:
 For this kind of work, treat AgentInbox as the durable tracking layer and use a
 consistent lifecycle:
 
+Important boundary:
+
+- inbox items, subscriptions, and timers can outlive the current terminal
+  session
+- terminal delivery does not automatically survive session boundaries just
+  because the inbox state does
+- if the original runtime/terminal disappears, items may keep accumulating in
+  the inbox while notifications stop reaching you
+- if a later session should resume the same logical agent, re-register or
+  explicitly rebind that agent to the current terminal before assuming prompt
+  delivery is live again
+
+For example, resuming the same logical agent in a later session may look like:
+
+```bash
+agentinbox agent register --agent-id <agentId> --force-rebind
+```
+
 1. register the current terminal session and keep the returned `agentId`
 2. reuse broad shared sources when they already exist
 3. add narrow task-scoped subscriptions or timers for the specific PR, issue,


### PR DESCRIPTION
## Summary
- add a focused default async lifecycle section to the bundled AgentInbox skill
- clarify when AgentInbox should be the default for delayed follow-up, PR review/CI waiting, and cross-session work
- document the default PR/review lifecycle, cleanup expectations, bounded ack guidance, and timer intent in one place

## Testing
- documentation-only change

Closes #152.