### PR TITLE
feat: add follow command orchestration

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -5,6 +5,7 @@ import {
   DeliveryRequest,
   DeliveryHandle,
   DeliveryOperationDescriptor,
+  FollowTemplateSpec,
   NotificationGrouping,
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
@@ -17,7 +18,7 @@ import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubDeliveryAdapter } from "./sources/github";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
-import { ExpandedSubscriptionPlan, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry } from "./sources/remote_modules";
+import { ExpandedFollowPlan, ExpandedSubscriptionPlan, ExpandFollowTemplateInput, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry } from "./sources/remote_modules";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
 
 export interface SourceAdapter {
@@ -195,6 +196,23 @@ export class AdapterRegistry {
       return null;
     }
     return this.remoteSource.expandSubscriptionShortcut(source, input);
+  }
+
+  async listFollowTemplates(source: SourceStream): Promise<FollowTemplateSpec[]> {
+    if (source.sourceType === "local_event") {
+      return [];
+    }
+    return this.remoteSource.listFollowTemplates(source);
+  }
+
+  async expandFollowTemplate(
+    source: SourceStream,
+    input: ExpandFollowTemplateInput,
+  ): Promise<ExpandedFollowPlan | null> {
+    if (source.sourceType === "local_event") {
+      return null;
+    }
+    return this.remoteSource.expandFollowTemplate(source, input);
   }
 
   async deriveInlinePreview(source: SourceStream, item: ActivationItem): Promise<string | null> {

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -18,7 +18,7 @@ import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubDeliveryAdapter } from "./sources/github";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
-import { ExpandedFollowPlan, ExpandedSubscriptionPlan, ExpandFollowTemplateInput, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry } from "./sources/remote_modules";
+import { ExpandedFollowPlan, ExpandedSubscriptionPlan, ExpandFollowTemplateInput, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry, builtinRemoteSourceTypes } from "./sources/remote_modules";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
 
 export interface SourceAdapter {
@@ -215,6 +215,23 @@ export class AdapterRegistry {
     return this.remoteSource.expandFollowTemplate(source, input);
   }
 
+  followPreviewRefsForProviderOrKind(
+    providerOrKind: string,
+    config?: Record<string, unknown>,
+  ): string[] {
+    const trimmed = providerOrKind.trim();
+    if (trimmed.length === 0) {
+      throw new Error("follow requires a providerOrKind");
+    }
+    if (isExplicitFollowPreviewRef(trimmed)) {
+      return [trimmed];
+    }
+    const candidates = hasRemoteSourceModulePath(config)
+      ? ["remote_source", ...builtinRemoteSourceTypes()]
+      : builtinRemoteSourceTypes();
+    return Array.from(new Set(candidates));
+  }
+
   async deriveInlinePreview(source: SourceStream, item: ActivationItem): Promise<string | null> {
     if (source.sourceType === "local_event") {
       return null;
@@ -286,6 +303,22 @@ export class AdapterRegistry {
     }
     return null;
   }
+}
+
+function isExplicitFollowPreviewRef(value: string): boolean {
+  return (
+    value === "local_event" ||
+    value === "remote_source" ||
+    value === "github_repo" ||
+    value === "github_repo_ci" ||
+    value === "feishu_bot" ||
+    value.startsWith("remote:")
+  );
+}
+
+function hasRemoteSourceModulePath(config: Record<string, unknown> | undefined): boolean {
+  const modulePath = config?.modulePath;
+  return typeof modulePath === "string" && modulePath.trim().length > 0;
 }
 
 function syntheticBuiltinSource(sourceType: "github_repo" | "feishu_bot"): SourceStream {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -209,6 +209,48 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "follow") {
+    const args = normalized.slice(1);
+    const positionals = positionalArgs(args, [
+      "--agent-id",
+      "--args-json",
+      "--arg",
+      "--config-json",
+      "--config-ref",
+      "--start-policy",
+      "--start-offset",
+      "--start-time",
+    ]);
+    const [providerOrKind, template] = positionals;
+    if (!providerOrKind || !template || positionals[2]) {
+      throw new Error("usage: agentinbox follow <providerOrKind> <template> [--agent-id ID] [--args-json JSON | --arg KEY=VALUE ...] [--config-json JSON] [--config-ref REF] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]");
+    }
+    const argsJson = takeFlagValue(normalized, "--args-json");
+    const hasArgFlags = hasFlag(normalized, "--arg");
+    if (argsJson != null && hasArgFlags) {
+      throw new Error("follow accepts either --args-json or repeated --arg flags, but not both");
+    }
+    const selection = await selectAgentForCommand(client, {
+      explicitAgentId: takeFlagValue(normalized, "--agent-id"),
+      autoRegister: true,
+    });
+    const response = await requestRemote<Record<string, unknown>>(client, "/follow", {
+      agentId: selection.agentId,
+      providerOrKind,
+      template,
+      templateArgs: argsJson != null
+        ? parseJsonArg(argsJson, "--args-json")
+        : readFollowTemplateArgs(normalized),
+      configRef: takeFlagValue(normalized, "--config-ref") ?? undefined,
+      config: parseJsonArg(takeFlagValue(normalized, "--config-json")),
+      startPolicy: takeFlagValue(normalized, "--start-policy") ?? undefined,
+      startOffset: parseOptionalNumber(takeFlagValue(normalized, "--start-offset")),
+      startTime: takeFlagValue(normalized, "--start-time") ?? undefined,
+    });
+    console.log(jsonResponse(withCommandMetadata(response.data, selection)));
+    return;
+  }
+
   if (command === "stream" && normalized[1] === "poll") {
     const streamId = normalized[2];
     if (!streamId) {
@@ -1211,6 +1253,51 @@ function readSubscriptionFilter(args: string[]): Record<string, unknown> {
   return {};
 }
 
+function readFollowTemplateArgs(args: string[]): Record<string, unknown> {
+  const parsed: Record<string, unknown> = {};
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] !== "--arg") {
+      continue;
+    }
+    const raw = args[index + 1];
+    if (!raw || raw.startsWith("--")) {
+      throw new Error("flag --arg requires KEY=VALUE");
+    }
+    const separator = raw.indexOf("=");
+    if (separator <= 0) {
+      throw new Error("flag --arg requires KEY=VALUE");
+    }
+    const key = raw.slice(0, separator).trim();
+    const rawValue = raw.slice(separator + 1);
+    if (key.length === 0) {
+      throw new Error("flag --arg requires a non-empty key");
+    }
+    parsed[key] = parseFollowTemplateArgValue(rawValue);
+    index += 1;
+  }
+  return parsed;
+}
+
+function parseFollowTemplateArgValue(raw: string): unknown {
+  if (raw === "true") {
+    return true;
+  }
+  if (raw === "false") {
+    return false;
+  }
+  if (/^-?\d+(?:\.\d+)?$/.test(raw)) {
+    return Number(raw);
+  }
+  if ((raw.startsWith("[") && raw.endsWith("]")) || (raw.startsWith("{") && raw.endsWith("}")) || raw === "null") {
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return raw;
+    }
+  }
+  return raw;
+}
+
 function withCommandMetadata<T extends Record<string, unknown>>(data: T, selection: AgentSelection): T & {
   agentId: string;
   autoRegistered?: true;
@@ -1299,6 +1386,7 @@ Usage:
 Commands:
   serve
   daemon
+  follow
   source
   agent
   timer
@@ -1344,6 +1432,11 @@ Usage:
   agentinbox stream schema preview <sourceKind|sourceType> [--config-json JSON] [--config-ref REF]
   agentinbox stream poll <streamId>
   agentinbox stream event <streamId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]
+`,
+    follow: `agentinbox follow
+
+Usage:
+  agentinbox follow <providerOrKind> <template> [--agent-id ID] [--args-json JSON | --arg KEY=VALUE ...] [--config-json JSON] [--config-ref REF] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
 `,
     source: `agentinbox source
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -3,7 +3,7 @@ import Fastify from "fastify";
 import swagger from "@fastify/swagger";
 import { summarizeActivationTarget } from "./current_agent";
 import { AgentInboxService } from "./service";
-import { ActivationMode, DeliveryHandle, PreviewSourceSchemaInput, WatchInboxOptions } from "./model";
+import { ActivationMode, DeliveryHandle, FollowInput, PreviewSourceSchemaInput, WatchInboxOptions } from "./model";
 import { jsonResponse } from "./util";
 
 function sendSse(res: http.ServerResponse, event: string, data: unknown): void {
@@ -490,6 +490,49 @@ function buildFastifyServer(service: AgentInboxService) {
       },
     },
   }, async (request) => service.previewSourceSchema(request.body as PreviewSourceSchemaInput));
