### PR TITLE
chore: upgrade uxc dependency baseline to v0.15.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ database.
 Requires:
 
 - Node.js 20 or newer
-- `uxc` 0.15.0 or newer if you want to use GitHub or Feishu adapters:
+- `uxc` 0.15.3 or newer if you want to use GitHub or Feishu adapters:
   https://github.com/holon-run/uxc
 
 Install globally:

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -10,7 +10,7 @@ is the preferred first-run path.
 ## Prerequisites
 
 - Node.js 20 or newer
-- `uxc` 0.15.0 or newer if you want to use GitHub or Feishu source adapters:
+- `uxc` 0.15.3 or newer if you want to use GitHub or Feishu source adapters:
   https://github.com/holon-run/uxc
 
 Install `AgentInbox` globally:

--- a/docs/site/guides/onboarding-with-agent-skill.md
+++ b/docs/site/guides/onboarding-with-agent-skill.md
@@ -54,7 +54,7 @@ If GitHub auth should be reused from `gh`:
 uxc auth credential import github --from gh
 ```
 
-This requires `uxc` 0.15.0 or newer:
+This requires `uxc` 0.15.3 or newer:
 
 - https://github.com/holon-run/uxc
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/swagger": "^9.5.2",
-        "@holon-run/uxc-daemon-client": "^0.15.0",
+        "@holon-run/uxc-daemon-client": "^0.15.3",
         "fastify": "^5.6.1",
         "jexl": "^2.3.0",
         "sql.js": "^1.13.0"
@@ -637,9 +637,9 @@
       }
     },
     "node_modules/@holon-run/uxc-daemon-client": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.15.0.tgz",
-      "integrity": "sha512-LuXItNXN4NIGE7tRc9XAd6qLkf8Rfve+tiK6tSLVysGjjvoEkl8uHg5GROFqk+WbEWoYmAuv7ByOhqMFN+nt4A==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.15.3.tgz",
+      "integrity": "sha512-YXKohCtKmmYU/LvwLFsDwCtdiHJbLPTlmmk9+1tOihtFEoikQwByNM22G9dxWjPu/B8JX3xUehIHHGDvXB8mWw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -826,6 +826,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -836,6 +837,7 @@
       "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/emscripten": "*",
         "@types/node": "*"
@@ -3614,7 +3616,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
       "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -3754,6 +3757,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@fastify/swagger": "^9.5.2",
-    "@holon-run/uxc-daemon-client": "^0.15.0",
+    "@holon-run/uxc-daemon-client": "^0.15.3",
     "fastify": "^5.6.1",
     "jexl": "^2.3.0",
     "sql.js": "^1.13.0"

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -66,7 +66,7 @@ gh auth status
 uxc auth credential import github --from gh
 ```
 
-This `gh` import path requires `uxc` 0.15.0 or newer.
+This `gh` import path requires `uxc` 0.15.3 or newer.
 
 Register the current terminal/runtime session:
 


### PR DESCRIPTION
## Summary
- bump `@holon-run/uxc-daemon-client` from the `0.15.0` baseline to `^0.15.3`
- refresh the lockfile to resolve `@holon-run/uxc-daemon-client` `0.15.3`
- update repo docs that describe the minimum supported `uxc` version

## Verification
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern='follow github pr ensures sources and dedupes subscriptions|control plane source views surface backend managed runtime state|pauseSource stops managed source, preserves binding, and resume re-ensures it' test/agentinbox.test.ts test/control_plane.test.ts test/remote_source.test.ts`

Closes #173
