### PR TITLE
feat: include latest notified entry ids in notifications

### DIFF
--- a/drizzle/migrations/0001_activation_entry_boundary.sql
+++ b/drizzle/migrations/0001_activation_entry_boundary.sql
@@ -1,0 +1,11 @@
+alter table activations add column latest_entry_id text;
+alter table activations add column new_entry_count integer not null default 0;
+
+update activations
+set latest_entry_id = (
+  select json_extract(items_json, '$[#-1].entryId')
+),
+new_entry_count = case
+  when items_json is not null then json_array_length(items_json)
+  else new_item_count
+end;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -259,6 +259,8 @@ export const activations = sqliteTable("activations", {
   targetKind: text("target_kind").notNull(),
   subscriptionIdsJson: text("subscription_ids_json").notNull(),
   sourceIdsJson: text("source_ids_json").notNull(),
+  latestEntryId: text("latest_entry_id"),
+  newEntryCount: integer("new_entry_count").notNull(),
   newItemCount: integer("new_item_count").notNull(),
   summary: text("summary").notNull(),
   itemsJson: text("items_json"),

--- a/src/model.ts
+++ b/src/model.ts
@@ -280,6 +280,7 @@ export interface Activation {
   targetKind: ActivationTargetKind;
   subscriptionIds: string[];
   sourceIds: string[];
+  latestEntryId: string | null;
   newEntryCount: number;
   newItemCount: number;
   summary: string;

--- a/src/service.ts
+++ b/src/service.ts
@@ -2759,6 +2759,7 @@ export class AgentInboxService {
           targetKind: target.kind,
           subscriptionIds: input.subscriptionIds,
           sourceIds: input.sourceIds,
+          latestEntryId: latestEntryIdForNotification(input.entries),
           newEntryCount: input.entries.length,
           newItemCount: input.newItemCount,
           summary,
@@ -2905,6 +2906,7 @@ export class AgentInboxService {
       totalUnackedCount,
       summary,
       preview,
+      latestEntryId: latestEntryIdForNotification(entries),
     });
     return {
       prompt,
@@ -3925,6 +3927,10 @@ function summarizeActivation(inboxId: string, newItemCount: number, firstSummary
     return `${newItemCount} new ${itemWord} in ${inboxId} from ${firstSummary}`;
   }
   return `${newItemCount} new ${itemWord} in ${inboxId}`;
+}
+
+function latestEntryIdForNotification(entries: InboxEntry[]): string | null {
+  return entries.length > 0 ? entries[entries.length - 1]?.entryId ?? null : null;
 }
 
 function latestSummary(entries: Array<{ summary: string | null }>): string | null {

--- a/src/store.ts
+++ b/src/store.ts
@@ -2427,6 +2427,7 @@ export class AgentInboxStore {
   }
 
   private mapActivation(row: Record<string, unknown>): Activation {
+    const entries = row.items_json ? parseJson<Activation["entries"]>(row.items_json as string) : undefined;
     return {
       kind: "agentinbox.activation",
       activationId: String(row.activation_id),
@@ -2436,10 +2437,11 @@ export class AgentInboxStore {
       targetKind: row.target_kind as Activation["targetKind"],
       subscriptionIds: parseJson<string[]>(row.subscription_ids_json as string),
       sourceIds: parseJson<string[]>(row.source_ids_json as string),
-      newEntryCount: row.items_json ? parseJson<Activation["entries"]>(row.items_json as string)?.length ?? 0 : Number(row.new_item_count),
+      latestEntryId: entries && entries.length > 0 ? entries[entries.length - 1]?.entryId ?? null : null,
+      newEntryCount: entries?.length ?? Number(row.new_item_count),
       newItemCount: Number(row.new_item_count),
       summary: String(row.summary),
-      entries: row.items_json ? parseJson<Activation["entries"]>(row.items_json as string) : undefined,
+      entries,
       createdAt: String(row.created_at),
       deliveredAt: row.delivered_at ? String(row.delivered_at) : null,
     };

--- a/src/store.ts
+++ b/src/store.ts
@@ -1801,8 +1801,8 @@ export class AgentInboxStore {
       `
       insert into activations (
         activation_id, kind, agent_id, inbox_id, target_id, target_kind,
-        subscription_ids_json, source_ids_json, new_item_count, summary, items_json, created_at, delivered_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        subscription_ids_json, source_ids_json, latest_entry_id, new_entry_count, new_item_count, summary, items_json, created_at, delivered_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         activation.activationId,
@@ -1813,6 +1813,8 @@ export class AgentInboxStore {
         activation.targetKind,
         JSON.stringify(activation.subscriptionIds),
         JSON.stringify(activation.sourceIds),
+        activation.latestEntryId,
+        activation.newEntryCount,
         activation.newItemCount,
         activation.summary,
         activation.entries ? JSON.stringify(activation.entries) : (activation.items ? JSON.stringify(activation.items) : null),
@@ -2437,8 +2439,8 @@ export class AgentInboxStore {
       targetKind: row.target_kind as Activation["targetKind"],
       subscriptionIds: parseJson<string[]>(row.subscription_ids_json as string),
       sourceIds: parseJson<string[]>(row.source_ids_json as string),
-      latestEntryId: entries && entries.length > 0 ? entries[entries.length - 1]?.entryId ?? null : null,
-      newEntryCount: entries?.length ?? Number(row.new_item_count),
+      latestEntryId: row.latest_entry_id == null ? null : String(row.latest_entry_id),
+      newEntryCount: Number(row.new_entry_count ?? (entries?.length ?? row.new_item_count ?? 0)),
       newItemCount: Number(row.new_item_count),
       summary: String(row.summary),
       entries,

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -92,18 +92,20 @@ export function renderAgentPrompt(input: {
   totalUnackedCount: number;
   summary?: string | null;
   preview?: string | null;
+  latestEntryId?: string | null;
 }): string {
   const totalUnackedCount = input.totalUnackedCount;
   const itemWord = totalUnackedCount === 1 ? "item" : "items";
   const base = `AgentInbox: ${totalUnackedCount} unacked ${itemWord} in inbox ${input.inboxId}.`;
+  const latestEntryIdSuffix = input.latestEntryId ? ` Latest entryId: ${input.latestEntryId}.` : "";
   if (totalUnackedCount === 1 && input.preview) {
     const suffix = /(?:[.!?…]|\.{3})$/.test(input.preview) ? "" : ".";
-    return `${base} Preview: ${input.preview}${suffix} Read the inbox for full details if needed.`;
+    return `${base}${latestEntryIdSuffix} Preview: ${input.preview}${suffix} Read the inbox for full details if needed.`;
   }
   if (input.summary) {
-    return `${base} Summary: ${input.summary}. Please read the inbox, process them, and ack when finished.`;
+    return `${base}${latestEntryIdSuffix} Summary: ${input.summary}. Please read the inbox, process them, and ack when finished.`;
   }
-  return `${base} Please read the inbox, process them, and ack when finished.`;
+  return `${base}${latestEntryIdSuffix} Please read the inbox, process them, and ack when finished.`;
 }
 
 const MAX_INLINE_PREVIEW_INPUT_CHARS = 240;

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -3159,6 +3159,7 @@ test("direct inbox text messages create inbox items and trigger activation", asy
     assert.equal(dispatcher.calls.length, 1);
     assert.equal(dispatcher.calls[0].activation.agentId, alpha.agentId);
     assert.equal(dispatcher.calls[0].activation.newItemCount, 1);
+    assert.ok(dispatcher.calls[0].activation.latestEntryId);
     assert.equal(dispatcher.calls[0].activation.items?.[0]?.itemId, delivered.itemId);
     assert.match(dispatcher.calls[0].activation.summary, /from direct_text_message:/);
   } finally {
@@ -3637,6 +3638,8 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
 
     assert.equal(dispatcher.calls.length, 1);
     assert.equal(terminalDispatcher.calls.length, 1);
+    assert.equal(dispatcher.calls[0].activation.latestEntryId, dispatcher.calls[0].activation.entries?.[0]?.entryId ?? null);
+    assert.match(terminalDispatcher.calls[0]!.prompt, /Latest entryId: ent_/);
 
     await service.appendSourceEventByCaller(source.sourceId, {
       sourceNativeId: "evt-2",

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -503,6 +503,7 @@ test("store reopens an existing v1 database without archiving it", async () => {
     const state = await readMigrationState(dbPath);
     assert.deepEqual(state.appliedTags, [
       "0000_v1_initial",
+      "0001_activation_entry_boundary",
       "0002_host_scoped_lifecycle_retirements",
       "0003_subscription_tracked_resource_indexes",
     ]);
@@ -531,6 +532,7 @@ test("store archives a pre-v1 database and starts fresh with the v1 baseline", a
     const state = await readMigrationState(dbPath);
     assert.deepEqual(state.appliedTags, [
       "0000_v1_initial",
+      "0001_activation_entry_boundary",
       "0002_host_scoped_lifecycle_retirements",
       "0003_subscription_tracked_resource_indexes",
     ]);
@@ -557,6 +559,7 @@ test("store upgrades source-scoped lifecycle retirements to host-scoped retireme
     const state = await readMigrationState(dbPath);
     assert.deepEqual(state.appliedTags, [
       "0000_v1_initial",
+      "0001_activation_entry_boundary",
       "0002_host_scoped_lifecycle_retirements",
       "0003_subscription_tracked_resource_indexes",
     ]);

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -472,6 +472,7 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
     const state = await readMigrationState(dbPath);
     assert.deepEqual(state.appliedTags, [
       "0000_v1_initial",
+      "0001_activation_entry_boundary",
       "0002_host_scoped_lifecycle_retirements",
       "0003_subscription_tracked_resource_indexes",
     ]);
@@ -3162,6 +3163,7 @@ test("direct inbox text messages create inbox items and trigger activation", asy
     assert.ok(dispatcher.calls[0].activation.latestEntryId);
     assert.equal(dispatcher.calls[0].activation.items?.[0]?.itemId, delivered.itemId);
     assert.match(dispatcher.calls[0].activation.summary, /from direct_text_message:/);
+    assert.equal(store.listActivations()[0]?.latestEntryId, dispatcher.calls[0].activation.latestEntryId);
   } finally {
     await service.stop();
     store.close();
@@ -3638,7 +3640,11 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
 
     assert.equal(dispatcher.calls.length, 1);
     assert.equal(terminalDispatcher.calls.length, 1);
-    assert.equal(dispatcher.calls[0].activation.latestEntryId, dispatcher.calls[0].activation.entries?.[0]?.entryId ?? null);
+    const activationEntries = dispatcher.calls[0].activation.entries ?? [];
+    assert.equal(
+      dispatcher.calls[0].activation.latestEntryId,
+      activationEntries.length > 0 ? activationEntries[activationEntries.length - 1]?.entryId ?? null : null,
+    );
     assert.match(terminalDispatcher.calls[0]!.prompt, /Latest entryId: ent_/);
 
     await service.appendSourceEventByCaller(source.sourceId, {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -2774,6 +2774,7 @@ test("e2e control plane can register an agent, route events, watch inbox, and se
       assert.equal(activation.agentId, agentId);
       assert.equal(activation.targetKind, "webhook");
       assert.equal(activation.newItemCount, 1);
+      assert.ok(activation.latestEntryId);
 
       const inboxResponse = await client.request<{ entries: Array<{ entryId: string }> }>(
         `/agents/${encodeURIComponent(agentId)}/inbox/entries`,

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -47,11 +47,12 @@ test("renderAgentPrompt renders a single-item prompt without preview text", () =
   const prompt = renderAgentPrompt({
     inboxId: "inbox_123",
     totalUnackedCount: 1,
+    latestEntryId: "ent_abc123",
   });
 
   assert.equal(
     prompt,
-    "AgentInbox: 1 unacked item in inbox inbox_123. Please read the inbox, process them, and ack when finished.",
+    "AgentInbox: 1 unacked item in inbox inbox_123. Latest entryId: ent_abc123. Please read the inbox, process them, and ack when finished.",
   );
 });
 
@@ -60,11 +61,12 @@ test("renderAgentPrompt includes inline preview for single-item prompts", () => 
     inboxId: "inbox_123",
     totalUnackedCount: 1,
     preview: "Review PR #51 CI failure and push a fix",
+    latestEntryId: "ent_abc123",
   });
 
   assert.equal(
     prompt,
-    "AgentInbox: 1 unacked item in inbox inbox_123. Preview: Review PR #51 CI failure and push a fix. Read the inbox for full details if needed.",
+    "AgentInbox: 1 unacked item in inbox inbox_123. Latest entryId: ent_abc123. Preview: Review PR #51 CI failure and push a fix. Read the inbox for full details if needed.",
   );
 });
 
@@ -73,11 +75,12 @@ test("renderAgentPrompt does not add duplicate punctuation after previews", () =
     inboxId: "inbox_123",
     totalUnackedCount: 1,
     preview: "Review PR #51 CI failure and push a fix...",
+    latestEntryId: "ent_abc123",
   });
 
   assert.equal(
     prompt,
-    "AgentInbox: 1 unacked item in inbox inbox_123. Preview: Review PR #51 CI failure and push a fix... Read the inbox for full details if needed.",
+    "AgentInbox: 1 unacked item in inbox inbox_123. Latest entryId: ent_abc123. Preview: Review PR #51 CI failure and push a fix... Read the inbox for full details if needed.",
   );
 });
 


### PR DESCRIPTION
## Summary
- include the latest notified inbox `entryId` in structured activation payloads as `latestEntryId`
- include the same boundary in terminal notification text via a stable `Latest entryId: ...` field
- extend notification-path tests so agents can ack directly from webhook/terminal notifications without an extra inbox read

## Verification
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern='renderAgentPrompt|direct inbox text messages create inbox items and trigger activation|webhook and terminal targets share ack-gated notification flow|e2e control plane can register an agent, route events, watch inbox, and send aggregated activation webhook|single preview-friendly unacked item is inlined into the terminal prompt' test/terminal.test.ts test/agentinbox.test.ts test/control_plane.test.ts`

Closes #171