+
+  app.post("/follow", {
+    schema: {
+      tags: ["subscriptions"],
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["agentId", "providerOrKind", "template"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+          providerOrKind: { type: "string", minLength: 1 },
+          template: { type: "string", minLength: 1 },
+          templateArgs: jsonObjectSchema,
+          configRef: { anyOf: [{ type: "string" }, { type: "null" }] },
+          config: jsonObjectSchema,
+          startPolicy: { type: "string" },
+          startOffset: { type: "integer" },
+          startTime: { type: "string" },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const body = request.body as Record<string, unknown>;
+    return service.follow({
+      agentId: String(body.agentId),
+      providerOrKind: String(body.providerOrKind),
+      template: String(body.template),
+      templateArgs: body.templateArgs && typeof body.templateArgs === "object"
+        ? body.templateArgs as Record<string, unknown>
+        : undefined,
+      configRef: optionalString(body.configRef) ?? null,
+      config: body.config && typeof body.config === "object"
+        ? body.config as Record<string, unknown>
+        : undefined,
+      startPolicy: optionalString(body.startPolicy) as never,
+      startOffset: typeof body.startOffset === "number" ? body.startOffset : undefined,
+      startTime: optionalString(body.startTime) ?? undefined,
+    } satisfies FollowInput);
+  });
 
   app.post("/streams/:streamId/poll", {
     schema: {
@@ -1800,6 +1843,10 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("cleanupPolicy ") ||
     message.startsWith("trackedResourceRef ") ||
     message.startsWith("preview failed: ") ||
+    message.startsWith("follow preview failed: ") ||
+    message.startsWith("follow template ") ||
+    message.startsWith("unknown follow template ") ||
+    message.startsWith("follow requires a providerOrKind") ||
     message.startsWith("unknown source kind or type for preview") ||
     message.startsWith("preview source kind ") ||
     message.startsWith("subscription add shortcut") ||

--- a/src/http.ts
+++ b/src/http.ts
@@ -29,6 +29,11 @@ const errorResponseSchema = {
   },
 } as const;
 
+const subscriptionStartPolicySchema = {
+  type: "string",
+  enum: ["latest", "earliest", "at_offset", "at_time"],
+} as const;
+
 const subscriptionCollectionSchema = {
   type: "object",
   required: ["subscriptions"],
@@ -505,7 +510,7 @@ function buildFastifyServer(service: AgentInboxService) {
           templateArgs: jsonObjectSchema,
           configRef: { anyOf: [{ type: "string" }, { type: "null" }] },
           config: jsonObjectSchema,
-          startPolicy: { type: "string" },
+          startPolicy: subscriptionStartPolicySchema,
           startOffset: { type: "integer" },
           startTime: { type: "string" },
         },
@@ -1193,7 +1198,7 @@ function buildFastifyServer(service: AgentInboxService) {
           filter: jsonObjectSchema,
           trackedResourceRef: { type: "string" },
           cleanupPolicy: jsonObjectSchema,
-          startPolicy: { type: "string" },
+          startPolicy: subscriptionStartPolicySchema,
           startOffset: { type: "integer" },
           startTime: { type: "string" },
         },
@@ -1319,7 +1324,7 @@ function buildFastifyServer(service: AgentInboxService) {
         additionalProperties: false,
         required: ["startPolicy"],
         properties: {
-          startPolicy: { type: "string", minLength: 1 },
+          startPolicy: subscriptionStartPolicySchema,
           startOffset: { type: "integer" },
           startTime: { type: "string" },
         },

--- a/src/model.ts
+++ b/src/model.ts
@@ -415,6 +415,18 @@ export interface RegisterSubscriptionInput {
   startTime?: string | null;
 }
 
+export interface FollowInput {
+  agentId: string;
+  providerOrKind: string;
+  template: string;
+  templateArgs?: Record<string, unknown>;
+  configRef?: string | null;
+  config?: Record<string, unknown>;
+  startPolicy?: SubscriptionStartPolicy;
+  startOffset?: number | null;
+  startTime?: string | null;
+}
+
 export interface PreviewSourceSchemaInput {
   sourceRef: string;
   configRef?: string | null;
@@ -426,6 +438,18 @@ export interface SourceSchemaField {
   type: string;
   description: string;
   required?: boolean;
+}
+
+export interface FollowTemplateSpec {
+  templateId: string;
+  providerOrKind: string;
+  label: string;
+  description: string;
+  argsSchema?: SourceSchemaField[];
+}
+
+export interface FollowSchema {
+  templates: FollowTemplateSpec[];
 }
 
 export interface SourceSchema {
@@ -454,9 +478,25 @@ export interface ResolvedSourceSchema extends SourceSchema, ResolvedSourceIdenti
       argsSchema?: SourceSchemaField[];
     }>;
   };
+  followSchema?: FollowSchema;
 }
 
 export interface SourceSchemaPreview extends Omit<ResolvedSourceSchema, "sourceId"> {}
+
+export interface FollowResult {
+  templateId: string;
+  agentId: string;
+  sources: Array<{
+    sourceId: string;
+    streamKind?: string;
+    created: boolean;
+  }>;
+  subscriptions: Array<{
+    subscriptionId: string;
+    sourceId: string;
+    created: boolean;
+  }>;
+}
 
 export interface AppendSourceEventInput {
   sourceId: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -1202,13 +1202,18 @@ export class AgentInboxService {
     startTime: string | null;
   }> {
     await validateSubscriptionFilter(input.filter ?? {});
+    const start = normalizeSubscriptionStartPosition({
+      startPolicy: input.startPolicy ?? "latest",
+      startOffset: input.startOffset ?? null,
+      startTime: input.startTime ?? null,
+    });
     return {
       filter: input.filter ?? {},
       trackedResourceRef: normalizeTrackedResourceRef(input.trackedResourceRef),
       cleanupPolicy: normalizeCleanupPolicy(input.cleanupPolicy ?? null),
-      startPolicy: input.startPolicy ?? "latest",
-      startOffset: input.startOffset ?? null,
-      startTime: input.startTime ?? null,
+      startPolicy: start.startPolicy,
+      startOffset: start.startOffset,
+      startTime: start.startTime,
     };
   }
 
@@ -1272,18 +1277,16 @@ export class AgentInboxService {
     startTime?: string | null;
   }): Promise<Record<string, unknown>> {
     this.getSubscription(input.subscriptionId);
-    if (!SUBSCRIPTION_START_POLICIES.has(input.startPolicy)) {
-      throw new Error(`unsupported start policy: ${input.startPolicy}`);
-    }
+    const normalizedStart = normalizeSubscriptionStartPosition(input);
     const consumer = await this.backend.getConsumer({ subscriptionId: input.subscriptionId });
     if (!consumer) {
       throw new Error(`unknown consumer for subscription: ${input.subscriptionId}`);
     }
     const reset = await this.backend.reset({
       consumerId: consumer.consumerId,
-      startPolicy: input.startPolicy,
-      startOffset: input.startOffset ?? null,
-      startTime: input.startTime ?? null,
+      startPolicy: normalizedStart.startPolicy,
+      startOffset: normalizedStart.startOffset,
+      startTime: normalizedStart.startTime,
     });
     return {
       subscription: this.getSubscription(input.subscriptionId),
@@ -3467,6 +3470,47 @@ function normalizeTrackedResourceRef(value: string | null | undefined): string |
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSubscriptionStartPosition(input: {
+  startPolicy: Subscription["startPolicy"];
+  startOffset?: number | null;
+  startTime?: string | null;
+}): {
+  startPolicy: Subscription["startPolicy"];
+  startOffset: number | null;
+  startTime: string | null;
+} {
+  if (!SUBSCRIPTION_START_POLICIES.has(input.startPolicy)) {
+    throw new Error(`unsupported start policy: ${input.startPolicy}`);
+  }
+  const startOffset = input.startOffset ?? null;
+  const startTime = input.startTime ?? null;
+  if (input.startPolicy === "at_offset") {
+    if (startOffset == null || !Number.isInteger(startOffset) || startOffset < 1) {
+      throw new Error("subscriptions requires positive integer startOffset when startPolicy=at_offset");
+    }
+    return {
+      startPolicy: input.startPolicy,
+      startOffset,
+      startTime: null,
+    };
+  }
+  if (input.startPolicy === "at_time") {
+    if (!startTime || !isValidIsoTimestamp(startTime)) {
+      throw new Error("subscriptions requires valid ISO8601 startTime when startPolicy=at_time");
+    }
+    return {
+      startPolicy: input.startPolicy,
+      startOffset: null,
+      startTime: canonicalIsoTimestamp(startTime),
+    };
+  }
+  return {
+    startPolicy: input.startPolicy,
+    startOffset: null,
+    startTime: null,
+  };
 }
 
 function normalizeCleanupPolicy(input: CleanupPolicy | null): CleanupPolicy {

--- a/src/service.ts
+++ b/src/service.ts
@@ -523,11 +523,11 @@ export class AgentInboxService {
     input: FollowInput,
     templateArgs: Record<string, unknown>,
   ): Promise<{ source: SourceStream; templateSpec: NonNullable<ResolvedSourceSchema["followSchema"]>["templates"][number] }> {
-    const candidates = followPreviewRefsForProviderOrKind(input.providerOrKind);
     const previewInput = {
       configRef: input.configRef ?? null,
       config: mergeFollowPreviewConfig(input.config, templateArgs),
     };
+    const candidates = this.adapters.followPreviewRefsForProviderOrKind(input.providerOrKind, previewInput.config);
     let previewFailure: Error | null = null;
     for (const sourceRef of candidates) {
       try {
@@ -3363,24 +3363,6 @@ function mergeFollowPreviewConfig(
     ...(config ?? {}),
     ...templateArgs,
   };
-}
-
-function followPreviewRefsForProviderOrKind(providerOrKind: string): string[] {
-  const trimmed = providerOrKind.trim();
-  if (trimmed.length === 0) {
-    throw new Error("follow requires a providerOrKind");
-  }
-  if (
-    trimmed === "local_event" ||
-    trimmed === "remote_source" ||
-    trimmed === "github_repo" ||
-    trimmed === "github_repo_ci" ||
-    trimmed === "feishu_bot" ||
-    trimmed.startsWith("remote:")
-  ) {
-    return [trimmed];
-  }
-  return ["github_repo", "github_repo_ci", "feishu_bot"];
 }
 
 function sourceTypeForPreviewRef(sourceRef: string): SourceStream["sourceType"] {

--- a/src/service.ts
+++ b/src/service.ts
@@ -16,6 +16,8 @@ import {
   DeliveryInvokeRequest,
   DeliveryOperationDescriptor,
   DeliveryRequest,
+  FollowInput,
+  FollowResult,
   Inbox,
   InboxAggregationPolicy,
   InboxEntry,
@@ -34,6 +36,7 @@ import {
   ResolvedSourceSchema,
   SourceHost,
   SourceSchema,
+  SourceSchemaField,
   SourceSchemaPreview,
   SourcePollResult,
   SourceStream,
@@ -69,7 +72,7 @@ import {
   renderAgentPrompt,
   TerminalDispatcher,
 } from "./terminal";
-import { ExpandedSubscriptionMember, ExpandedSubscriptionPlan, LifecycleSignal } from "./sources/remote_modules";
+import { ExpandedFollowPlan, ExpandedSubscriptionMember, ExpandedSubscriptionPlan, LifecycleSignal } from "./sources/remote_modules";
 import { ActivationGate, DefaultActivationGate, GatingPolicy } from "./runtime_gate";
 import { Logger, NoopLogger } from "./logging";
 import { resolveSourceRegistration } from "./source_hosts";
@@ -446,6 +449,123 @@ export class AgentInboxService {
       }
       throw new Error(`preview failed: ${message}`);
     }
+  }
+
+  async follow(input: FollowInput): Promise<FollowResult> {
+    const templateArgs = input.templateArgs ?? {};
+    const resolved = await this.resolveFollowTemplate(input, templateArgs);
+    validateFollowTemplateArgs(resolved.templateSpec.argsSchema ?? [], templateArgs, resolved.templateSpec.templateId);
+    const plan = await this.adapters.expandFollowTemplate(resolved.source, {
+      template: input.template,
+      args: templateArgs,
+      source: resolved.source,
+    });
+    if (!plan) {
+      throw new Error(`unknown follow template ${input.providerOrKind}.${input.template}`);
+    }
+    validateExpandedFollowPlan(plan, resolved.templateSpec.templateId);
+
+    const sourceRefs = new Map<string, SourceStream>();
+    const sourceResults: FollowResult["sources"] = [];
+    for (const ensuredSource of plan.sources) {
+      const result = await this.ensureFollowSource(ensuredSource);
+      sourceRefs.set(ensuredSource.logicalName, result.source);
+      sourceResults.push({
+        sourceId: result.source.sourceId,
+        streamKind: result.source.streamKind,
+        created: result.created,
+      });
+    }
+
+    const createdSubscriptions: Subscription[] = [];
+    const subscriptionResults: FollowResult["subscriptions"] = [];
+    try {
+      for (const ensuredSubscription of plan.subscriptions) {
+        const source = sourceRefs.get(ensuredSubscription.sourceLogicalName);
+        if (!source) {
+          throw new Error(
+            `follow template ${plan.templateId} references unknown ensured source ${ensuredSubscription.sourceLogicalName}`,
+          );
+        }
+        const result = await this.ensureSubscription({
+          agentId: input.agentId,
+          sourceId: source.sourceId,
+          filter: ensuredSubscription.filter,
+          trackedResourceRef: ensuredSubscription.trackedResourceRef ?? null,
+          cleanupPolicy: ensuredSubscription.cleanupPolicy ?? null,
+          startPolicy: ensuredSubscription.startPolicy ?? input.startPolicy,
+          startOffset: ensuredSubscription.startOffset ?? input.startOffset ?? null,
+          startTime: ensuredSubscription.startTime ?? input.startTime ?? null,
+        });
+        if (result.created) {
+          createdSubscriptions.push(result.subscription);
+        }
+        subscriptionResults.push({
+          subscriptionId: result.subscription.subscriptionId,
+          sourceId: result.subscription.sourceId,
+          created: result.created,
+        });
+      }
+    } catch (error) {
+      await this.rollbackRegisteredSubscriptions(createdSubscriptions);
+      throw error;
+    }
+
+    return {
+      templateId: plan.templateId,
+      agentId: input.agentId,
+      sources: sourceResults,
+      subscriptions: subscriptionResults,
+    };
+  }
+
+  private async resolveFollowTemplate(
+    input: FollowInput,
+    templateArgs: Record<string, unknown>,
+  ): Promise<{ source: SourceStream; templateSpec: NonNullable<ResolvedSourceSchema["followSchema"]>["templates"][number] }> {
+    const candidates = followPreviewRefsForProviderOrKind(input.providerOrKind);
+    const previewInput = {
+      configRef: input.configRef ?? null,
+      config: mergeFollowPreviewConfig(input.config, templateArgs),
+    };
+    let previewFailure: Error | null = null;
+    for (const sourceRef of candidates) {
+      try {
+        const source = buildPreviewSource({
+          sourceRef,
+          configRef: previewInput.configRef,
+          config: previewInput.config,
+        });
+        const templateSpec = (await this.adapters.listFollowTemplates(source)).find((candidate) =>
+          (candidate.providerOrKind === input.providerOrKind || sourceRef === input.providerOrKind) &&
+          followTemplateName(candidate.templateId) === input.template,
+        );
+        if (!templateSpec) {
+          continue;
+        }
+        await this.adapters.sourceAdapterFor(source.sourceType).validateSource?.(source);
+        return { source, templateSpec };
+      } catch (error) {
+        if (!previewFailure || sourceRef === input.providerOrKind || candidates.length === 1) {
+          previewFailure = error instanceof Error ? error : new Error(String(error));
+        }
+      }
+    }
+    if (previewFailure) {
+      throw new Error(`follow preview failed: ${previewFailure.message}`);
+    }
+    throw new Error(`unknown follow template ${input.providerOrKind}.${input.template}`);
+  }
+
+  private async ensureFollowSource(input: RegisterSourceInput & { logicalName: string }): Promise<{ source: SourceStream; created: boolean }> {
+    const existing = this.store.getSourceByKey(input.sourceType, input.sourceKey);
+    if (existing) {
+      return { source: existing, created: false };
+    }
+    return {
+      source: await this.registerSource(input),
+      created: true,
+    };
   }
 
   async removeSource(
@@ -910,6 +1030,41 @@ export class AgentInboxService {
     return [await this.registerSingleSubscription(input)];
   }
 
+  private async ensureSubscription(input: RegisterSubscriptionInput): Promise<{ subscription: Subscription; created: boolean }> {
+    if (input.shortcut) {
+      throw new Error("follow ensureSubscription does not support shortcuts");
+    }
+    const source = this.store.getSource(input.sourceId);
+    if (!source) {
+      throw new Error(`unknown source: ${input.sourceId}`);
+    }
+    const normalized = await this.normalizeSubscriptionRegistrationInput(input);
+    const existing = this.store.listSubscriptionsForAgent(input.agentId).find((subscription) =>
+      subscription.sourceId === source.sourceId &&
+      subscription.startPolicy === normalized.startPolicy &&
+      (subscription.startOffset ?? null) === normalized.startOffset &&
+      (subscription.startTime ?? null) === normalized.startTime &&
+      stableJson(subscription.filter) === stableJson(normalized.filter) &&
+      normalizeTrackedResourceRef(subscription.trackedResourceRef) === normalized.trackedResourceRef &&
+      stableJson(subscription.cleanupPolicy) === stableJson(normalized.cleanupPolicy)
+    );
+    if (existing) {
+      return { subscription: existing, created: false };
+    }
+    return {
+      subscription: await this.registerSingleSubscription({
+        ...input,
+        filter: normalized.filter,
+        trackedResourceRef: normalized.trackedResourceRef,
+        cleanupPolicy: normalized.cleanupPolicy,
+        startPolicy: normalized.startPolicy,
+        startOffset: normalized.startOffset,
+        startTime: normalized.startTime,
+      }),
+      created: true,
+    };
+  }
+
   private async expandShortcutRegistration(
     input: RegisterSubscriptionInput,
   ): Promise<{ source: SourceStream; plan: ExpandedSubscriptionPlan } | null> {
@@ -997,8 +1152,7 @@ export class AgentInboxService {
     if (!source) {
       throw new Error(`unknown source: ${input.sourceId}`);
     }
-    await validateSubscriptionFilter(input.filter ?? {});
-    const cleanupPolicy = normalizeCleanupPolicy(input.cleanupPolicy ?? null);
+    const normalized = await this.normalizeSubscriptionRegistrationInput(input);
     const idleState = this.store.getSourceIdleState(source.sourceId);
     if (idleState?.autoPausedAt) {
       await this.resumeSource(source.sourceId);
@@ -1009,12 +1163,12 @@ export class AgentInboxService {
       subscriptionId: generateCanonicalId("sub"),
       agentId: input.agentId,
       sourceId: input.sourceId,
-      filter: input.filter ?? {},
-      trackedResourceRef: normalizeTrackedResourceRef(input.trackedResourceRef),
-      cleanupPolicy,
-      startPolicy: input.startPolicy ?? "latest",
-      startOffset: input.startOffset ?? null,
-      startTime: input.startTime ?? null,
+      filter: normalized.filter,
+      trackedResourceRef: normalized.trackedResourceRef,
+      cleanupPolicy: normalized.cleanupPolicy,
+      startPolicy: normalized.startPolicy,
+      startOffset: normalized.startOffset,
+      startTime: normalized.startTime,
       createdAt: nowIso(),
     };
     this.ensureInboxForAgent(subscription.agentId);
@@ -1037,6 +1191,25 @@ export class AgentInboxService {
       this.refreshSourceIdleState(source.sourceId);
       throw error;
     }
+  }
+
+  private async normalizeSubscriptionRegistrationInput(input: RegisterSubscriptionInput): Promise<{
+    filter: Subscription["filter"];
+    trackedResourceRef: string | null;
+    cleanupPolicy: CleanupPolicy;
+    startPolicy: Subscription["startPolicy"];
+    startOffset: number | null;
+    startTime: string | null;
+  }> {
+    await validateSubscriptionFilter(input.filter ?? {});
+    return {
+      filter: input.filter ?? {},
+      trackedResourceRef: normalizeTrackedResourceRef(input.trackedResourceRef),
+      cleanupPolicy: normalizeCleanupPolicy(input.cleanupPolicy ?? null),
+      startPolicy: input.startPolicy ?? "latest",
+      startOffset: input.startOffset ?? null,
+      startTime: input.startTime ?? null,
+    };
   }
 
   async removeSubscription(subscriptionId: string): Promise<{ removed: boolean; subscriptionId: string }> {
@@ -3179,6 +3352,34 @@ function buildPreviewSource(input: PreviewSourceSchemaInput): SourceStream {
   };
 }
 
+function mergeFollowPreviewConfig(
+  config: Record<string, unknown> | undefined,
+  templateArgs: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...(config ?? {}),
+    ...templateArgs,
+  };
+}
+
+function followPreviewRefsForProviderOrKind(providerOrKind: string): string[] {
+  const trimmed = providerOrKind.trim();
+  if (trimmed.length === 0) {
+    throw new Error("follow requires a providerOrKind");
+  }
+  if (
+    trimmed === "local_event" ||
+    trimmed === "remote_source" ||
+    trimmed === "github_repo" ||
+    trimmed === "github_repo_ci" ||
+    trimmed === "feishu_bot" ||
+    trimmed.startsWith("remote:")
+  ) {
+    return [trimmed];
+  }
+  return ["github_repo", "github_repo_ci", "feishu_bot"];
+}
+
 function sourceTypeForPreviewRef(sourceRef: string): SourceStream["sourceType"] {
   if (sourceRef === "local_event" || sourceRef === "remote_source" || sourceRef === "github_repo" || sourceRef === "github_repo_ci" || sourceRef === "feishu_bot") {
     return sourceRef;
@@ -3187,6 +3388,77 @@ function sourceTypeForPreviewRef(sourceRef: string): SourceStream["sourceType"] 
     return "remote_source";
   }
   throw new Error(`unknown source kind or type for preview: ${sourceRef}`);
+}
+
+function followTemplateName(templateId: string): string {
+  const trimmed = templateId.trim();
+  const separator = trimmed.lastIndexOf(".");
+  return separator === -1 ? trimmed : trimmed.slice(separator + 1);
+}
+
+function validateFollowTemplateArgs(
+  argsSchema: SourceSchemaField[],
+  args: Record<string, unknown>,
+  templateId: string,
+): void {
+  for (const field of argsSchema) {
+    const value = args[field.name];
+    if (field.required && value === undefined) {
+      throw new Error(`follow template ${templateId} requires argument ${field.name}`);
+    }
+    if (value === undefined) {
+      continue;
+    }
+    if (!matchesFollowArgType(value, field.type)) {
+      throw new Error(`follow template ${templateId} expected ${field.name} to be ${field.type}`);
+    }
+  }
+}
+
+function matchesFollowArgType(value: unknown, type: string): boolean {
+  if (type === "string") {
+    return typeof value === "string";
+  }
+  if (type === "number") {
+    return typeof value === "number" && Number.isFinite(value);
+  }
+  if (type === "boolean") {
+    return typeof value === "boolean";
+  }
+  if (type === "string[]") {
+    return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+  }
+  if (type === "number[]") {
+    return Array.isArray(value) && value.every((entry) => typeof entry === "number" && Number.isFinite(entry));
+  }
+  return true;
+}
+
+function validateExpandedFollowPlan(plan: ExpandedFollowPlan, expectedTemplateId: string): void {
+  if (plan.templateId !== expectedTemplateId) {
+    throw new Error(`follow template ${expectedTemplateId} expanded to unexpected templateId ${plan.templateId}`);
+  }
+  if (plan.sources.length === 0) {
+    throw new Error(`follow template ${plan.templateId} did not produce any sources`);
+  }
+  const logicalNames = new Set<string>();
+  for (const source of plan.sources) {
+    const logicalName = source.logicalName.trim();
+    if (logicalName.length === 0) {
+      throw new Error(`follow template ${plan.templateId} returned an empty source logicalName`);
+    }
+    if (logicalNames.has(logicalName)) {
+      throw new Error(`follow template ${plan.templateId} returned duplicate source logicalName ${logicalName}`);
+    }
+    logicalNames.add(logicalName);
+  }
+  for (const subscription of plan.subscriptions) {
+    if (!logicalNames.has(subscription.sourceLogicalName)) {
+      throw new Error(
+        `follow template ${plan.templateId} references unknown ensured source ${subscription.sourceLogicalName}`,
+      );
+    }
+  }
 }
 
 function normalizeTrackedResourceRef(value: string | null | undefined): string | null {
@@ -3243,6 +3515,25 @@ function normalizeGracePeriodSecs(value: number): number {
     throw new Error("cleanupPolicy gracePeriodSecs must be a non-negative integer");
   }
   return value;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value));
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sortJsonValue(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  return Object.keys(value as Record<string, unknown>)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = sortJsonValue((value as Record<string, unknown>)[key]);
+      return acc;
+    }, {});
 }
 
 function normalizeLifecycleSignal(signal: LifecycleSignal, fallbackOccurredAt?: string): LifecycleSignal | null {

--- a/src/source_resolution.ts
+++ b/src/source_resolution.ts
@@ -81,6 +81,9 @@ export async function resolveSourceSchema(
           shortcuts: typeof module?.listSubscriptionShortcuts === "function"
             ? module.listSubscriptionShortcuts(moduleInputSource(source))
             : [],
+          followTemplates: typeof module?.listFollowTemplates === "function"
+            ? module.listFollowTemplates(moduleInputSource(source))
+            : [],
         }
       : undefined,
   );
@@ -96,6 +99,13 @@ export function withResolvedIdentity(
     supportsLifecycleSignals?: boolean;
     shortcuts?: Array<{
       name: string;
+      description: string;
+      argsSchema?: SourceSchema["configFields"];
+    }>;
+    followTemplates?: Array<{
+      templateId: string;
+      providerOrKind: string;
+      label: string;
       description: string;
       argsSchema?: SourceSchema["configFields"];
     }>;
@@ -119,6 +129,13 @@ export function withResolvedIdentity(
         shortcuts: capabilityMetadata.shortcuts ?? [],
       },
     } : {}),
+    ...(capabilityMetadata?.followTemplates
+      ? {
+          followSchema: {
+            templates: capabilityMetadata.followTemplates,
+          },
+        }
+      : {}),
   };
 }
 

--- a/src/source_resolution.ts
+++ b/src/source_resolution.ts
@@ -83,7 +83,7 @@ export async function resolveSourceSchema(
             : [],
           followTemplates: typeof module?.listFollowTemplates === "function"
             ? module.listFollowTemplates(moduleInputSource(source))
-            : [],
+            : undefined,
         }
       : undefined,
   );
@@ -129,7 +129,7 @@ export function withResolvedIdentity(
         shortcuts: capabilityMetadata.shortcuts ?? [],
       },
     } : {}),
-    ...(capabilityMetadata?.followTemplates
+    ...(capabilityMetadata?.followTemplates && capabilityMetadata.followTemplates.length > 0
       ? {
           followSchema: {
             templates: capabilityMetadata.followTemplates,

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -5,10 +5,12 @@ import {
   DeliveryHandle,
   DeliveryOperationDescriptor,
   DeliveryRequest,
+  FollowTemplateSpec,
   SourceSchemaField,
   SourceStream,
   SubscriptionFilter,
 } from "../model";
+import type { ExpandedFollowPlan, ExpandFollowTemplateInput } from "./remote_modules";
 
 export const GITHUB_ENDPOINT = "https://api.github.com";
 const DEFAULT_GITHUB_CALL_CLIENT = new UxcDaemonClient({ env: process.env });
@@ -393,6 +395,11 @@ export function canonicalGithubPullRequestRef(source: SourceStream, number: numb
   return `repo:${config.owner}/${config.repo}:pr:${number}`;
 }
 
+export function canonicalGithubIssueRef(source: SourceStream, number: number): string {
+  const config = parseGithubSourceConfig(source);
+  return `repo:${config.owner}/${config.repo}:issue:${number}`;
+}
+
 export function deriveGithubTrackedResource(filter: SubscriptionFilter, source: SourceStream): { ref: string } | null {
   const metadata = asRecord(filter.metadata);
   const payload = asRecord(filter.payload);
@@ -417,6 +424,43 @@ export function githubSubscriptionShortcutSpec(): Array<{
       { name: "withCi", type: "boolean", required: false, description: "Also create a sibling ci_runs subscription under the same host and stream key." },
     ],
   }];
+}
+
+export function githubFollowTemplateSpec(): FollowTemplateSpec[] {
+  const repoArgs: SourceSchemaField[] = [
+    { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+    { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+  ];
+  return [
+    {
+      templateId: "github.repo",
+      providerOrKind: "github",
+      label: "GitHub Repository",
+      description: "Follow a repository event stream.",
+      argsSchema: repoArgs,
+    },
+    {
+      templateId: "github.pr",
+      providerOrKind: "github",
+      label: "GitHub Pull Request",
+      description: "Follow one pull request and optionally its CI.",
+      argsSchema: [
+        ...repoArgs,
+        { name: "number", type: "number", required: true, description: "Pull request number." },
+        { name: "withCi", type: "boolean", required: false, description: "Also follow the repository CI stream for that pull request." },
+      ],
+    },
+    {
+      templateId: "github.issue",
+      providerOrKind: "github",
+      label: "GitHub Issue",
+      description: "Follow one issue without automatic terminal cleanup.",
+      argsSchema: [
+        ...repoArgs,
+        { name: "number", type: "number", required: true, description: "Issue number." },
+      ],
+    },
+  ];
 }
 
 export function expandGithubSubscriptionShortcut(input: {
@@ -469,6 +513,110 @@ export function expandGithubSubscriptionShortcut(input: {
   };
 }
 
+export function expandGithubFollowTemplate(input: ExpandFollowTemplateInput): ExpandedFollowPlan | null {
+  const config = parseGithubSourceConfig(input.source);
+  if (input.template === "repo") {
+    return {
+      templateId: "github.repo",
+      sources: [
+        {
+          logicalName: "repo_events",
+          sourceType: "github_repo",
+          sourceKey: `${config.owner}/${config.repo}`,
+          configRef: input.source.configRef ?? null,
+          config: githubFollowSourceConfig(input.source),
+        },
+      ],
+      subscriptions: [],
+    };
+  }
+
+  const number = typeof input.args?.number === "number" ? input.args.number : null;
+  if (input.template !== "pr" && input.template !== "issue") {
+    return null;
+  }
+  if (!number || !Number.isInteger(number) || number <= 0) {
+    throw new Error(`follow template github.${input.template} requires a positive integer number`);
+  }
+
+  if (input.template === "pr") {
+    const trackedResourceRef = canonicalGithubPullRequestRef(input.source, number);
+    const withCi = input.args?.withCi === true;
+    return {
+      templateId: "github.pr",
+      sources: [
+        {
+          logicalName: "repo_events",
+          sourceType: "github_repo",
+          sourceKey: `${config.owner}/${config.repo}`,
+          configRef: input.source.configRef ?? null,
+          config: githubFollowSourceConfig(input.source),
+        },
+        ...(withCi
+          ? [{
+              logicalName: "ci_runs",
+              sourceType: "github_repo_ci" as const,
+              sourceKey: `${config.owner}/${config.repo}`,
+              configRef: input.source.configRef ?? null,
+              config: githubFollowSourceConfig(input.source),
+            }]
+          : []),
+      ],
+      subscriptions: [
+        {
+          sourceLogicalName: "repo_events",
+          filter: {
+            metadata: {
+              number,
+              isPullRequest: true,
+            },
+          },
+          trackedResourceRef,
+          cleanupPolicy: { mode: "on_terminal" },
+        },
+        ...(withCi
+          ? [{
+              sourceLogicalName: "ci_runs",
+              filter: {
+                metadata: {
+                  pullRequestNumbers: [number],
+                },
+              },
+              trackedResourceRef,
+              cleanupPolicy: { mode: "on_terminal" as const },
+            }]
+          : []),
+      ],
+    };
+  }
+
+  return {
+    templateId: "github.issue",
+    sources: [
+      {
+        logicalName: "repo_events",
+        sourceType: "github_repo",
+        sourceKey: `${config.owner}/${config.repo}`,
+        configRef: input.source.configRef ?? null,
+        config: githubFollowSourceConfig(input.source),
+      },
+    ],
+    subscriptions: [
+      {
+        sourceLogicalName: "repo_events",
+        filter: {
+          metadata: {
+            number,
+            isPullRequest: false,
+          },
+        },
+        trackedResourceRef: canonicalGithubIssueRef(input.source, number),
+        cleanupPolicy: { mode: "manual" },
+      },
+    ],
+  };
+}
+
 export function projectGithubLifecycleSignal(rawPayload: Record<string, unknown>, source: SourceStream): {
   ref: string;
   terminal: boolean;
@@ -495,6 +643,13 @@ export function projectGithubLifecycleSignal(rawPayload: Record<string, unknown>
     state: "closed",
     result: merged ? "merged" : "closed",
   };
+}
+
+function githubFollowSourceConfig(source: SourceStream): Record<string, unknown> {
+  const config = { ...(source.config ?? {}) };
+  delete config.number;
+  delete config.withCi;
+  return config;
 }
 
 function buildGithubDeliveryHandle(

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -527,7 +527,13 @@ export function expandGithubFollowTemplate(input: ExpandFollowTemplateInput): Ex
           config: githubFollowSourceConfig(input.source),
         },
       ],
-      subscriptions: [],
+      subscriptions: [
+        {
+          sourceLogicalName: "repo_events",
+          filter: {},
+          cleanupPolicy: { mode: "manual" },
+        },
+      ],
     };
   }
 

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -1,11 +1,13 @@
 import { ManagedSourceEnsureResponse, ManagedStreamReadResponse, UxcDaemonClient } from "@holon-run/uxc-daemon-client";
-import { ActivationItem, AppendSourceEventInput, NotificationGrouping, SourcePollResult, SourceStream } from "../model";
+import { ActivationItem, AppendSourceEventInput, FollowTemplateSpec, NotificationGrouping, SourcePollResult, SourceStream } from "../model";
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
 import { nowIso } from "../util";
 import {
+  ExpandedFollowPlan,
   ExpandedSubscriptionInput,
   ExpandedSubscriptionPlan,
+  ExpandFollowTemplateInput,
   LifecycleSignal,
   ManagedSourceSpec,
   RemoteSourceModuleRegistry,
@@ -246,6 +248,35 @@ export class RemoteSourceRuntime {
       source: moduleInputSource(source),
     });
     return normalizeExpandedSubscriptionPlan(expanded);
+  }
+
+  async listFollowTemplates(source: SourceStream): Promise<FollowTemplateSpec[]> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return [];
+    }
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    if (typeof module.listFollowTemplates !== "function") {
+      return [];
+    }
+    return module.listFollowTemplates(moduleInputSource(source));
+  }
+
+  async expandFollowTemplate(
+    source: SourceStream,
+    input: ExpandFollowTemplateInput,
+  ): Promise<ExpandedFollowPlan | null> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return null;
+    }
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    if (typeof module.expandFollowTemplate !== "function") {
+      return null;
+    }
+    return module.expandFollowTemplate({
+      template: input.template,
+      args: input.args,
+      source: moduleInputSource(source),
+    });
   }
 
   async deriveInlinePreview(source: SourceStream, item: ActivationItem): Promise<string | null> {

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -177,6 +177,7 @@ export interface RemoteSourceModule {
 
 const REMOTE_USER_MODULE_ROOT_DIR = "source-modules";
 const BUILTIN_MODULE_IDS = new Set(["builtin.github_repo", "builtin.github_repo_ci", "builtin.feishu_bot"]);
+const BUILTIN_REMOTE_SOURCE_TYPES = ["github_repo", "github_repo_ci", "feishu_bot"] as const;
 
 export class RemoteSourceModuleRegistry {
   private readonly moduleCache = new Map<string, RemoteSourceModule>();
@@ -242,6 +243,10 @@ export function builtInModuleIdForSourceType(sourceType: SourceStream["sourceTyp
     return "builtin.feishu_bot";
   }
   return null;
+}
+
+export function builtinRemoteSourceTypes(): SourceStream["sourceType"][] {
+  return [...BUILTIN_REMOTE_SOURCE_TYPES];
 }
 
 function validateModuleContract(module: RemoteSourceModule, sourcePath: string): void {

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -9,17 +9,22 @@ import {
   DeliveryAttempt,
   DeliveryHandle,
   DeliveryOperationDescriptor,
+  FollowTemplateSpec,
   NotificationGrouping,
+  RegisterSourceInput,
   SourceSchemaField,
   SourceStream,
   SubscriptionFilter,
+  SubscriptionStartPolicy,
 } from "../model";
 import {
   deriveGithubTrackedResource,
+  expandGithubFollowTemplate,
   expandGithubSubscriptionShortcut,
   GITHUB_ENDPOINT,
   GithubCallClient,
   githubDeliveryOperationsForHandle,
+  githubFollowTemplateSpec,
   githubSubscriptionShortcutSpec,
   hydrateGithubRepoEventIfNeeded,
   invokeGithubDeliveryOperation,
@@ -100,6 +105,32 @@ export interface ExpandSubscriptionShortcutInput {
   source: SourceStream;
 }
 
+export interface ExpandedFollowSourceEnsure extends RegisterSourceInput {
+  logicalName: string;
+}
+
+export interface ExpandedFollowSubscriptionEnsure {
+  sourceLogicalName: string;
+  filter?: SubscriptionFilter;
+  trackedResourceRef?: string | null;
+  cleanupPolicy?: CleanupPolicy | null;
+  startPolicy?: SubscriptionStartPolicy;
+  startOffset?: number | null;
+  startTime?: string | null;
+}
+
+export interface ExpandedFollowPlan {
+  templateId: string;
+  sources: ExpandedFollowSourceEnsure[];
+  subscriptions: ExpandedFollowSubscriptionEnsure[];
+}
+
+export interface ExpandFollowTemplateInput {
+  template: string;
+  args?: Record<string, unknown>;
+  source: SourceStream;
+}
+
 export interface LifecycleSignal {
   ref: string;
   terminal: boolean;
@@ -133,6 +164,8 @@ export interface RemoteSourceModule {
   describeCapabilities?(source: SourceStream): RemoteSourceCapabilityDescription;
   listSubscriptionShortcuts?(source: SourceStream): SubscriptionShortcutSpec[];
   expandSubscriptionShortcut?(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | ExpandedSubscriptionPlan | null;
+  listFollowTemplates?(source: SourceStream): FollowTemplateSpec[];
+  expandFollowTemplate?(input: ExpandFollowTemplateInput): ExpandedFollowPlan | null;
   deriveTrackedResource?(filter: SubscriptionFilter, source: SourceStream): { ref: string } | null;
   projectLifecycleSignal?(rawPayload: Record<string, unknown>, source: SourceStream): LifecycleSignal | null;
   deriveInlinePreview?(item: ActivationItem, source: SourceStream): string | null;
@@ -230,6 +263,8 @@ function validateModuleContract(module: RemoteSourceModule, sourcePath: string):
   validateOptionalHook(module.describeCapabilities, "describeCapabilities", sourcePath);
   validateOptionalHook(module.listSubscriptionShortcuts, "listSubscriptionShortcuts", sourcePath);
   validateOptionalHook(module.expandSubscriptionShortcut, "expandSubscriptionShortcut", sourcePath);
+  validateOptionalHook(module.listFollowTemplates, "listFollowTemplates", sourcePath);
+  validateOptionalHook(module.expandFollowTemplate, "expandFollowTemplate", sourcePath);
   validateOptionalHook(module.deriveTrackedResource, "deriveTrackedResource", sourcePath);
   validateOptionalHook(module.projectLifecycleSignal, "projectLifecycleSignal", sourcePath);
   validateOptionalHook(module.deriveInlinePreview, "deriveInlinePreview", sourcePath);
@@ -343,6 +378,12 @@ export function createGithubRepoRemoteModule(options?: { callClient?: GithubCall
     },
     expandSubscriptionShortcut(input: ExpandSubscriptionShortcutInput): ExpandedSubscriptionInput | ExpandedSubscriptionPlan | null {
       return expandGithubSubscriptionShortcut(input);
+    },
+    listFollowTemplates(): FollowTemplateSpec[] {
+      return githubFollowTemplateSpec();
+    },
+    expandFollowTemplate(input: ExpandFollowTemplateInput): ExpandedFollowPlan | null {
+      return expandGithubFollowTemplate(input);
     },
     deriveTrackedResource(filter: SubscriptionFilter, source: SourceStream): { ref: string } | null {
       return deriveGithubTrackedResource(filter, source);

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -1426,6 +1426,142 @@ test("follow github pr ensures sources and dedupes subscriptions", async () => {
   }
 });
 
+test("follow github repo creates a repository subscription", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "github-follow-repo-thread",
+      tmuxPaneId: "%946-follow",
+    });
+
+    const first = await service.follow({
+      agentId: agent.agent.agentId,
+      providerOrKind: "github",
+      template: "repo",
+      templateArgs: {
+        owner: "holon-run",
+        repo: "agentinbox",
+      },
+    });
+
+    assert.equal(first.templateId, "github.repo");
+    assert.deepEqual(first.sources.map((source) => source.created), [true]);
+    assert.deepEqual(first.subscriptions.map((subscription) => subscription.created), [true]);
+    assert.equal(store.listSources().length, 1);
+    assert.equal(store.listSubscriptions().length, 1);
+
+    const second = await service.follow({
+      agentId: agent.agent.agentId,
+      providerOrKind: "github",
+      template: "repo",
+      templateArgs: {
+        owner: "holon-run",
+        repo: "agentinbox",
+      },
+    });
+
+    assert.deepEqual(second.sources.map((source) => source.created), [false]);
+    assert.deepEqual(second.subscriptions.map((subscription) => subscription.created), [false]);
+    assert.equal(store.listSources().length, 1);
+    assert.equal(store.listSubscriptions().length, 1);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("follow resolves providerOrKind through remote module templates without core provider mapping", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const moduleDir = path.join(dir, "source-modules");
+    fs.mkdirSync(moduleDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(moduleDir, "follow-provider.mjs"),
+      `export default {
+  id: "demo.follow-provider",
+  validateConfig(source) {
+    if (!source.config.tenant) throw new Error("tenant required");
+  },
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() { return null; },
+  listFollowTemplates() {
+    return [{
+      templateId: "demo.ticket",
+      providerOrKind: "demo",
+      label: "Demo Ticket",
+      description: "Follow one ticket",
+      argsSchema: [{ name: "id", type: "string", required: true, description: "Ticket id." }]
+    }];
+  },
+  expandFollowTemplate(input) {
+    if (input.template !== "ticket") return null;
+    return {
+      templateId: "demo.ticket",
+      sources: [{
+        logicalName: "events",
+        sourceType: "local_event",
+        sourceKey: "demo-follow-events",
+        config: {}
+      }],
+      subscriptions: [{
+        sourceLogicalName: "events",
+        filter: { metadata: { ticketId: input.args.id } },
+        trackedResourceRef: "ticket:" + input.args.id,
+        cleanupPolicy: { mode: "manual" }
+      }]
+    };
+  }
+};`,
+      "utf8",
+    );
+
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "demo-follow-provider-thread",
+      tmuxPaneId: "%947-follow",
+    });
+
+    const followed = await service.follow({
+      agentId: agent.agent.agentId,
+      providerOrKind: "demo",
+      template: "ticket",
+      templateArgs: {
+        id: "A-9",
+      },
+      config: {
+        modulePath: "follow-provider.mjs",
+        moduleConfig: {
+          tenant: "team-a",
+        },
+      },
+    });
+
+    assert.equal(followed.templateId, "demo.ticket");
+    assert.deepEqual(followed.sources.map((source) => source.created), [true]);
+    assert.deepEqual(followed.subscriptions.map((subscription) => subscription.created), [true]);
+    assert.equal(store.listSources().length, 1);
+    assert.equal(store.listSubscriptions().length, 1);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("registerSubscription rejects invalid start policy requirements", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -775,6 +775,7 @@ test("remote_source registration succeeds", async () => {
         hostType: string;
         sourceKind: string;
         implementationId: string;
+        followSchema?: unknown;
         subscriptionSchema: {
           supportsTrackedResourceRef: boolean;
           supportsLifecycleSignals: boolean;
@@ -796,6 +797,7 @@ test("remote_source registration succeeds", async () => {
       supportsLifecycleSignals: false,
       shortcuts: [],
     });
+    assert.equal("followSchema" in details.schema, false);
   } finally {
     await service.stop();
     store.close();
@@ -1417,6 +1419,45 @@ test("follow github pr ensures sources and dedupes subscriptions", async () => {
     assert.deepEqual(second.subscriptions.map((subscription) => subscription.created), [false, false]);
     assert.equal(store.listSources().length, 2);
     assert.equal(store.listSubscriptions().length, 2);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("registerSubscription rejects invalid start policy requirements", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const source = await service.registerSource({
+      sourceType: "local_event",
+      sourceKey: "start-policy-validation",
+      config: {},
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "start-policy-validation-thread",
+      tmuxPaneId: "%945-start-policy",
+    });
+
+    await assert.rejects(
+      service.registerSubscription({
+        agentId: agent.agent.agentId,
+        sourceId: source.sourceId,
+        startPolicy: "at_time",
+      } as never),
+      /subscriptions requires valid ISO8601 startTime when startPolicy=at_time/,
+    );
+
+    await assert.rejects(
+      service.registerSubscription({
+        agentId: agent.agent.agentId,
+        sourceId: source.sourceId,
+        startPolicy: "at_offset",
+      } as never),
+      /subscriptions requires positive integer startOffset when startPolicy=at_offset/,
+    );
   } finally {
     await service.stop();
     store.close();

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -823,6 +823,7 @@ test("builtin remote-backed source details expose resolved remote identity", asy
         sourceKind: string;
         implementationId: string;
         aliases?: string[];
+        followSchema?: unknown;
         subscriptionSchema: {
           supportsTrackedResourceRef: boolean;
           supportsLifecycleSignals: boolean;
@@ -853,6 +854,44 @@ test("builtin remote-backed source details expose resolved remote identity", asy
             required: false,
             description: "Also create a sibling ci_runs subscription under the same host and stream key.",
           },
+        ],
+      }],
+    });
+    assert.deepEqual(details.schema.followSchema, {
+      templates: [{
+        templateId: "github.repo",
+        providerOrKind: "github",
+        label: "GitHub Repository",
+        description: "Follow a repository event stream.",
+        argsSchema: [
+          { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+          { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+        ],
+      }, {
+        templateId: "github.pr",
+        providerOrKind: "github",
+        label: "GitHub Pull Request",
+        description: "Follow one pull request and optionally its CI.",
+        argsSchema: [
+          { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+          { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+          { name: "number", type: "number", required: true, description: "Pull request number." },
+          {
+            name: "withCi",
+            type: "boolean",
+            required: false,
+            description: "Also follow the repository CI stream for that pull request.",
+          },
+        ],
+      }, {
+        templateId: "github.issue",
+        providerOrKind: "github",
+        label: "GitHub Issue",
+        description: "Follow one issue without automatic terminal cleanup.",
+        argsSchema: [
+          { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+          { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+          { name: "number", type: "number", required: true, description: "Issue number." },
         ],
       }],
     });
@@ -950,6 +989,44 @@ test("stream schema preview supports builtin remote-backed aliases without persi
         },
       ],
     }]);
+    assert.deepEqual(preview.followSchema, {
+      templates: [{
+        templateId: "github.repo",
+        providerOrKind: "github",
+        label: "GitHub Repository",
+        description: "Follow a repository event stream.",
+        argsSchema: [
+          { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+          { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+        ],
+      }, {
+        templateId: "github.pr",
+        providerOrKind: "github",
+        label: "GitHub Pull Request",
+        description: "Follow one pull request and optionally its CI.",
+        argsSchema: [
+          { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+          { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+          { name: "number", type: "number", required: true, description: "Pull request number." },
+          {
+            name: "withCi",
+            type: "boolean",
+            required: false,
+            description: "Also follow the repository CI stream for that pull request.",
+          },
+        ],
+      }, {
+        templateId: "github.issue",
+        providerOrKind: "github",
+        label: "GitHub Issue",
+        description: "Follow one issue without automatic terminal cleanup.",
+        argsSchema: [
+          { name: "owner", type: "string", required: true, description: "GitHub repository owner." },
+          { name: "repo", type: "string", required: true, description: "GitHub repository name." },
+          { name: "number", type: "number", required: true, description: "Issue number." },
+        ],
+      }],
+    });
     assert.equal(store.listSources().length, 0);
   } finally {
     await service.stop();
@@ -1000,6 +1077,15 @@ test("remote_source capability hooks override resolved schema fields and adverti
       argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }]
     }];
   },
+  listFollowTemplates() {
+    return [{
+      templateId: "demo.ticket",
+      providerOrKind: "demo",
+      label: "Demo Ticket",
+      description: "Follow one ticket",
+      argsSchema: [{ name: "id", type: "string", required: true, description: "Ticket id." }]
+    }];
+  },
   deriveTrackedResource() {
     return { ref: "resource:demo" };
   },
@@ -1037,6 +1123,15 @@ test("remote_source capability hooks override resolved schema fields and adverti
         name: "pr",
         description: "Follow one pull request",
         argsSchema: [{ name: "number", type: "number", required: true, description: "Pull request number." }],
+      }],
+    });
+    assert.deepEqual(schema.followSchema, {
+      templates: [{
+        templateId: "demo.ticket",
+        providerOrKind: "demo",
+        label: "Demo Ticket",
+        description: "Follow one ticket",
+        argsSchema: [{ name: "id", type: "string", required: true, description: "Ticket id." }],
       }],
     });
   } finally {
@@ -1271,6 +1366,57 @@ test("github pr shortcut with withCi creates repo and sibling ci subscriptions",
       { mode: "on_terminal" },
       { mode: "on_terminal" },
     ]);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("follow github pr ensures sources and dedupes subscriptions", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "github-follow-pr-thread",
+      tmuxPaneId: "%945-follow",
+    });
+
+    const first = await service.follow({
+      agentId: agent.agent.agentId,
+      providerOrKind: "github",
+      template: "pr",
+      templateArgs: {
+        owner: "holon-run",
+        repo: "agentinbox",
+        number: 93,
+        withCi: true,
+      },
+    });
+
+    assert.equal(first.templateId, "github.pr");
+    assert.deepEqual(first.sources.map((source) => source.created), [true, true]);
+    assert.deepEqual(first.subscriptions.map((subscription) => subscription.created), [true, true]);
+    assert.equal(store.listSources().length, 2);
+    assert.equal(store.listSubscriptions().length, 2);
+
+    const second = await service.follow({
+      agentId: agent.agent.agentId,
+      providerOrKind: "github",
+      template: "pr",
+      templateArgs: {
+        owner: "holon-run",
+        repo: "agentinbox",
+        number: 93,
+        withCi: true,
+      },
+    });
+
+    assert.deepEqual(second.sources.map((source) => source.created), [false, false]);
+    assert.deepEqual(second.subscriptions.map((subscription) => subscription.created), [false, false]);
+    assert.equal(store.listSources().length, 2);
+    assert.equal(store.listSubscriptions().length, 2);
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1050,6 +1050,45 @@ test("cli stream schema preview resolves remote module-backed schemas before reg
   }
 });
 
+test("cli follow supports repeated --arg values and returns ensured sources", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-follow-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%937-follow",
+    CODEX_THREAD_ID: "thread-follow-cli",
+  };
+
+  try {
+    const followed = runCli([
+      "follow",
+      "github",
+      "pr",
+      "--arg", "owner=holon-run",
+      "--arg", "repo=agentinbox",
+      "--arg", "number=93",
+      "--arg", "withCi=true",
+    ], env);
+    assert.equal(followed.status, 0, followed.stderr);
+    const payload = JSON.parse(followed.stdout) as {
+      templateId: string;
+      autoRegistered?: boolean;
+      sources: Array<{ created: boolean }>;
+      subscriptions: Array<{ created: boolean }>;
+    };
+    assert.equal(payload.templateId, "github.pr");
+    assert.equal(payload.autoRegistered, true);
+    assert.deepEqual(payload.sources.map((source) => source.created), [true, true]);
+    assert.deepEqual(payload.subscriptions.map((subscription) => subscription.created), [true, true]);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli inbox read rejects unsupported flags like --ack", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-read-flags-"));
   const env = {
@@ -1900,6 +1939,80 @@ test("control plane stream schema preview resolves remote modules without persis
       assert.equal(preview.data.sourceKind, "remote:demo.http.preview");
       assert.equal(preview.data.implementationId, "demo.http.preview");
       assert.equal(store.listSources().length, 0);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane follow ensures sources and dedupes subscriptions", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-follow-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }), { homeDir });
+  const service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const registered = service.registerAgent({
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "http-follow-thread",
+        tmuxPaneId: "%http-follow",
+      });
+      const first = await client.request<{
+        templateId: string;
+        sources: Array<{ created: boolean }>;
+        subscriptions: Array<{ created: boolean }>;
+      }>("/follow", {
+        agentId: registered.agent.agentId,
+        providerOrKind: "github",
+        template: "pr",
+        templateArgs: {
+          owner: "holon-run",
+          repo: "agentinbox",
+          number: 93,
+          withCi: true,
+        },
+      }, "POST");
+      assert.equal(first.statusCode, 200);
+      assert.equal(first.data.templateId, "github.pr");
+      assert.deepEqual(first.data.sources.map((source) => source.created), [true, true]);
+      assert.deepEqual(first.data.subscriptions.map((subscription) => subscription.created), [true, true]);
+
+      const second = await client.request<{
+        sources: Array<{ created: boolean }>;
+        subscriptions: Array<{ created: boolean }>;
+      }>("/follow", {
+        agentId: registered.agent.agentId,
+        providerOrKind: "github",
+        template: "pr",
+        templateArgs: {
+          owner: "holon-run",
+          repo: "agentinbox",
+          number: 93,
+          withCi: true,
+        },
+      }, "POST");
+      assert.equal(second.statusCode, 200);
+      assert.deepEqual(second.data.sources.map((source) => source.created), [false, false]);
+      assert.deepEqual(second.data.subscriptions.map((subscription) => subscription.created), [false, false]);
     } finally {
       await started.close();
     }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { AdapterRegistry } from "../src/adapters";
 import { AgentInboxClient } from "../src/client";
 import { startControlServer } from "../src/control_server";
@@ -74,6 +74,50 @@ function runCli(args: string[], env: NodeJS.ProcessEnv, timeout = 25_000, input?
     encoding: "utf8",
     timeout,
     input,
+  });
+}
+
+async function runCliAsync(args: string[], env: NodeJS.ProcessEnv, timeout = 25_000, input?: string): Promise<{
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}> {
+  const repoDir = path.resolve(__dirname, "..");
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", ["-r", "ts-node/register", "src/cli.ts", ...args], {
+      cwd: repoDir,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+    }, timeout);
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (status, signal) => {
+      clearTimeout(timer);
+      resolve({ status, signal, stdout, stderr });
+    });
+
+    if (input != null) {
+      child.stdin.write(input);
+    }
+    child.stdin.end();
   });
 }
 
@@ -1050,8 +1094,10 @@ test("cli stream schema preview resolves remote module-backed schemas before reg
   }
 });
 
