### PR TITLE
Fix silent notification black holes for offline session-bound agents

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -981,7 +981,7 @@ async function printCurrentAgent(client: AgentInboxClient): Promise<void> {
   const records = await listAgentsWithTargets(client);
   const current = resolveCurrentAgent(records, context);
   if (!current) {
-    throw new Error("no current agent is registered for this terminal/runtime context; run `agentinbox agent register`");
+    throw new Error(noCurrentAgentMessage());
   }
   console.log(jsonResponse(current));
 }
@@ -1027,7 +1027,7 @@ async function selectAgentForCommand(
   }
 
   if (!options.autoRegister) {
-    throw new Error("no current agent is registered for this terminal/runtime context; run `agentinbox agent register`");
+    throw new Error(noCurrentAgentMessage());
   }
 
   await requestRemote(client, "/agents", {
@@ -1079,6 +1079,10 @@ async function requestRemote<T = unknown>(
     throw new Error(jsonResponse(response.data));
   }
   return { data: response.data };
+}
+
+function noCurrentAgentMessage(): string {
+  return "no current agent is registered for this terminal/runtime context; run `agentinbox agent list` to inspect offline agents, then `agentinbox agent register` or `agentinbox agent register --force-rebind --agent-id <agentId>` to rebind one";
 }
 
 function takeFlagValue(args: string[], flag: string): string | undefined {

--- a/src/current_agent.ts
+++ b/src/current_agent.ts
@@ -36,6 +36,9 @@ export interface CurrentAgentMatch {
   matchesCurrentTerminal: boolean;
   matchesCurrentRuntime: boolean;
   terminalIdentity: string | null;
+  notifyCapable: boolean;
+  activeTargetCount: number;
+  offlineTargetCount: number;
 }
 
 export interface AnnotatedAgent extends Agent {
@@ -44,6 +47,9 @@ export interface AnnotatedAgent extends Agent {
   matchesCurrentRuntime: boolean;
   terminalIdentity: string | null;
   isCurrent: boolean;
+  notifyCapable: boolean;
+  activeTargetCount: number;
+  offlineTargetCount: number;
 }
 
 export function summarizeActivationTarget(target: ActivationTarget): ActivationTargetSummary {
@@ -88,6 +94,9 @@ export function resolveCurrentAgent(
     matchesCurrentTerminal: matchesCurrentTerminal(agent, context),
     matchesCurrentRuntime: matchesCurrentRuntime(agent, context),
     terminalIdentity: terminalIdentityForAgent(agent),
+    notifyCapable: notifyCapableForAgent(agent),
+    activeTargetCount: activeActivationTargetCount(agent),
+    offlineTargetCount: offlineActivationTargetCount(agent),
   };
 }
 
@@ -105,6 +114,9 @@ export function annotateAgents(
       matchesCurrentRuntime: context ? matchesCurrentRuntime(entry, context) : false,
       terminalIdentity: terminalIdentityForAgent(entry),
       isCurrent: current?.agentId === entry.agent.agentId,
+      notifyCapable: notifyCapableForAgent(entry),
+      activeTargetCount: activeActivationTargetCount(entry),
+      offlineTargetCount: offlineActivationTargetCount(entry),
     })),
   };
 }
