### PR TITLE
fix: preserve PR metadata for truncated github review events

### DIFF
--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -11,8 +11,10 @@ import {
 } from "../model";
 
 export const GITHUB_ENDPOINT = "https://api.github.com";
-const GITHUB_EVENT_HYDRATION_PER_PAGE = 1;
-const GITHUB_EVENT_HYDRATION_MAX_PAGES = 25;
+const DEFAULT_GITHUB_CALL_CLIENT = new UxcDaemonClient({ env: process.env });
+const GITHUB_EVENT_HYDRATION_MIN_PER_PAGE = 10;
+const GITHUB_EVENT_HYDRATION_MAX_PER_PAGE = 30;
+const GITHUB_EVENT_HYDRATION_MAX_PAGES = 3;
 const HYDRATABLE_GITHUB_REPO_EVENT_TYPES = new Set([
   "PullRequestReviewEvent",
   "PullRequestReviewCommentEvent",
@@ -44,7 +46,7 @@ export interface GithubCallClient {
 }
 
 export class GithubUxcClient {
-  constructor(private readonly client: GithubCallClient = new UxcDaemonClient({ env: process.env })) {}
+  constructor(private readonly client: GithubCallClient = DEFAULT_GITHUB_CALL_CLIENT) {}
 
   async createIssueComment(input: { owner: string; repo: string; issueNumber: number; body: string; auth?: string }): Promise<void> {
     await this.client.call({
@@ -341,7 +343,7 @@ export function normalizeGithubRepoEvent(
 export async function hydrateGithubRepoEventIfNeeded(
   config: GithubSourceConfig,
   raw: Record<string, unknown>,
-  client: GithubCallClient = new UxcDaemonClient({ env: process.env }),
+  client: GithubCallClient = DEFAULT_GITHUB_CALL_CLIENT,
 ): Promise<Record<string, unknown>> {
   if (!shouldHydrateGithubRepoEvent(raw)) {
     return raw;
@@ -352,18 +354,24 @@ export async function hydrateGithubRepoEventIfNeeded(
     return raw;
   }
 
+  const perPage = computeGithubHydrationPerPage(config.perPage);
   for (let page = 1; page <= GITHUB_EVENT_HYDRATION_MAX_PAGES; page += 1) {
-    const response = await client.call({
-      endpoint: GITHUB_ENDPOINT,
-      operation: "get:/repos/{owner}/{repo}/events",
-      payload: {
-        owner: config.owner,
-        repo: config.repo,
-        per_page: GITHUB_EVENT_HYDRATION_PER_PAGE,
-        page,
-      },
-      options: { auth: config.uxcAuth },
-    });
+    let response: Awaited<ReturnType<GithubCallClient["call"]>>;
+    try {
+      response = await client.call({
+        endpoint: GITHUB_ENDPOINT,
+        operation: "get:/repos/{owner}/{repo}/events",
+        payload: {
+          owner: config.owner,
+          repo: config.repo,
+          per_page: perPage,
+          page,
+        },
+        options: { auth: config.uxcAuth },
+      });
+    } catch {
+      return raw;
+    }
     const candidates = Array.isArray(response.data) ? response.data : [];
     if (candidates.length === 0) {
       break;
@@ -562,6 +570,13 @@ function extractMentions(...values: Array<string | null>): string[] {
     }
   }
   return Array.from(seen.values()).sort();
+}
+
+function computeGithubHydrationPerPage(perPage: number | undefined): number {
+  const configured = Number.isInteger(perPage) && perPage && perPage > 0
+    ? perPage
+    : GITHUB_EVENT_HYDRATION_MIN_PER_PAGE;
+  return Math.min(GITHUB_EVENT_HYDRATION_MAX_PER_PAGE, Math.max(GITHUB_EVENT_HYDRATION_MIN_PER_PAGE, configured));
 }
 
 function extractGithubRepoEventUrl(

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -11,6 +11,12 @@ import {
 } from "../model";
 
 export const GITHUB_ENDPOINT = "https://api.github.com";
+const GITHUB_EVENT_HYDRATION_PER_PAGE = 1;
+const GITHUB_EVENT_HYDRATION_MAX_PAGES = 25;
+const HYDRATABLE_GITHUB_REPO_EVENT_TYPES = new Set([
+  "PullRequestReviewEvent",
+  "PullRequestReviewCommentEvent",
+]);
 export const DEFAULT_GITHUB_EVENT_TYPES = [
   "IssuesEvent",
   "IssueCommentEvent",
@@ -268,7 +274,7 @@ export function normalizeGithubRepoEvent(
   if (!eventType || !(config.eventTypes ?? DEFAULT_GITHUB_EVENT_TYPES).includes(eventType)) {
     return null;
   }
-  const eventId = asString(event.id);
+  const eventId = asIdString(event.id);
   if (!eventId) {
     return null;
   }
@@ -281,20 +287,18 @@ export function normalizeGithubRepoEvent(
   const review = asRecord(payload.review);
   const comment = asRecord(payload.comment);
   const action = asString(payload.action) ?? "observed";
-
-  const number = asNumber(issue.number) ?? asNumber(pullRequest.number);
+  const url = extractGithubRepoEventUrl(event, issue, pullRequest, review, comment);
+  const number =
+    asNumber(issue.number)
+    ?? asNumber(pullRequest.number)
+    ?? asNumber(payload.number)
+    ?? extractGithubNumberFromUrl(url);
   const isPullRequest = eventType.startsWith("PullRequest");
   const title = asString(issue.title) ?? asString(pullRequest.title) ?? null;
   const reviewState = asString(review.state) ?? null;
   const body = asString(comment.body) ?? asString(review.body) ?? asString(issue.body) ?? asString(pullRequest.body) ?? null;
   const labels = extractLabels(issue.labels);
   const mentions = extractMentions(title, body);
-  const url =
-    asString(comment.html_url) ??
-    asString(review.html_url) ??
-    asString(issue.html_url) ??
-    asString(pullRequest.html_url) ??
-    asString(event.url);
   const deliveryHandle = buildGithubDeliveryHandle(config, eventType, number, comment);
 
   return {
@@ -332,6 +336,48 @@ export function normalizeGithubRepoEvent(
     },
     deliveryHandle,
   };
+}
+
+export async function hydrateGithubRepoEventIfNeeded(
+  config: GithubSourceConfig,
+  raw: Record<string, unknown>,
+  client: GithubCallClient = new UxcDaemonClient({ env: process.env }),
+): Promise<Record<string, unknown>> {
+  if (!shouldHydrateGithubRepoEvent(raw)) {
+    return raw;
+  }
+
+  const eventId = asIdString(raw.id);
+  if (!eventId) {
+    return raw;
+  }
+
+  for (let page = 1; page <= GITHUB_EVENT_HYDRATION_MAX_PAGES; page += 1) {
+    const response = await client.call({
+      endpoint: GITHUB_ENDPOINT,
+      operation: "get:/repos/{owner}/{repo}/events",
+      payload: {
+        owner: config.owner,
+        repo: config.repo,
+        per_page: GITHUB_EVENT_HYDRATION_PER_PAGE,
+        page,
+      },
+      options: { auth: config.uxcAuth },
+    });
+    const candidates = Array.isArray(response.data) ? response.data : [];
+    if (candidates.length === 0) {
+      break;
+    }
+    for (const candidateValue of candidates) {
+      const candidate = asRecord(candidateValue);
+      if (asIdString(candidate.id) !== eventId) {
+        continue;
+      }
+      return hasGithubRepoEventMetadata(candidate) ? candidate : raw;
+    }
+  }
+
+  return raw;
 }
 
 export function canonicalGithubPullRequestRef(source: SourceStream, number: number): string {
@@ -518,6 +564,74 @@ function extractMentions(...values: Array<string | null>): string[] {
   return Array.from(seen.values()).sort();
 }
 
+function extractGithubRepoEventUrl(
+  event: Record<string, unknown>,
+  issue: Record<string, unknown>,
+  pullRequest: Record<string, unknown>,
+  review: Record<string, unknown>,
+  comment: Record<string, unknown>,
+): string | null {
+  return (
+    asString(comment.html_url)
+    ?? asString(review.html_url)
+    ?? asString(issue.html_url)
+    ?? asString(pullRequest.html_url)
+    ?? asString(comment.pull_request_url)
+    ?? asString(review.pull_request_url)
+    ?? asString(event.url)
+  );
+}
+
+function extractGithubNumberFromUrl(url: string | null): number | null {
+  if (!url) {
+    return null;
+  }
+  const match = url.match(/\/(?:pull|pulls|issues)\/(\d+)(?:$|[/?#])/);
+  return match ? Number(match[1]) : null;
+}
+
+function shouldHydrateGithubRepoEvent(raw: Record<string, unknown>): boolean {
+  const eventType = asString(raw.type);
+  if (!eventType || !HYDRATABLE_GITHUB_REPO_EVENT_TYPES.has(eventType)) {
+    return false;
+  }
+  const payload = asRecord(raw.payload);
+  const issue = asRecord(payload.issue);
+  const pullRequest = asRecord(payload.pull_request);
+  const review = asRecord(payload.review);
+  const comment = asRecord(payload.comment);
+  const url = extractGithubRepoEventUrl(raw, issue, pullRequest, review, comment);
+  const number =
+    asNumber(issue.number)
+    ?? asNumber(pullRequest.number)
+    ?? asNumber(payload.number)
+    ?? extractGithubNumberFromUrl(url);
+  if (number) {
+    return false;
+  }
+  return [pullRequest, review, comment].some(isUxcPreviewTruncatedObject);
+}
+
+function hasGithubRepoEventMetadata(raw: Record<string, unknown>): boolean {
+  const payload = asRecord(raw.payload);
+  const issue = asRecord(payload.issue);
+  const pullRequest = asRecord(payload.pull_request);
+  const review = asRecord(payload.review);
+  const comment = asRecord(payload.comment);
+  return Boolean(
+    asNumber(issue.number)
+    ?? asNumber(pullRequest.number)
+    ?? asNumber(payload.number)
+    ?? extractGithubNumberFromUrl(extractGithubRepoEventUrl(raw, issue, pullRequest, review, comment))
+    ?? asString(review.state)
+    ?? extractGithubRepoEventUrl(raw, issue, pullRequest, review, comment),
+  );
+}
+
+function isUxcPreviewTruncatedObject(value: Record<string, unknown>): boolean {
+  return value._uxc_preview_truncated === true;
+}
+
 function parseTargetRef(targetRef: string): { owner: string; repo: string; number: number } {
   const match = targetRef.match(/^([^/]+)\/([^#]+)#(\d+)$/);
   if (!match) {
@@ -587,6 +701,16 @@ function asRecord(value: unknown): Record<string, unknown> {
 
 function asString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
+}
+
+function asIdString(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
 }
 
 function asNumber(value: unknown): number | null {

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -366,7 +366,7 @@ export class RemoteSourceRuntime {
         if (Object.keys(rawPayload).length === 0) {
           continue;
         }
-        const mapped = module.mapRawEvent(rawPayload, moduleSource);
+        const mapped = await module.mapRawEvent(rawPayload, moduleSource);
         if (!mapped) {
           continue;
         }

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -18,8 +18,10 @@ import {
   deriveGithubTrackedResource,
   expandGithubSubscriptionShortcut,
   GITHUB_ENDPOINT,
+  GithubCallClient,
   githubDeliveryOperationsForHandle,
   githubSubscriptionShortcutSpec,
+  hydrateGithubRepoEventIfNeeded,
   invokeGithubDeliveryOperation,
   normalizeGithubRepoEvent,
   parseGithubSourceConfig,
@@ -123,7 +125,10 @@ export interface RemoteSourceModule {
   id: string;
   validateConfig(source: SourceStream): void;
   buildManagedSourceSpec(source: SourceStream): ManagedSourceSpec;
-  mapRawEvent(rawPayload: Record<string, unknown>, source: SourceStream): MappedRemoteEvent | null;
+  mapRawEvent(
+    rawPayload: Record<string, unknown>,
+    source: SourceStream,
+  ): MappedRemoteEvent | null | Promise<MappedRemoteEvent | null>;
   // Optional capability hooks used by resolved schema and future subscription ergonomics.
   describeCapabilities?(source: SourceStream): RemoteSourceCapabilityDescription;
   listSubscriptionShortcuts?(source: SourceStream): SubscriptionShortcutSpec[];
@@ -271,169 +276,174 @@ function asNonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-const GITHUB_REPO_MODULE: RemoteSourceModule = {
-  id: "builtin.github_repo",
-  listDeliveryOperations(input: ListDeliveryOperationsInput): DeliveryOperationDescriptor[] {
-    return githubDeliveryOperationsForHandle(input.handle);
-  },
-  async invokeDeliveryOperation(input: InvokeDeliveryOperationInput): Promise<{ status: DeliveryAttempt["status"]; note: string }> {
-    return invokeGithubDeliveryOperation(input.handle, input.operation, input.input);
-  },
-  describeCapabilities(source: SourceStream): RemoteSourceCapabilityDescription {
-    const config = parseGithubSourceConfig(source);
-    return {
-      sourceKind: "github_repo",
-      aliases: ["github_repo"],
-      configSchema: [
-        { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
-        { name: "repo", type: "string", required: true, description: "GitHub repository name." },
-        { name: "uxcAuth", type: "string", required: false, description: "Optional uxc auth profile." },
-        { name: "eventTypes", type: "string[]", required: false, description: "Optional GitHub event type allowlist." },
-        { name: "perPage", type: "number", required: false, description: `Repository events requested per poll. Default ${config.perPage ?? 10}.` },
-        { name: "pollIntervalSecs", type: "number", required: false, description: `Polling interval in seconds. Default ${config.pollIntervalSecs ?? 30}.` },
-      ],
-      metadataFields: [
-        { name: "eventType", type: "string", description: "GitHub event type such as IssueCommentEvent." },
-        { name: "action", type: "string", description: "GitHub event action suffix such as created." },
-        { name: "author", type: "string|null", description: "Actor login for the event." },
-        { name: "isPullRequest", type: "boolean", description: "Whether the event targets a pull request surface." },
-        { name: "reviewState", type: "string|null", description: "Review decision state for PullRequestReviewEvent such as approved or changes_requested." },
-        { name: "labels", type: "string[]", description: "Labels extracted from the issue or pull request." },
-        { name: "mentions", type: "string[]", description: "Mention handles extracted from title/body/comment text." },
-        { name: "number", type: "number|null", description: "Issue or pull request number when present." },
-        { name: "repoFullName", type: "string", description: "Repository full name in owner/repo form." },
-        { name: "title", type: "string|null", description: "Issue, pull request, or comment title." },
-        { name: "body", type: "string|null", description: "Issue, pull request, or comment body text." },
-        { name: "url", type: "string|null", description: "Primary GitHub HTML URL for the event target." },
-      ],
-      payloadExamples: [
-        {
-          id: "1234567891",
-          type: "PullRequestReviewEvent",
-          action: "created",
-          actor: "Copilot",
-          pull_request: { number: 67, title: "feat: add remote module capability hooks" },
-          review: { state: "commented", body: "review summary" },
-        },
-        {
-          id: "1234567892",
-          type: "PullRequestEvent",
-          action: "closed",
-          actor: "jolestar",
-          pull_request: { number: 72, title: "feat: add cleanup policy lifecycle engine", merged: true },
-        },
-      ],
-      eventVariantExamples: [
-        "IssueCommentEvent.created",
-        "PullRequestEvent.opened",
-        "PullRequestEvent.closed",
-        "PullRequestReviewEvent.created",
-        "PullRequestReviewCommentEvent.created",
-      ],
-    };
-  },
-  listSubscriptionShortcuts(): SubscriptionShortcutSpec[] {
-    return githubSubscriptionShortcutSpec();
-  },
-  expandSubscriptionShortcut(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | ExpandedSubscriptionPlan | null {
-    return expandGithubSubscriptionShortcut(input);
-  },
-  deriveTrackedResource(filter: SubscriptionFilter, source: SourceStream): { ref: string } | null {
-    return deriveGithubTrackedResource(filter, source);
-  },
-  deriveNotificationGrouping(item: ActivationItem): NotificationGrouping | null {
-    const number = typeof item.metadata.number === "number" ? item.metadata.number : null;
-    if (!number) {
+export function createGithubRepoRemoteModule(options?: { callClient?: GithubCallClient }): RemoteSourceModule {
+  return {
+    id: "builtin.github_repo",
+    listDeliveryOperations(input: ListDeliveryOperationsInput): DeliveryOperationDescriptor[] {
+      return githubDeliveryOperationsForHandle(input.handle);
+    },
+    async invokeDeliveryOperation(input: InvokeDeliveryOperationInput): Promise<{ status: DeliveryAttempt["status"]; note: string }> {
+      return invokeGithubDeliveryOperation(input.handle, input.operation, input.input);
+    },
+    describeCapabilities(source: SourceStream): RemoteSourceCapabilityDescription {
+      const config = parseGithubSourceConfig(source);
+      return {
+        sourceKind: "github_repo",
+        aliases: ["github_repo"],
+        configSchema: [
+          { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+          { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+          { name: "uxcAuth", type: "string", required: false, description: "Optional uxc auth profile." },
+          { name: "eventTypes", type: "string[]", required: false, description: "Optional GitHub event type allowlist." },
+          { name: "perPage", type: "number", required: false, description: `Repository events requested per poll. Default ${config.perPage ?? 10}.` },
+          { name: "pollIntervalSecs", type: "number", required: false, description: `Polling interval in seconds. Default ${config.pollIntervalSecs ?? 30}.` },
+        ],
+        metadataFields: [
+          { name: "eventType", type: "string", description: "GitHub event type such as IssueCommentEvent." },
+          { name: "action", type: "string", description: "GitHub event action suffix such as created." },
+          { name: "author", type: "string|null", description: "Actor login for the event." },
+          { name: "isPullRequest", type: "boolean", description: "Whether the event targets a pull request surface." },
+          { name: "reviewState", type: "string|null", description: "Review decision state for PullRequestReviewEvent such as approved or changes_requested." },
+          { name: "labels", type: "string[]", description: "Labels extracted from the issue or pull request." },
+          { name: "mentions", type: "string[]", description: "Mention handles extracted from title/body/comment text." },
+          { name: "number", type: "number|null", description: "Issue or pull request number when present." },
+          { name: "repoFullName", type: "string", description: "Repository full name in owner/repo form." },
+          { name: "title", type: "string|null", description: "Issue, pull request, or comment title." },
+          { name: "body", type: "string|null", description: "Issue, pull request, or comment body text." },
+          { name: "url", type: "string|null", description: "Primary GitHub HTML URL for the event target." },
+        ],
+        payloadExamples: [
+          {
+            id: "1234567891",
+            type: "PullRequestReviewEvent",
+            action: "created",
+            actor: "Copilot",
+            pull_request: { number: 67, title: "feat: add remote module capability hooks" },
+            review: { state: "commented", body: "review summary" },
+          },
+          {
+            id: "1234567892",
+            type: "PullRequestEvent",
+            action: "closed",
+            actor: "jolestar",
+            pull_request: { number: 72, title: "feat: add cleanup policy lifecycle engine", merged: true },
+          },
+        ],
+        eventVariantExamples: [
+          "IssueCommentEvent.created",
+          "PullRequestEvent.opened",
+          "PullRequestEvent.closed",
+          "PullRequestReviewEvent.created",
+          "PullRequestReviewCommentEvent.created",
+        ],
+      };
+    },
+    listSubscriptionShortcuts(): SubscriptionShortcutSpec[] {
+      return githubSubscriptionShortcutSpec();
+    },
+    expandSubscriptionShortcut(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | ExpandedSubscriptionPlan | null {
+      return expandGithubSubscriptionShortcut(input);
+    },
+    deriveTrackedResource(filter: SubscriptionFilter, source: SourceStream): { ref: string } | null {
+      return deriveGithubTrackedResource(filter, source);
+    },
+    deriveNotificationGrouping(item: ActivationItem): NotificationGrouping | null {
+      const number = typeof item.metadata.number === "number" ? item.metadata.number : null;
+      if (!number) {
+        return null;
+      }
+      const variant = item.eventVariant;
+      if (variant.startsWith("PullRequestReviewCommentEvent.")) {
+        return {
+          groupable: true,
+          resourceRef: `pr:${number}`,
+          eventFamily: "review_comments",
+          summaryHint: `review comments on PR #${number}`,
+        };
+      }
+      if (variant.startsWith("PullRequestReviewEvent.")) {
+        return {
+          groupable: true,
+          resourceRef: `pr:${number}`,
+          eventFamily: "reviews",
+          summaryHint: `reviews on PR #${number}`,
+        };
+      }
+      if (variant.startsWith("IssueCommentEvent.")) {
+        return {
+          groupable: true,
+          resourceRef: item.metadata.isPullRequest === true ? `pr:${number}` : `issue:${number}`,
+          eventFamily: "comments",
+          summaryHint: item.metadata.isPullRequest === true ? `comments on PR #${number}` : `comments on issue #${number}`,
+        };
+      }
+      if (variant.startsWith("PullRequestEvent.closed")) {
+        return {
+          groupable: true,
+          resourceRef: `pr:${number}`,
+          eventFamily: "lifecycle",
+          summaryHint: `PR #${number} lifecycle updates`,
+          flushClass: "immediate",
+        };
+      }
       return null;
-    }
-    const variant = item.eventVariant;
-    if (variant.startsWith("PullRequestReviewCommentEvent.")) {
+    },
+    summarizeDigestThread(items: ActivationItem[], _source: SourceStream, grouping: NotificationGrouping): string | null {
+      if (!grouping.summaryHint || items.length === 0) {
+        return null;
+      }
+      const count = items.length;
+      return `${count} ${grouping.summaryHint}`;
+    },
+    projectLifecycleSignal(rawPayload: Record<string, unknown>, source: SourceStream) {
+      return projectGithubLifecycleSignal(rawPayload, source);
+    },
+    validateConfig(source: SourceStream): void {
+      parseGithubSourceConfig(source);
+    },
+    buildManagedSourceSpec(source: SourceStream): ManagedSourceSpec {
+      const config = parseGithubSourceConfig(source);
       return {
-        groupable: true,
-        resourceRef: `pr:${number}`,
-        eventFamily: "review_comments",
-        summaryHint: `review comments on PR #${number}`,
-      };
-    }
-    if (variant.startsWith("PullRequestReviewEvent.")) {
-      return {
-        groupable: true,
-        resourceRef: `pr:${number}`,
-        eventFamily: "reviews",
-        summaryHint: `reviews on PR #${number}`,
-      };
-    }
-    if (variant.startsWith("IssueCommentEvent.")) {
-      return {
-        groupable: true,
-        resourceRef: item.metadata.isPullRequest === true ? `pr:${number}` : `issue:${number}`,
-        eventFamily: "comments",
-        summaryHint: item.metadata.isPullRequest === true ? `comments on PR #${number}` : `comments on issue #${number}`,
-      };
-    }
-    if (variant.startsWith("PullRequestEvent.closed")) {
-      return {
-        groupable: true,
-        resourceRef: `pr:${number}`,
-        eventFamily: "lifecycle",
-        summaryHint: `PR #${number} lifecycle updates`,
-        flushClass: "immediate",
-      };
-    }
-    return null;
-  },
-  summarizeDigestThread(items: ActivationItem[], _source: SourceStream, grouping: NotificationGrouping): string | null {
-    if (!grouping.summaryHint || items.length === 0) {
-      return null;
-    }
-    const count = items.length;
-    return `${count} ${grouping.summaryHint}`;
-  },
-  projectLifecycleSignal(rawPayload: Record<string, unknown>, source: SourceStream) {
-    return projectGithubLifecycleSignal(rawPayload, source);
-  },
-  validateConfig(source: SourceStream): void {
-    parseGithubSourceConfig(source);
-  },
-  buildManagedSourceSpec(source: SourceStream): ManagedSourceSpec {
-    const config = parseGithubSourceConfig(source);
-    return {
-      endpoint: GITHUB_ENDPOINT,
-      operation_id: "get:/repos/{owner}/{repo}/events",
-      args: {
-        owner: config.owner,
-        repo: config.repo,
-        per_page: config.perPage ?? 10,
-      },
-      mode: "poll",
-      poll_config: {
-        interval_secs: config.pollIntervalSecs ?? 30,
-        extract_items_pointer: "",
-        checkpoint_strategy: {
-          type: "item_key",
-          item_key_pointer: "/id",
-          seen_window: 1024,
+        endpoint: GITHUB_ENDPOINT,
+        operation_id: "get:/repos/{owner}/{repo}/events",
+        args: {
+          owner: config.owner,
+          repo: config.repo,
+          per_page: config.perPage ?? 10,
         },
-      },
-      options: { auth: config.uxcAuth },
-    };
-  },
-  mapRawEvent(rawPayload: Record<string, unknown>, source: SourceStream): MappedRemoteEvent | null {
-    const config = parseGithubSourceConfig(source);
-    const normalized = normalizeGithubRepoEvent(source, config, rawPayload);
-    if (!normalized) {
-      return null;
-    }
-    return {
-      sourceNativeId: normalized.sourceNativeId,
-      eventVariant: normalized.eventVariant,
-      metadata: normalized.metadata ?? {},
-      rawPayload: normalized.rawPayload ?? rawPayload,
-      occurredAt: normalized.occurredAt,
-      deliveryHandle: normalized.deliveryHandle,
-    };
-  },
-};
+        mode: "poll",
+        poll_config: {
+          interval_secs: config.pollIntervalSecs ?? 30,
+          extract_items_pointer: "",
+          checkpoint_strategy: {
+            type: "item_key",
+            item_key_pointer: "/id",
+            seen_window: 1024,
+          },
+        },
+        options: { auth: config.uxcAuth },
+      };
+    },
+    async mapRawEvent(rawPayload: Record<string, unknown>, source: SourceStream): Promise<MappedRemoteEvent | null> {
+      const config = parseGithubSourceConfig(source);
+      const hydratedPayload = await hydrateGithubRepoEventIfNeeded(config, rawPayload, options?.callClient);
+      const normalized = normalizeGithubRepoEvent(source, config, hydratedPayload);
+      if (!normalized) {
+        return null;
+      }
+      return {
+        sourceNativeId: normalized.sourceNativeId,
+        eventVariant: normalized.eventVariant,
+        metadata: normalized.metadata ?? {},
+        rawPayload: normalized.rawPayload ?? hydratedPayload,
+        occurredAt: normalized.occurredAt,
+        deliveryHandle: normalized.deliveryHandle,
+      };
+    },
+  };
+}
+
+const GITHUB_REPO_MODULE: RemoteSourceModule = createGithubRepoRemoteModule();
 
 const GITHUB_REPO_CI_MODULE: RemoteSourceModule = {
   id: "builtin.github_repo_ci",

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -18,9 +18,14 @@ import { DeliveryAttempt, SourceStream, SubscriptionFilter } from "../src/model"
 class FakeUxcClient implements GithubCallClient {
   public calls: Array<Record<string, unknown>> = [];
   public responses: Array<{ data: unknown }> = [];
+  public errors: Error[] = [];
 
   async call(args: Record<string, unknown>) {
     this.calls.push(args);
+    const error = this.errors.shift();
+    if (error) {
+      throw error;
+    }
     return this.responses.shift() ?? { data: { ok: true } };
   }
 }
@@ -223,11 +228,56 @@ test("github_repo remote module hydrates truncated review events before mapping"
     payload: {
       owner: "holon-run",
       repo: "agentinbox",
-      per_page: 1,
+      per_page: 10,
       page: 1,
     },
     options: { auth: "github-default" },
   });
+});
+
+test("github_repo remote module falls back to raw truncated review events when hydration fails", async () => {
+  const source: SourceStream = {
+    sourceId: "src_review_hydrate_error",
+    sourceType: "github_repo",
+    sourceKey: "holon-run/agentinbox",
+    config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    configRef: null,
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const fake = new FakeUxcClient();
+  fake.errors.push(new Error("transient github failure"));
+  const module = createGithubRepoRemoteModule({ callClient: fake });
+
+  const mapped = await module.mapRawEvent({
+    id: "8568075838",
+    type: "PullRequestReviewEvent",
+    created_at: "2026-04-19T09:37:10Z",
+    actor: { login: "jolestar" },
+    repo: { name: "holon-run/agentinbox" },
+    payload: {
+      action: "created",
+      issue: {},
+      pull_request: {
+        _uxc_preview_truncated: true,
+        _uxc_type: "object",
+      },
+      review: {
+        _uxc_preview_truncated: true,
+        _uxc_type: "object",
+      },
+      comment: {},
+    },
+  }, source);
+
+  assert.ok(mapped);
+  assert.equal(mapped.metadata.number, null);
+  assert.equal(mapped.metadata.reviewState, null);
+  assert.equal(mapped.metadata.url, null);
+  assert.equal(mapped.deliveryHandle, null);
+  assert.equal(fake.calls.length, 1);
 });
 
 test("normalizeGithubRepoEvent preserves pull request merged state for lifecycle hooks", async () => {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -12,14 +12,16 @@ import {
   projectGithubLifecycleSignal,
   type GithubCallClient,
 } from "../src/sources/github";
+import { createGithubRepoRemoteModule } from "../src/sources/remote_modules";
 import { DeliveryAttempt, SourceStream, SubscriptionFilter } from "../src/model";
 
 class FakeUxcClient implements GithubCallClient {
   public calls: Array<Record<string, unknown>> = [];
+  public responses: Array<{ data: unknown }> = [];
 
   async call(args: Record<string, unknown>) {
     this.calls.push(args);
-    return { data: { ok: true } };
+    return this.responses.shift() ?? { data: { ok: true } };
   }
 }
 
@@ -115,6 +117,117 @@ test("normalizeGithubRepoEvent includes PullRequestReviewEvent by default", asyn
   });
   assert.equal(normalized.deliveryHandle?.surface, "issue_comment");
   assert.equal(normalized.deliveryHandle?.targetRef, "holon-run/agentinbox#67");
+});
+
+test("normalizeGithubRepoEvent derives pull request numbers from review URLs", async () => {
+  const source: SourceStream = {
+    sourceId: "src_review_url",
+    sourceType: "github_repo",
+    sourceKey: "holon-run/agentinbox",
+    config: { owner: "holon-run", repo: "agentinbox" },
+    configRef: null,
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const normalized = normalizeGithubRepoEvent(source, { owner: "holon-run", repo: "agentinbox" }, {
+    id: "201",
+    type: "PullRequestReviewEvent",
+    created_at: "2026-04-19T10:41:34Z",
+    actor: { login: "Copilot" },
+    repo: { name: "holon-run/agentinbox" },
+    payload: {
+      action: "created",
+      review: {
+        state: "commented",
+        html_url: "https://github.com/holon-run/agentinbox/pull/67#pullrequestreview-1",
+      },
+      pull_request: {},
+    },
+  });
+
+  assert.ok(normalized);
+  assert.equal(normalized.metadata?.number, 67);
+  assert.equal(normalized.metadata?.url, "https://github.com/holon-run/agentinbox/pull/67#pullrequestreview-1");
+  assert.equal(normalized.deliveryHandle?.targetRef, "holon-run/agentinbox#67");
+});
+
+test("github_repo remote module hydrates truncated review events before mapping", async () => {
+  const source: SourceStream = {
+    sourceId: "src_review_hydrate",
+    sourceType: "github_repo",
+    sourceKey: "holon-run/agentinbox",
+    config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    configRef: null,
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const fake = new FakeUxcClient();
+  fake.responses.push({
+    data: [{
+      id: "8568075837",
+      type: "PullRequestReviewEvent",
+      created_at: "2026-04-19T09:37:09Z",
+      actor: { login: "jolestar" },
+      repo: { name: "holon-run/agentinbox" },
+      payload: {
+        action: "created",
+        review: {
+          state: "approved",
+          body: "ship it",
+          html_url: "https://github.com/holon-run/agentinbox/pull/252#pullrequestreview-9",
+        },
+        pull_request: {
+          number: 252,
+          title: "feat: hydrate truncated review events",
+          html_url: "https://github.com/holon-run/agentinbox/pull/252",
+        },
+      },
+    }],
+  });
+  const module = createGithubRepoRemoteModule({ callClient: fake });
+
+  const mapped = await module.mapRawEvent({
+    id: "8568075837",
+    type: "PullRequestReviewEvent",
+    created_at: "2026-04-19T09:37:09Z",
+    actor: { login: "jolestar" },
+    repo: { name: "holon-run/agentinbox" },
+    payload: {
+      action: "created",
+      issue: {},
+      pull_request: {
+        _uxc_preview_truncated: true,
+        _uxc_type: "object",
+      },
+      review: {
+        _uxc_preview_truncated: true,
+        _uxc_type: "object",
+      },
+      comment: {},
+    },
+  }, source);
+
+  assert.ok(mapped);
+  assert.equal(mapped.metadata.number, 252);
+  assert.equal(mapped.metadata.reviewState, "approved");
+  assert.equal(mapped.metadata.url, "https://github.com/holon-run/agentinbox/pull/252#pullrequestreview-9");
+  assert.equal(mapped.deliveryHandle?.targetRef, "holon-run/agentinbox#252");
+  assert.equal(fake.calls.length, 1);
+  assert.deepEqual(fake.calls[0], {
+    endpoint: "https://api.github.com",
+    operation: "get:/repos/{owner}/{repo}/events",
+    payload: {
+      owner: "holon-run",
+      repo: "agentinbox",
+      per_page: 1,
+      page: 1,
+    },
+    options: { auth: "github-default" },
+  });
 });
 
 test("normalizeGithubRepoEvent preserves pull request merged state for lifecycle hooks", async () => {


### PR DESCRIPTION
## Summary
- hydrate preview-truncated GitHub review events by refetching the matching repo event with a small page size
- fall back to parsing PR numbers from review URLs when number fields are absent
- make remote source event mapping awaitable and lock the regression with review-event tests

## Testing
- node --require ts-node/register --test test/github.test.ts test/remote_source.test.ts
- npm run build

Fixes #163