### PR TITLE
fix: surface backend runtime in source views

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -9,6 +9,7 @@ import {
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
   SourcePollResult,
+  SourceRuntimeState,
   SourceStream,
   SourceType,
 } from "./model";
@@ -209,6 +210,17 @@ export class AdapterRegistry {
       return null;
     }
     return this.remoteSource.deriveNotificationGrouping(source, item);
+  }
+
+  async getSourceRuntime(source: SourceStream): Promise<SourceRuntimeState | null> {
+    if (source.sourceType === "local_event") {
+      return null;
+    }
+    return this.remoteSource.getSourceRuntime(source);
+  }
+
+  async listSourceRuntimes(sources: SourceStream[]): Promise<Map<string, SourceRuntimeState | null>> {
+    return this.remoteSource.listSourceRuntimes(sources);
   }
 
   async summarizeDigestThread(

--- a/src/http.ts
+++ b/src/http.ts
@@ -304,7 +304,7 @@ function buildFastifyServer(service: AgentInboxService) {
         },
       },
     },
-  }, async () => ({ sources: service.listSources() }));
+  }, async () => ({ sources: await service.listSourceViews() }));
 
   app.post("/sources", {
     schema: {

--- a/src/model.ts
+++ b/src/model.ts
@@ -46,6 +46,20 @@ export interface SourceStream {
   updatedAt: string;
 }
 
+export interface SourceRuntimeState {
+  backend: "uxc";
+  observation: "live" | "cached";
+  namespace: string;
+  sourceKey: string;
+  status?: string | null;
+  runId?: string | null;
+  streamId?: string | null;
+  lastError?: string | null;
+  updatedAt?: string | null;
+  startedAt?: string | null;
+  stoppedAt?: string | null;
+}
+
 export interface SourceIdleState {
   sourceId: string;
   idleSince: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -33,6 +33,7 @@ import {
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
   SourceHost,
+  SourceRuntimeState,
   SourceSchema,
   SourceSchemaPreview,
   SourcePollResult,
@@ -274,6 +275,10 @@ export class AgentInboxService {
     return this.store.listSources();
   }
 
+  async listSourceViews(): Promise<Array<SourceStream & { runtime: SourceRuntimeState | null }>> {
+    return this.attachSourceRuntimes(this.store.listSources());
+  }
+
   listHosts(): SourceHost[] {
     return this.store.listSourceHosts();
   }
@@ -321,8 +326,10 @@ export class AgentInboxService {
         ? schema
         : withResolvedIdentity(source.sourceId, fallbackSchema, resolvedIdentity))
       : fallbackSchema;
+    const runtime = await this.adapters.getSourceRuntime(source);
     return {
       source,
+      runtime,
       host: source.hostId ? this.store.getSourceHost(source.hostId) : null,
       resolvedIdentity,
       ...(resolutionError ? { resolutionError } : {}),
@@ -1780,7 +1787,8 @@ export class AgentInboxService {
     return this.adapters.invokeDeliveryOperation(source, handle, canonicalOperation.name, input, attempt);
   }
 
-  status(): Record<string, unknown> {
+  async status(): Promise<Record<string, unknown>> {
+    const sources = await this.listSourceViews();
     return {
       retention: {
         ackedInboxItemsMs: this.ackedRetentionMs,
@@ -1789,7 +1797,7 @@ export class AgentInboxService {
       },
       counts: this.store.getCounts(),
       agents: this.store.listAgents(),
-      sources: this.store.listSources(),
+      sources,
       subscriptions: this.store.listSubscriptions(),
       inboxes: this.store.listInboxes(),
       activationTargets: this.store.listActivationTargets(),
@@ -1805,6 +1813,16 @@ export class AgentInboxService {
         lastOfflineAgentGcAt: this.lastOfflineAgentGcAt > 0 ? new Date(this.lastOfflineAgentGcAt).toISOString() : null,
       },
     };
+  }
+
+  private async attachSourceRuntimes(
+    sources: SourceStream[],
+  ): Promise<Array<SourceStream & { runtime: SourceRuntimeState | null }>> {
+    const runtimes = await this.adapters.listSourceRuntimes(sources);
+    return sources.map((source) => ({
+      ...source,
+      runtime: runtimes.get(source.sourceId) ?? null,
+    }));
   }
 
   private ensureInboxForAgent(agentId: string): Inbox {

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -204,7 +204,7 @@ export class RemoteSourceRuntime {
     this.nextRetryAt.delete(sourceId);
     const checkpoint = parseRemoteCheckpoint(source.checkpoint);
     const pausedAt = nowIso();
-    const baseRuntime = checkpoint.managedRuntime ?? checkpointRuntimeFromSource(source) ?? {};
+    const baseRuntime = checkpoint.managedRuntime ?? checkpointRuntimeFromSource(source, checkpoint) ?? {};
     this.store.updateSourceRuntime(sourceId, {
       status: "paused",
       checkpoint: JSON.stringify({
@@ -511,7 +511,7 @@ export class RemoteSourceRuntime {
           checkpoint: JSON.stringify({
             ...checkpoint,
             managedRuntime: checkpointRuntimeWithError(
-              checkpoint.managedRuntime ?? checkpointRuntimeFromSource(source),
+              checkpoint.managedRuntime ?? checkpointRuntimeFromSource(source, checkpoint),
               error instanceof Error ? error.message : String(error),
               nowIso(),
             ),
@@ -693,8 +693,10 @@ function checkpointRuntimeWithError(
   };
 }
 
-function checkpointRuntimeFromSource(source: SourceStream): NonNullable<RemoteSourceCheckpoint["managedRuntime"]> | null {
-  const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+function checkpointRuntimeFromSource(
+  source: SourceStream,
+  checkpoint: RemoteSourceCheckpoint = parseRemoteCheckpoint(source.checkpoint),
+): NonNullable<RemoteSourceCheckpoint["managedRuntime"]> | null {
   if (checkpoint.managedRuntime) {
     return checkpoint.managedRuntime;
   }

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -1,5 +1,11 @@
-import { ManagedSourceEnsureResponse, ManagedStreamReadResponse, UxcDaemonClient } from "@holon-run/uxc-daemon-client";
-import { ActivationItem, AppendSourceEventInput, NotificationGrouping, SourcePollResult, SourceStream } from "../model";
+import {
+  ManagedSourceEnsureResponse,
+  ManagedSourceListEntry,
+  ManagedSourceView,
+  ManagedStreamReadResponse,
+  UxcDaemonClient,
+} from "@holon-run/uxc-daemon-client";
+import { ActivationItem, AppendSourceEventInput, NotificationGrouping, SourcePollResult, SourceRuntimeState, SourceStream } from "../model";
 import { resolveAgentInboxHome } from "../paths";
 import { AgentInboxStore } from "../store";
 import { nowIso } from "../util";
@@ -29,6 +35,15 @@ interface RemoteSourceCheckpoint {
     sourceKey: string;
     streamId: string;
   };
+  managedRuntime?: {
+    status?: string | null;
+    runId?: string | null;
+    streamId?: string | null;
+    lastError?: string | null;
+    updatedAt?: string | null;
+    startedAt?: string | null;
+    stoppedAt?: string | null;
+  };
   streamCursor?: {
     afterOffset: number;
   };
@@ -42,6 +57,8 @@ export interface UxcRemoteSourceClient {
     sourceKey: string;
     spec: ManagedSourceSpec;
   }): Promise<ManagedSourceEnsureResponse>;
+  sourceStatus(namespace: string, sourceKey: string): Promise<ManagedSourceView>;
+  sourceList(): Promise<ManagedSourceListEntry[]>;
   sourceStop(namespace: string, sourceKey: string): Promise<void>;
   sourceDelete(namespace: string, sourceKey: string): Promise<void>;
   streamRead(args: {
@@ -74,6 +91,14 @@ export class RpcUxcRemoteSourceClient implements UxcRemoteSourceClient {
 
   async sourceStop(namespace: string, sourceKey: string): Promise<void> {
     await this.client.sourceStop(namespace, sourceKey);
+  }
+
+  sourceStatus(namespace: string, sourceKey: string): Promise<ManagedSourceView> {
+    return this.client.sourceStatus(namespace, sourceKey);
+  }
+
+  sourceList(): Promise<ManagedSourceListEntry[]> {
+    return this.client.sourceList();
   }
 
   async sourceDelete(namespace: string, sourceKey: string): Promise<void> {
@@ -178,6 +203,8 @@ export class RemoteSourceRuntime {
     this.errorCounts.delete(sourceId);
     this.nextRetryAt.delete(sourceId);
     const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+    const pausedAt = nowIso();
+    const baseRuntime = checkpoint.managedRuntime ?? checkpointRuntimeFromSource(source) ?? {};
     this.store.updateSourceRuntime(sourceId, {
       status: "paused",
       checkpoint: JSON.stringify({
@@ -189,6 +216,13 @@ export class RemoteSourceRuntime {
             streamId: checkpoint.managedSource.streamId,
           },
         } : {}),
+        managedRuntime: {
+          ...baseRuntime,
+          status: "stopped",
+          updatedAt: pausedAt,
+          stoppedAt: pausedAt,
+          lastError: null,
+        },
         lastError: null,
       } satisfies RemoteSourceCheckpoint),
     });
@@ -216,6 +250,53 @@ export class RemoteSourceRuntime {
       activeSourceIds: Array.from(this.inFlight.values()).sort(),
       erroredSourceIds: Array.from(this.errorCounts.keys()).sort(),
     };
+  }
+
+  async getSourceRuntime(source: SourceStream): Promise<SourceRuntimeState | null> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return null;
+    }
+    const binding = managedBindingForSource(source);
+    try {
+      const managed = await this.client.sourceStatus(binding.namespace, binding.sourceKey);
+      return runtimeStateFromManagedView(managed, "live");
+    } catch {
+      return runtimeStateFromCheckpoint(source);
+    }
+  }
+
+  async listSourceRuntimes(sources: SourceStream[]): Promise<Map<string, SourceRuntimeState | null>> {
+    const result = new Map<string, SourceRuntimeState | null>();
+    const remoteSources = sources.filter((source) => REMOTE_SOURCE_TYPES.has(source.sourceType));
+    for (const source of sources) {
+      if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+        result.set(source.sourceId, null);
+      }
+    }
+    if (remoteSources.length === 0) {
+      return result;
+    }
+
+    try {
+      const managedSources = await this.client.sourceList();
+      const byBinding = new Map(
+        managedSources.map((entry) => [managedSourceBindingKey(entry.namespace, entry.source_key), entry] as const),
+      );
+      for (const source of remoteSources) {
+        const binding = managedBindingForSource(source);
+        const live = byBinding.get(managedSourceBindingKey(binding.namespace, binding.sourceKey));
+        result.set(
+          source.sourceId,
+          live ? runtimeStateFromManagedSourceListEntry(live, "live") : runtimeStateFromCheckpoint(source),
+        );
+      }
+      return result;
+    } catch {
+      for (const source of remoteSources) {
+        result.set(source.sourceId, runtimeStateFromCheckpoint(source));
+      }
+      return result;
+    }
   }
 
   async projectLifecycleSignal(source: SourceStream, rawPayload: Record<string, unknown>): Promise<LifecycleSignal | null> {
@@ -398,6 +479,11 @@ export class RemoteSourceRuntime {
           streamCursor: {
             afterOffset: batch.next_after_offset,
           },
+          managedRuntime: checkpointRuntimeFromEnsureResponse(
+            ensured,
+            checkpoint.managedRuntime ?? null,
+            nowIso(),
+          ),
           lastEventAt: nowIso(),
           lastError: null,
         } satisfies RemoteSourceCheckpoint),
@@ -424,6 +510,11 @@ export class RemoteSourceRuntime {
           status: source.status === "paused" ? "paused" : "error",
           checkpoint: JSON.stringify({
             ...checkpoint,
+            managedRuntime: checkpointRuntimeWithError(
+              checkpoint.managedRuntime ?? checkpointRuntimeFromSource(source),
+              error instanceof Error ? error.message : String(error),
+              nowIso(),
+            ),
             lastError: error instanceof Error ? error.message : String(error),
           } satisfies RemoteSourceCheckpoint),
         });
@@ -494,6 +585,10 @@ function managedBindingForSource(source: SourceStream): { namespace: string; sou
   };
 }
 
+function managedSourceBindingKey(namespace: string, sourceKey: string): string {
+  return `${namespace}:${sourceKey}`;
+}
+
 function parseRemoteCheckpoint(checkpoint: string | null | undefined): RemoteSourceCheckpoint {
   if (!checkpoint) {
     return {};
@@ -503,6 +598,125 @@ function parseRemoteCheckpoint(checkpoint: string | null | undefined): RemoteSou
   } catch {
     return {};
   }
+}
+
+function runtimeStateFromManagedView(
+  managed: ManagedSourceView,
+  observation: SourceRuntimeState["observation"],
+): SourceRuntimeState {
+  return {
+    backend: "uxc",
+    observation,
+    namespace: managed.namespace,
+    sourceKey: managed.source_key,
+    status: managed.status,
+    runId: managed.run_id,
+    streamId: managed.stream_id,
+    lastError: managed.last_error ?? null,
+    updatedAt: unixToIso(managed.updated_at_unix),
+    startedAt: unixToIso(managed.started_at_unix ?? null),
+    stoppedAt: unixToIso(managed.stopped_at_unix ?? null),
+  };
+}
+
+function runtimeStateFromManagedSourceListEntry(
+  managed: ManagedSourceListEntry,
+  observation: SourceRuntimeState["observation"],
+): SourceRuntimeState {
+  return {
+    backend: "uxc",
+    observation,
+    namespace: managed.namespace,
+    sourceKey: managed.source_key,
+    status: managed.status,
+    runId: managed.run_id,
+    streamId: managed.stream_id,
+    lastError: managed.last_error ?? null,
+    updatedAt: unixToIso(managed.updated_at_unix),
+    startedAt: null,
+    stoppedAt: null,
+  };
+}
+
+function runtimeStateFromCheckpoint(source: SourceStream): SourceRuntimeState | null {
+  const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+  const binding = managedBindingForSource(source);
+  const runtime = checkpoint.managedRuntime;
+  const streamId = runtime?.streamId ?? checkpoint.managedSource?.streamId ?? null;
+  if (!runtime && !checkpoint.managedSource) {
+    return null;
+  }
+  return {
+    backend: "uxc",
+    observation: "cached",
+    namespace: binding.namespace,
+    sourceKey: binding.sourceKey,
+    status: runtime?.status ?? null,
+    runId: runtime?.runId ?? null,
+    streamId,
+    lastError: runtime?.lastError ?? checkpoint.lastError ?? null,
+    updatedAt: runtime?.updatedAt ?? source.updatedAt,
+    startedAt: runtime?.startedAt ?? null,
+    stoppedAt: runtime?.stoppedAt ?? null,
+  };
+}
+
+function checkpointRuntimeFromEnsureResponse(
+  ensured: ManagedSourceEnsureResponse,
+  previous: RemoteSourceCheckpoint["managedRuntime"] | null,
+  observedAt: string,
+): NonNullable<RemoteSourceCheckpoint["managedRuntime"]> {
+  return {
+    status: ensured.status,
+    runId: ensured.run_id,
+    streamId: ensured.stream_id,
+    lastError: null,
+    updatedAt: observedAt,
+    startedAt: previous?.runId === ensured.run_id ? previous.startedAt ?? null : null,
+    stoppedAt: null,
+  };
+}
+
+function checkpointRuntimeWithError(
+  previous: RemoteSourceCheckpoint["managedRuntime"] | null,
+  lastError: string,
+  observedAt: string,
+): NonNullable<RemoteSourceCheckpoint["managedRuntime"]> {
+  return {
+    status: previous?.status ?? null,
+    runId: previous?.runId ?? null,
+    streamId: previous?.streamId ?? null,
+    lastError,
+    updatedAt: observedAt,
+    startedAt: previous?.startedAt ?? null,
+    stoppedAt: previous?.stoppedAt ?? null,
+  };
+}
+
+function checkpointRuntimeFromSource(source: SourceStream): NonNullable<RemoteSourceCheckpoint["managedRuntime"]> | null {
+  const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+  if (checkpoint.managedRuntime) {
+    return checkpoint.managedRuntime;
+  }
+  if (!checkpoint.managedSource) {
+    return null;
+  }
+  return {
+    status: null,
+    runId: null,
+    streamId: checkpoint.managedSource.streamId,
+    lastError: checkpoint.lastError ?? null,
+    updatedAt: source.updatedAt,
+    startedAt: null,
+    stoppedAt: null,
+  };
+}
+
+function unixToIso(value: number | null | undefined): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return new Date(value * 1000).toISOString();
 }
 
 function computeErrorBackoffMs(baseIntervalSecs: number, errorCount: number): number {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -106,6 +106,18 @@ class BlockingActivationGate implements ActivationGate {
 }
 
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
+  private readonly managedStatuses = new Map<string, {
+    namespace: string;
+    source_key: string;
+    run_id: string;
+    stream_id: string;
+    status: string;
+    updated_at_unix: number;
+    started_at_unix?: number | null;
+    stopped_at_unix?: number | null;
+    last_error?: string | null;
+  }>();
+
   async sourceEnsure(args: { namespace: string; sourceKey: string; spec: unknown }): Promise<{
     namespace: string;
     source_key: string;
@@ -116,7 +128,7 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
     replaced_previous: boolean;
   }> {
     void args.spec;
-    return {
+    const ensured = {
       namespace: args.namespace,
       source_key: args.sourceKey,
       run_id: `run:${args.sourceKey}`,
@@ -125,14 +137,78 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
       reused: true,
       replaced_previous: false,
     };
+    this.managedStatuses.set(`${args.namespace}:${args.sourceKey}`, {
+      ...ensured,
+      updated_at_unix: Math.floor(Date.now() / 1000),
+      started_at_unix: Math.floor(Date.now() / 1000),
+      stopped_at_unix: null,
+      last_error: null,
+    });
+    return ensured;
   }
 
   async sourceStop(_namespace: string, _sourceKey: string): Promise<void> {
+    const key = `${_namespace}:${_sourceKey}`;
+    const current = this.managedStatuses.get(key);
+    if (current) {
+      this.managedStatuses.set(key, {
+        ...current,
+        status: "stopped",
+        updated_at_unix: Math.floor(Date.now() / 1000),
+        stopped_at_unix: Math.floor(Date.now() / 1000),
+        last_error: null,
+      });
+    }
     return;
   }
 
   async sourceDelete(_namespace: string, _sourceKey: string): Promise<void> {
+    this.managedStatuses.delete(`${_namespace}:${_sourceKey}`);
     return;
+  }
+
+  async sourceStatus(namespace: string, sourceKey: string): Promise<{
+    namespace: string;
+    source_key: string;
+    run_id: string;
+    stream_id: string;
+    spec_key: string;
+    status: string;
+    created_at_unix: number;
+    updated_at_unix: number;
+    started_at_unix?: number | null;
+    stopped_at_unix?: number | null;
+    last_error?: string | null;
+  }> {
+    const current = this.managedStatuses.get(`${namespace}:${sourceKey}`);
+    if (!current) {
+      throw new Error(`unknown managed source: ${namespace}/${sourceKey}`);
+    }
+    return {
+      ...current,
+      spec_key: `${namespace}:${sourceKey}`,
+      created_at_unix: current.started_at_unix ?? current.updated_at_unix,
+    };
+  }
+
+  async sourceList(): Promise<Array<{
+    namespace: string;
+    source_key: string;
+    status: string;
+    run_id: string;
+    stream_id: string;
+    updated_at_unix: number;
+    last_error?: string | null;
+  }>> {
+    return Array.from(this.managedStatuses.values()).map((current) => ({
+      namespace: current.namespace,
+      source_key: current.source_key,
+      status: current.status,
+      run_id: current.run_id,
+      stream_id: current.stream_id,
+      updated_at_unix: current.updated_at_unix,
+      last_error: current.last_error ?? null,
+    }));
   }
 
   async streamRead(_args: { streamId: string; afterOffset?: number; limit?: number }): Promise<{

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -20,6 +20,47 @@ import { TerminalDispatcher } from "../src/terminal";
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   public readonly ensuredSources: Array<{ namespace: string; sourceKey: string }> = [];
   public readonly stoppedSources: Array<{ namespace: string; sourceKey: string }> = [];
+  private readonly managedStatuses = new Map<string, {
+    namespace: string;
+    source_key: string;
+    run_id: string;
+    stream_id: string;
+    status: string;
+    updated_at_unix: number;
+    started_at_unix?: number | null;
+    stopped_at_unix?: number | null;
+    last_error?: string | null;
+  }>();
+
+  setManagedStatus(namespace: string, sourceKey: string, input: {
+    status?: string;
+    lastError?: string | null;
+    updatedAtUnix?: number;
+    startedAtUnix?: number | null;
+    stoppedAtUnix?: number | null;
+  }): void {
+    const key = `${namespace}:${sourceKey}`;
+    const current = this.managedStatuses.get(key) ?? {
+      namespace,
+      source_key: sourceKey,
+      run_id: `run:${sourceKey}`,
+      stream_id: `stream:${sourceKey}`,
+      status: "running",
+      updated_at_unix: Math.floor(Date.now() / 1000),
+      started_at_unix: Math.floor(Date.now() / 1000),
+      stopped_at_unix: null,
+      last_error: null,
+    };
+    this.managedStatuses.set(key, {
+      ...current,
+      status: input.status ?? current.status,
+      last_error: input.lastError !== undefined ? input.lastError : current.last_error ?? null,
+      updated_at_unix: input.updatedAtUnix ?? current.updated_at_unix,
+      started_at_unix: input.startedAtUnix !== undefined ? input.startedAtUnix : current.started_at_unix ?? null,
+      stopped_at_unix: input.stoppedAtUnix !== undefined ? input.stoppedAtUnix : current.stopped_at_unix ?? null,
+    });
+  }
+
   async sourceEnsure(args: { namespace: string; sourceKey: string; spec: unknown }): Promise<{
     namespace: string;
     source_key: string;
@@ -31,7 +72,7 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   }> {
     void args.spec;
     this.ensuredSources.push({ namespace: args.namespace, sourceKey: args.sourceKey });
-    return {
+    const ensured = {
       namespace: args.namespace,
       source_key: args.sourceKey,
       run_id: `run:${args.sourceKey}`,
@@ -40,15 +81,78 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
       reused: true,
       replaced_previous: false,
     };
+    this.managedStatuses.set(`${args.namespace}:${args.sourceKey}`, {
+      ...ensured,
+      updated_at_unix: Math.floor(Date.now() / 1000),
+      started_at_unix: Math.floor(Date.now() / 1000),
+      stopped_at_unix: null,
+      last_error: null,
+    });
+    return ensured;
   }
 
   async sourceStop(namespace: string, sourceKey: string): Promise<void> {
     this.stoppedSources.push({ namespace, sourceKey });
+    const current = this.managedStatuses.get(`${namespace}:${sourceKey}`);
+    if (current) {
+      this.managedStatuses.set(`${namespace}:${sourceKey}`, {
+        ...current,
+        status: "stopped",
+        updated_at_unix: Math.floor(Date.now() / 1000),
+        stopped_at_unix: Math.floor(Date.now() / 1000),
+        last_error: null,
+      });
+    }
     return;
   }
 
   async sourceDelete(_namespace: string, _sourceKey: string): Promise<void> {
+    this.managedStatuses.delete(`${_namespace}:${_sourceKey}`);
     return;
+  }
+
+  async sourceStatus(namespace: string, sourceKey: string): Promise<{
+    namespace: string;
+    source_key: string;
+    run_id: string;
+    stream_id: string;
+    spec_key: string;
+    status: string;
+    created_at_unix: number;
+    updated_at_unix: number;
+    started_at_unix?: number | null;
+    stopped_at_unix?: number | null;
+    last_error?: string | null;
+  }> {
+    const current = this.managedStatuses.get(`${namespace}:${sourceKey}`);
+    if (!current) {
+      throw new Error(`unknown managed source: ${namespace}/${sourceKey}`);
+    }
+    return {
+      ...current,
+      spec_key: `${namespace}:${sourceKey}`,
+      created_at_unix: current.started_at_unix ?? current.updated_at_unix,
+    };
+  }
+
+  async sourceList(): Promise<Array<{
+    namespace: string;
+    source_key: string;
+    status: string;
+    run_id: string;
+    stream_id: string;
+    updated_at_unix: number;
+    last_error?: string | null;
+  }>> {
+    return Array.from(this.managedStatuses.values()).map((current) => ({
+      namespace: current.namespace,
+      source_key: current.source_key,
+      status: current.status,
+      run_id: current.run_id,
+      stream_id: current.stream_id,
+      updated_at_unix: current.updated_at_unix,
+      last_error: current.last_error ?? null,
+    }));
   }
 
   async streamRead(_args: { streamId: string; afterOffset?: number; limit?: number }): Promise<{
@@ -648,6 +752,138 @@ test("control plane GET /agents can include activation target summaries", async 
       assert.equal(listed.activationTargets[1]?.kind, "webhook");
       assert.equal(listed.activationTargets[1]?.status, "active");
       assert.equal("url" in (listed.activationTargets[1] ?? {}), false);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane source views surface backend managed runtime state", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-source-runtime-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const fake = new FakeRemoteSourceClient();
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
+    homeDir,
+    remoteSourceClient: fake,
+  });
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    const source = await service.registerSource({
+      sourceType: "github_repo",
+      sourceKey: "holon-run/agentinbox",
+      config: { owner: "holon-run", repo: "agentinbox", uxcAuth: "github-default" },
+    });
+
+    await adapters.start();
+    await service.start();
+    fake.setManagedStatus("agentinbox", "github_repo:holon-run/agentinbox", {
+      status: "starting",
+      lastError: "warming up",
+      updatedAtUnix: 1713139200,
+      startedAtUnix: 1713139100,
+    });
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const listed = await client.request<{
+        sources: Array<{
+          sourceId: string;
+          status: string;
+          runtime?: {
+            backend: string;
+            observation: string;
+            namespace: string;
+            sourceKey: string;
+            status: string;
+            runId: string;
+            streamId: string;
+            lastError: string | null;
+            updatedAt: string | null;
+          } | null;
+        }>;
+      }>("/sources", undefined, "GET");
+      assert.equal(listed.statusCode, 200);
+      const listedSource = listed.data.sources.find((entry) => entry.sourceId === source.sourceId);
+      assert.ok(listedSource);
+      assert.equal(listedSource?.status, "active");
+      assert.equal(listedSource?.runtime?.backend, "uxc");
+      assert.equal(listedSource?.runtime?.observation, "live");
+      assert.equal(listedSource?.runtime?.namespace, "agentinbox");
+      assert.equal(listedSource?.runtime?.sourceKey, "github_repo:holon-run/agentinbox");
+      assert.equal(listedSource?.runtime?.status, "starting");
+      assert.equal(listedSource?.runtime?.runId, "run:github_repo:holon-run/agentinbox");
+      assert.equal(listedSource?.runtime?.streamId, "stream:github_repo:holon-run/agentinbox");
+      assert.equal(listedSource?.runtime?.lastError, "warming up");
+      assert.equal(listedSource?.runtime?.updatedAt, "2024-04-15T00:00:00.000Z");
+
+      const details = await client.request<{
+        source: { sourceId: string; status: string };
+        runtime?: {
+          backend: string;
+          observation: string;
+          namespace: string;
+          sourceKey: string;
+          status: string;
+          runId: string;
+          streamId: string;
+          lastError: string | null;
+          updatedAt: string | null;
+        } | null;
+      }>(`/sources/${encodeURIComponent(source.sourceId)}`, undefined, "GET");
+      assert.equal(details.statusCode, 200);
+      assert.equal(details.data.source.sourceId, source.sourceId);
+      assert.equal(details.data.source.status, "active");
+      assert.equal(details.data.runtime?.backend, "uxc");
+      assert.equal(details.data.runtime?.observation, "live");
+      assert.equal(details.data.runtime?.namespace, "agentinbox");
+      assert.equal(details.data.runtime?.sourceKey, "github_repo:holon-run/agentinbox");
+      assert.equal(details.data.runtime?.status, "starting");
+      assert.equal(details.data.runtime?.runId, "run:github_repo:holon-run/agentinbox");
+      assert.equal(details.data.runtime?.streamId, "stream:github_repo:holon-run/agentinbox");
+      assert.equal(details.data.runtime?.lastError, "warming up");
+      assert.equal(details.data.runtime?.updatedAt, "2024-04-15T00:00:00.000Z");
+
+      const status = await client.request<{
+        sources: Array<{
+          sourceId: string;
+          runtime?: {
+            backend: string;
+            observation: string;
+            namespace: string;
+            sourceKey: string;
+            status: string;
+            runId: string;
+            streamId: string;
+            lastError: string | null;
+            updatedAt: string | null;
+          } | null;
+        }>;
+      }>("/status", undefined, "GET");
+      assert.equal(status.statusCode, 200);
+      const statusSource = status.data.sources.find((entry) => entry.sourceId === source.sourceId);
+      assert.ok(statusSource);
+      assert.equal(statusSource?.runtime?.backend, "uxc");
+      assert.equal(statusSource?.runtime?.observation, "live");
+      assert.equal(statusSource?.runtime?.namespace, "agentinbox");
+      assert.equal(statusSource?.runtime?.sourceKey, "github_repo:holon-run/agentinbox");
+      assert.equal(statusSource?.runtime?.status, "starting");
+      assert.equal(statusSource?.runtime?.runId, "run:github_repo:holon-run/agentinbox");
+      assert.equal(statusSource?.runtime?.streamId, "stream:github_repo:holon-run/agentinbox");
+      assert.equal(statusSource?.runtime?.lastError, "warming up");
+      assert.equal(statusSource?.runtime?.updatedAt, "2024-04-15T00:00:00.000Z");
     } finally {
       await started.close();
     }

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -18,6 +18,17 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   private readonly offsets = new Map<string, number>();
   private readonly streamSpecs = new Map<string, ManagedSourceSpec>();
   private readonly streamCheckpointKeys = new Map<string, string[]>();
+  private readonly managedStatuses = new Map<string, {
+    namespace: string;
+    source_key: string;
+    run_id: string;
+    stream_id: string;
+    status: string;
+    updated_at_unix: number;
+    started_at_unix?: number | null;
+    stopped_at_unix?: number | null;
+    last_error?: string | null;
+  }>();
   public readonly ensuredSources: Array<{ namespace: string; sourceKey: string }> = [];
   public readonly stoppedSources: Array<{ namespace: string; sourceKey: string }> = [];
   public readonly deletedSources: Array<{ namespace: string; sourceKey: string }> = [];
@@ -48,7 +59,7 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
     this.ensuredSources.push({ namespace: args.namespace, sourceKey: args.sourceKey });
     const streamId = `stream:${args.sourceKey}`;
     this.streamSpecs.set(streamId, args.spec);
-    return {
+    const ensured = {
       namespace: args.namespace,
       source_key: args.sourceKey,
       run_id: `run:${args.sourceKey}`,
@@ -57,16 +68,79 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
       reused: true,
       replaced_previous: false,
     };
+    this.managedStatuses.set(`${args.namespace}:${args.sourceKey}`, {
+      ...ensured,
+      updated_at_unix: Math.floor(Date.now() / 1000),
+      started_at_unix: Math.floor(Date.now() / 1000),
+      stopped_at_unix: null,
+      last_error: null,
+    });
+    return ensured;
   }
 
   async sourceStop(namespace: string, sourceKey: string): Promise<void> {
     this.stoppedSources.push({ namespace, sourceKey });
+    const current = this.managedStatuses.get(`${namespace}:${sourceKey}`);
+    if (current) {
+      this.managedStatuses.set(`${namespace}:${sourceKey}`, {
+        ...current,
+        status: "stopped",
+        updated_at_unix: Math.floor(Date.now() / 1000),
+        stopped_at_unix: Math.floor(Date.now() / 1000),
+        last_error: null,
+      });
+    }
     return;
   }
 
   async sourceDelete(namespace: string, sourceKey: string): Promise<void> {
     this.deletedSources.push({ namespace, sourceKey });
+    this.managedStatuses.delete(`${namespace}:${sourceKey}`);
     return;
+  }
+
+  async sourceStatus(namespace: string, sourceKey: string): Promise<{
+    namespace: string;
+    source_key: string;
+    run_id: string;
+    stream_id: string;
+    spec_key: string;
+    status: string;
+    created_at_unix: number;
+    updated_at_unix: number;
+    started_at_unix?: number | null;
+    stopped_at_unix?: number | null;
+    last_error?: string | null;
+  }> {
+    const current = this.managedStatuses.get(`${namespace}:${sourceKey}`);
+    if (!current) {
+      throw new Error(`unknown managed source: ${namespace}/${sourceKey}`);
+    }
+    return {
+      ...current,
+      spec_key: `${namespace}:${sourceKey}`,
+      created_at_unix: current.started_at_unix ?? current.updated_at_unix,
+    };
+  }
+
+  async sourceList(): Promise<Array<{
+    namespace: string;
+    source_key: string;
+    status: string;
+    run_id: string;
+    stream_id: string;
+    updated_at_unix: number;
+    last_error?: string | null;
+  }>> {
+    return Array.from(this.managedStatuses.values()).map((current) => ({
+      namespace: current.namespace,
+      source_key: current.source_key,
+      status: current.status,
+      run_id: current.run_id,
+      stream_id: current.stream_id,
+      updated_at_unix: current.updated_at_unix,
+      last_error: current.last_error ?? null,
+    }));
   }
 
   async streamRead(args: { streamId: string; afterOffset?: number; limit?: number }): Promise<{
@@ -842,7 +916,7 @@ test("pauseSource stops managed source, preserves binding, and resume re-ensures
     }]);
     assert.equal(remoteRuntime.errorCounts.has(source.sourceId), false);
     assert.equal(remoteRuntime.nextRetryAt.has(source.sourceId), false);
-    assert.deepEqual((service.status().adapters as { remote: { erroredSourceIds: string[] } }).remote.erroredSourceIds, []);
+    assert.deepEqual(((await service.status()).adapters as { remote: { erroredSourceIds: string[] } }).remote.erroredSourceIds, []);
 
     const pausedPoll = await service.pollSource(source.sourceId);
     assert.equal(pausedPoll.note, "source is paused; resume it before polling");


### PR DESCRIPTION
## Summary
- surface UXC managed-source runtime metadata on source list, source show, and global status views without replacing the existing local source lifecycle state
- cache managed runtime details in remote-source checkpoints so AgentInbox can still show the last observed backend status when live UXC status calls fail
- add control-plane coverage for the new runtime fields and extend remote-source test fakes to model managed runtime state

## Verification
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern='source views surface backend managed runtime state|pauseSource stops managed source, preserves binding, and resume re-ensures it' test/control_plane.test.ts test/remote_source.test.ts`

Closes #170