-test("cli follow supports repeated --arg values and returns ensured sources", () => {
+test("cli follow supports repeated --arg values and returns ensured sources", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-follow-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
   const env = {
     ...process.env,
     AGENTINBOX_HOME: homeDir,
@@ -1062,8 +1108,20 @@ test("cli follow supports repeated --arg values and returns ensured sources", ()
     CODEX_THREAD_ID: "thread-follow-cli",
   };
 
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
+  service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
   try {
-    const followed = runCli([
+    await adapters.start();
+    await service.start();
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    const followed = await runCliAsync([
       "follow",
       "github",
       "pr",
@@ -1072,19 +1130,25 @@ test("cli follow supports repeated --arg values and returns ensured sources", ()
       "--arg", "number=93",
       "--arg", "withCi=true",
     ], env);
-    assert.equal(followed.status, 0, followed.stderr);
-    const payload = JSON.parse(followed.stdout) as {
-      templateId: string;
-      autoRegistered?: boolean;
-      sources: Array<{ created: boolean }>;
-      subscriptions: Array<{ created: boolean }>;
-    };
-    assert.equal(payload.templateId, "github.pr");
-    assert.equal(payload.autoRegistered, true);
-    assert.deepEqual(payload.sources.map((source) => source.created), [true, true]);
-    assert.deepEqual(payload.subscriptions.map((subscription) => subscription.created), [true, true]);
+    try {
+      assert.equal(followed.status, 0, followed.stderr);
+      const payload = JSON.parse(followed.stdout) as {
+        templateId: string;
+        autoRegistered?: boolean;
+        sources: Array<{ created: boolean }>;
+        subscriptions: Array<{ created: boolean }>;
+      };
+      assert.equal(payload.templateId, "github.pr");
+      assert.equal(payload.autoRegistered, true);
+      assert.deepEqual(payload.sources.map((source) => source.created), [true, true]);
+      assert.deepEqual(payload.subscriptions.map((subscription) => subscription.created), [true, true]);
+    } finally {
+      await started.close();
+    }
   } finally {
-    void runCli(["daemon", "stop"], env);
+    await adapters.stop();
+    await service.stop();
+    store.close();
     fs.rmSync(homeDir, { recursive: true, force: true });
   }
 });
@@ -1955,11 +2019,16 @@ test("control plane follow ensures sources and dedupes subscriptions", async () 
   const dbPath = path.join(homeDir, "agentinbox.sqlite");
 
   const store = await AgentInboxStore.open(dbPath);
-  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }), { homeDir });
+  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }), {
+    homeDir,
+    remoteSourceClient: new FakeRemoteSourceClient(),
+  });
   const service = new AgentInboxService(store, adapters);
   const server = createServer(service);
 
   try {
+    await adapters.start();
+    await service.start();
     const started = await startControlServer(server, {
       kind: "socket",
       socketPath,
@@ -2017,6 +2086,7 @@ test("control plane follow ensures sources and dedupes subscriptions", async () 
       await started.close();
     }
   } finally {
+    await adapters.stop();
     await service.stop();
     store.close();
     fs.rmSync(homeDir, { recursive: true, force: true });

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -2023,6 +2023,55 @@ test("control plane follow ensures sources and dedupes subscriptions", async () 
   }
 });
 
+test("control plane follow rejects invalid startPolicy at schema validation time", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-follow-sp-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }), { homeDir });
+  const service = new AgentInboxService(store, adapters);
+  const server = createServer(service);
+
+  try {
+    const started = await startControlServer(server, {
+      kind: "socket",
+      socketPath,
+    });
+    try {
+      const client = new AgentInboxClient({
+        kind: "socket",
+        socketPath,
+        source: "flag",
+      });
+      const registered = service.registerAgent({
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "http-follow-start-policy-thread",
+        tmuxPaneId: "%http-follow-start-policy",
+      });
+      const response = await client.request<{ error?: string }>("/follow", {
+        agentId: registered.agent.agentId,
+        providerOrKind: "github",
+        template: "pr",
+        startPolicy: "bogus",
+        templateArgs: {
+          owner: "holon-run",
+          repo: "agentinbox",
+          number: 93,
+        },
+      }, "POST");
+      assert.equal(response.statusCode, 400);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("control plane stream schema preview returns 400 for invalid preview inputs", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-schema-preview-error-"));
   const socketPath = path.join(os.tmpdir(), `aix-preview-${process.pid}-${Date.now()}.sock`);

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -2,9 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   deriveGithubTrackedResource,
+  expandGithubFollowTemplate,
   GithubDeliveryAdapter,
   GithubUxcClient,
   githubSubscriptionShortcutSpec,
+  githubFollowTemplateSpec,
   githubDeliveryOperationsForHandle,
   expandGithubSubscriptionShortcut,
   invokeGithubDeliveryOperation,
@@ -429,6 +431,74 @@ test("github subscription shortcut helpers expose and expand the builtin pr shor
       },
       {
         streamKind: "ci_runs",
+        filter: {
+          metadata: {
+            pullRequestNumbers: [74],
+          },
+        },
+        trackedResourceRef: "repo:holon-run/agentinbox:pr:74",
+        cleanupPolicy: { mode: "on_terminal" },
+      },
+    ],
+  });
+});
+
+test("github follow helpers expose templates and expand the builtin pr template", async () => {
+  assert.deepEqual(githubFollowTemplateSpec().map((template) => template.templateId), [
+    "github.repo",
+    "github.pr",
+    "github.issue",
+  ]);
+  const source: SourceStream = {
+    sourceId: "src_follow_template",
+    hostId: "hst_follow_template",
+    streamKind: "repo_events",
+    streamKey: "holon-run/agentinbox",
+    sourceType: "github_repo",
+    sourceKey: "holon-run/agentinbox",
+    config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    configRef: null,
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  assert.deepEqual(expandGithubFollowTemplate({
+    template: "pr",
+    args: { number: 74, withCi: true },
+    source,
+  }), {
+    templateId: "github.pr",
+    sources: [
+      {
+        logicalName: "repo_events",
+        sourceType: "github_repo",
+        sourceKey: "holon-run/agentinbox",
+        configRef: null,
+        config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+      },
+      {
+        logicalName: "ci_runs",
+        sourceType: "github_repo_ci",
+        sourceKey: "holon-run/agentinbox",
+        configRef: null,
+        config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+      },
+    ],
+    subscriptions: [
+      {
+        sourceLogicalName: "repo_events",
+        filter: {
+          metadata: {
+            number: 74,
+            isPullRequest: true,
+          },
+        },
+        trackedResourceRef: "repo:holon-run/agentinbox:pr:74",
+        cleanupPolicy: { mode: "on_terminal" },
+      },
+      {
+        sourceLogicalName: "ci_runs",
         filter: {
           metadata: {
             pullRequestNumbers: [74],


### PR DESCRIPTION
## Summary
- implement `follow` as a generic orchestration path above the existing host/source/subscription model
- expose follow template discovery in resolved schema and stream schema preview
- add GitHub builtin follow templates for repo, PR, and issue plus CLI and HTTP follow entrypoints

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern='follow|builtin remote-backed source details expose resolved remote identity|stream schema preview supports builtin remote-backed aliases without persisting a source|remote_source capability hooks override resolved schema fields and advertise shortcut/lifecycle support|github subscription shortcut helpers expose and expand the builtin pr shortcut' test/github.test.ts test/agentinbox.test.ts test/control_plane.test.ts`
- `node --require ts-node/register --test --test-force-exit test/github.test.ts test/agentinbox.test.ts test/control_plane.test.ts` (ran through the affected suites but did not exit cleanly after completion because a spawned CLI/daemon path stayed alive)

Closes #168.