@@ -115,7 +127,7 @@ function resolveAgentRecord(
 ): AgentWithTargets | null {
   if (context.tmuxPaneId) {
     const match = agents.find((agent) =>
-      activeTerminalTargets(agent).some((target) => target.backend === "tmux" && target.tmuxPaneId === context.tmuxPaneId),
+      terminalTargetsForCurrentMatch(agent).some((target) => target.backend === "tmux" && target.tmuxPaneId === context.tmuxPaneId),
     );
     if (match) {
       return match;
@@ -124,7 +136,7 @@ function resolveAgentRecord(
 
   if (context.itermSessionId) {
     const match = agents.find((agent) =>
-      activeTerminalTargets(agent).some((target) => target.backend === "iterm2" && target.itermSessionId === context.itermSessionId),
+      terminalTargetsForCurrentMatch(agent).some((target) => target.backend === "iterm2" && target.itermSessionId === context.itermSessionId),
     );
     if (match) {
       return match;
@@ -133,7 +145,7 @@ function resolveAgentRecord(
 
   if (context.tty) {
     const match = agents.find((agent) =>
-      activeTerminalTargets(agent).some((target) => target.tty === context.tty),
+      terminalTargetsForCurrentMatch(agent).some((target) => target.tty === context.tty),
     );
     if (match) {
       return match;
@@ -159,10 +171,26 @@ function terminalTargets(agent: AgentWithTargets): TerminalTargetSummary[] {
 }
 
 function activeTerminalTargets(agent: AgentWithTargets): TerminalTargetSummary[] {
+  return terminalTargets(agent).filter((target) => target.status === "active");
+}
+
+function terminalTargetsForCurrentMatch(agent: AgentWithTargets): TerminalTargetSummary[] {
   if (agent.agent.status !== "active") {
     return [];
   }
-  return terminalTargets(agent).filter((target) => target.status === "active");
+  return activeTerminalTargets(agent);
+}
+
+function activeActivationTargetCount(agent: AgentWithTargets): number {
+  return agent.activationTargets.filter((target) => target.status === "active").length;
+}
+
+function offlineActivationTargetCount(agent: AgentWithTargets): number {
+  return agent.activationTargets.filter((target) => target.status === "offline").length;
+}
+
+function notifyCapableForAgent(agent: AgentWithTargets): boolean {
+  return agent.agent.status === "active" && activeActivationTargetCount(agent) > 0;
 }
 
 function terminalIdentityForAgent(agent: AgentWithTargets): string | null {
@@ -183,7 +211,7 @@ function terminalIdentityForAgent(agent: AgentWithTargets): string | null {
 }
 
 function matchesCurrentTerminal(agent: AgentWithTargets, context: DetectedTerminalContext): boolean {
-  return activeTerminalTargets(agent).some((target) =>
+  return terminalTargetsForCurrentMatch(agent).some((target) =>
     (context.tmuxPaneId != null && target.tmuxPaneId === context.tmuxPaneId)
     || (context.itermSessionId != null && target.itermSessionId === context.itermSessionId)
     || (context.tty != null && target.tty === context.tty),

--- a/src/current_agent.ts
+++ b/src/current_agent.ts
@@ -171,13 +171,13 @@ function terminalTargets(agent: AgentWithTargets): TerminalTargetSummary[] {
 }
 
 function activeTerminalTargets(agent: AgentWithTargets): TerminalTargetSummary[] {
+  if (agent.agent.status !== "active") {
+    return [];
+  }
   return terminalTargets(agent).filter((target) => target.status === "active");
 }
 
 function terminalTargetsForCurrentMatch(agent: AgentWithTargets): TerminalTargetSummary[] {
-  if (agent.agent.status !== "active") {
-    return [];
-  }
   return activeTerminalTargets(agent);
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -675,7 +675,7 @@ export class AgentInboxService {
   }
 
   registerTimer(input: RegisterTimerInput): AgentTimer {
-    this.getAgent(input.agentId);
+    this.assertAgentNotifyCapable(input.agentId, "timer add");
     const normalized = normalizeTimerInput(input);
     const timezone = normalized.timezone ?? detectHostTimezone();
     assertValidTimeZone(timezone);
@@ -992,7 +992,7 @@ export class AgentInboxService {
   }
 
   private async registerSingleSubscription(input: RegisterSubscriptionInput): Promise<Subscription> {
-    this.getAgent(input.agentId);
+    this.assertAgentNotifyCapable(input.agentId, "subscription add");
     const source = this.store.getSource(input.sourceId);
     if (!source) {
       throw new Error(`unknown source: ${input.sourceId}`);
@@ -1912,6 +1912,22 @@ export class AgentInboxService {
     for (const watcher of watchers) {
       watcher.onItems(items);
     }
+  }
+
+  private assertAgentNotifyCapable(agentId: string, operation: "subscription add" | "timer add"): void {
+    this.getAgent(agentId);
+    const targets = this.store.listActivationTargetsForAgent(agentId);
+    const activeTargetCount = targets.filter((target) => target.status === "active").length;
+    if (activeTargetCount > 0) {
+      return;
+    }
+    const offlineTargetCount = targets.filter((target) => target.status === "offline").length;
+    const targetSummary = targets.length === 0
+      ? "it has no activation targets"
+      : `all ${offlineTargetCount} activation target(s) are offline`;
+    throw new Error(
+      `agent ${agentId} is not notify-capable: ${targetSummary}; refusing ${operation} to avoid a silent notification black hole. Rebind with \`agentinbox agent register --force-rebind --agent-id ${agentId}\` or resume/add a target first.`,
+    );
   }
 
   private resolveAutoAgentId(input: {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -2791,6 +2791,130 @@ test("direct inbox text messages fail cleanly if the inbox item cannot be persis
   }
 });
 
+test("registerSubscription rejects offline agents with no active activation targets", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "notify-sub-offline");
+    const agent = service.getAgent(alpha.agentId);
+    const offlineAt = "2026-04-01T00:00:00.000Z";
+    store.updateActivationTargetRuntime(alpha.targetId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      consecutiveFailures: 1,
+      lastError: "runtime gate: runtime_gone",
+      updatedAt: offlineAt,
+    });
+    store.updateAgent(alpha.agentId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      runtimeKind: agent.runtimeKind,
+      runtimeSessionId: agent.runtimeSessionId,
+      updatedAt: offlineAt,
+      lastSeenAt: offlineAt,
+    });
+
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "notify-sub-offline",
+      config: {},
+    });
+
+    await assert.rejects(
+      service.registerSubscription({
+        agentId: alpha.agentId,
+        sourceId: source.sourceId,
+        startPolicy: "earliest",
+      }),
+      /not notify-capable: all 1 activation target\(s\) are offline; refusing subscription add to avoid a silent notification black hole/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("registerTimer rejects offline agents with no active activation targets", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "notify-timer-offline");
+    const agent = service.getAgent(alpha.agentId);
+    const offlineAt = "2026-04-01T00:00:00.000Z";
+    store.updateActivationTargetRuntime(alpha.targetId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      consecutiveFailures: 1,
+      lastError: "runtime gate: runtime_gone",
+      updatedAt: offlineAt,
+    });
+    store.updateAgent(alpha.agentId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      runtimeKind: agent.runtimeKind,
+      runtimeSessionId: agent.runtimeSessionId,
+      updatedAt: offlineAt,
+      lastSeenAt: offlineAt,
+    });
+
+    assert.throws(
+      () => service.registerTimer({
+        agentId: alpha.agentId,
+        every: 60_000,
+        message: "Check the queue",
+      }),
+      /not notify-capable: all 1 activation target\(s\) are offline; refusing timer add to avoid a silent notification black hole/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("registerSubscription and registerTimer allow agents with another active target", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const alpha = await registerTmuxAgent(service, "notify-fallback");
+    service.addWebhookActivationTarget(alpha.agentId, {
+      url: "http://127.0.0.1:9999/notify-fallback",
+      activationMode: "activation_with_items",
+    });
+    const offlineAt = "2026-04-01T00:00:00.000Z";
+    store.updateActivationTargetRuntime(alpha.targetId, {
+      status: "offline",
+      offlineSince: offlineAt,
+      consecutiveFailures: 1,
+      lastError: "runtime gate: runtime_gone",
+      updatedAt: offlineAt,
+    });
+
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "notify-fallback",
+      config: {},
+    });
+    const subscription = await service.registerSubscription({
+      agentId: alpha.agentId,
+      sourceId: source.sourceId,
+      startPolicy: "earliest",
+    });
+    const timer = service.registerTimer({
+      agentId: alpha.agentId,
+      every: 60_000,
+      message: "Check the queue",
+    });
+
+    assert.ok(subscription.subscriptionId);
+    assert.equal(subscription.agentId, alpha.agentId);
+    assert.ok(timer.scheduleId);
+    assert.equal(timer.agentId, alpha.agentId);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("at timers fire once into the inbox and then pause", async () => {
   const dispatcher = new RecordingActivationDispatcher();
   const { store, service, dir } = await makeService({

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -894,6 +894,29 @@ test("cli resolves current agent, auto-registers session workflows, and warns on
   }
 });
 
+test("cli agent current explains how to inspect and rebind when no current agent exists", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-current-missing-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%9010",
+    CODEX_THREAD_ID: "thread-current-missing",
+  };
+
+  try {
+    const current = runCli(["agent", "current"], env);
+    assert.notEqual(current.status, 0);
+    assert.match(current.stderr, /run `agentinbox agent list` to inspect offline agents/);
+    assert.match(current.stderr, /agentinbox agent register --force-rebind --agent-id <agentId>/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli agent register accepts min-unacked-items", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-cli-pol-"));
   const env = {

--- a/test/current_agent.test.ts
+++ b/test/current_agent.test.ts
@@ -157,6 +157,31 @@ test("annotateAgents surfaces notify capability and offline target counts", () =
   assert.equal(annotated.agents[1]?.offlineTargetCount, 0);
 });
 
+test("annotateAgents keeps offline agents detached during in-flight target status transitions", () => {
+  const agents: AgentWithTargets[] = [
+    makeAgentRecord({
+      agentId: "agent-transitioning",
+      status: "offline",
+      activationTargets: [{
+        targetId: "tgt-active",
+        kind: "terminal",
+        status: "active",
+        backend: "tmux",
+        tmuxPaneId: "%401",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-transitioning",
+      }],
+    }),
+  ];
+
+  const annotated = annotateAgents(agents, null);
+
+  assert.equal(annotated.agents[0]?.bindingKind, "detached");
+  assert.equal(annotated.agents[0]?.terminalIdentity, null);
+  assert.equal(annotated.agents[0]?.notifyCapable, false);
+  assert.equal(annotated.agents[0]?.activeTargetCount, 1);
+});
+
 test("resolveCurrentAgent ignores offline agents and offline terminal targets", () => {
   const agents: AgentWithTargets[] = [
     makeAgentRecord({

--- a/test/current_agent.test.ts
+++ b/test/current_agent.test.ts
@@ -70,6 +70,9 @@ test("resolveCurrentAgent prefers terminal identity over runtime identity", () =
     matchesCurrentTerminal: true,
     matchesCurrentRuntime: false,
     terminalIdentity: "tmux:%202",
+    notifyCapable: true,
+    activeTargetCount: 1,
+    offlineTargetCount: 0,
   });
 });
 
@@ -108,9 +111,50 @@ test("annotateAgents marks current and detached agents correctly", () => {
   assert.equal(annotated.agents[0]?.isCurrent, true);
   assert.equal(annotated.agents[0]?.terminalIdentity, "iterm2:SESSION-1");
   assert.equal(annotated.agents[0]?.bindingKind, "session_bound");
+  assert.equal(annotated.agents[0]?.notifyCapable, true);
+  assert.equal(annotated.agents[0]?.activeTargetCount, 1);
+  assert.equal(annotated.agents[0]?.offlineTargetCount, 0);
   assert.equal(annotated.agents[1]?.isCurrent, false);
   assert.equal(annotated.agents[1]?.bindingKind, "detached");
   assert.equal(annotated.agents[1]?.terminalIdentity, null);
+  assert.equal(annotated.agents[1]?.notifyCapable, false);
+  assert.equal(annotated.agents[1]?.activeTargetCount, 0);
+  assert.equal(annotated.agents[1]?.offlineTargetCount, 0);
+});
+
+test("annotateAgents surfaces notify capability and offline target counts", () => {
+  const agents: AgentWithTargets[] = [
+    makeAgentRecord({
+      agentId: "agent-offline",
+      status: "offline",
+      activationTargets: [{
+        targetId: "tgt-offline",
+        kind: "terminal",
+        status: "offline",
+        backend: "tmux",
+        tmuxPaneId: "%301",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-offline",
+      }],
+    }),
+    makeAgentRecord({
+      agentId: "agent-webhook",
+      activationTargets: [{
+        targetId: "wh-1",
+        kind: "webhook",
+        status: "active",
+      }],
+    }),
+  ];
+
+  const annotated = annotateAgents(agents, null);
+
+  assert.equal(annotated.agents[0]?.notifyCapable, false);
+  assert.equal(annotated.agents[0]?.activeTargetCount, 0);
+  assert.equal(annotated.agents[0]?.offlineTargetCount, 1);
+  assert.equal(annotated.agents[1]?.notifyCapable, true);
+  assert.equal(annotated.agents[1]?.activeTargetCount, 1);
+  assert.equal(annotated.agents[1]?.offlineTargetCount, 0);
 });
 
 test("resolveCurrentAgent ignores offline agents and offline terminal targets", () => {


### PR DESCRIPTION
Closes #161

## Summary
- reject `subscription add` and `timer add` when an agent has no active activation targets, so offline session-bound agents cannot silently accumulate work they will never be notified about
- surface `notifyCapable`, `activeTargetCount`, and `offlineTargetCount` in current-agent/list annotations while still excluding offline agents from current-session matching
- improve the no-current-agent CLI guidance so operators are sent to `agent list` and `agent register --force-rebind`

## Verification
- `node --require ts-node/register --test test/current_agent.test.ts`
- `node --require ts-node/register --test test/agentinbox.test.ts`
- `npm run build`
- manual CLI smoke for `agent current` missing/current flows