### PR TITLE
feat: support webhook-only agent registration

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -395,9 +395,33 @@ async function main(): Promise<void> {
   }
 
   if (command === "agent" && normalized[1] === "register") {
+    const agentId = takeFlagValue(normalized, "--agent-id") ?? undefined;
+    const notifyLeaseMs = parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? undefined;
+    const minUnackedItems = parseOptionalNumber(takeFlagValue(normalized, "--min-unacked-items")) ?? undefined;
+    const webhookUrl = takeFlagValue(normalized, "--webhook-url");
+    if (webhookUrl) {
+      const webhookNotifyLeaseMs = parseOptionalNumber(
+        takeFlagValue(normalized, "--webhook-notify-lease-ms"),
+      ) ?? notifyLeaseMs;
+      const webhookMinUnackedItems = parseOptionalNumber(
+        takeFlagValue(normalized, "--webhook-min-unacked-items"),
+      ) ?? minUnackedItems;
+      await printRemote(client, "/agents", {
+        agentId,
+        forceRebind: normalized.includes("--force-rebind"),
+        webhook: {
+          url: webhookUrl,
+          activationMode: takeFlagValue(normalized, "--webhook-activation-mode") ?? undefined,
+          notifyLeaseMs: webhookNotifyLeaseMs,
+          minUnackedItems: webhookMinUnackedItems,
+        },
+      });
+      return;
+    }
+
     const detected = detectTerminalContext(process.env);
     await printRemote(client, "/agents", {
-      agentId: takeFlagValue(normalized, "--agent-id") ?? undefined,
+      agentId,
       forceRebind: normalized.includes("--force-rebind"),
       backend: detected.backend,
       runtimeKind: detected.runtimeKind,
@@ -407,8 +431,8 @@ async function main(): Promise<void> {
       tty: detected.tty ?? undefined,
       termProgram: detected.termProgram ?? undefined,
       itermSessionId: detected.itermSessionId ?? undefined,
-      notifyLeaseMs: parseOptionalNumber(takeFlagValue(normalized, "--notify-lease-ms")) ?? undefined,
-      minUnackedItems: parseOptionalNumber(takeFlagValue(normalized, "--min-unacked-items")) ?? undefined,
+      notifyLeaseMs,
+      minUnackedItems,
     });
     return;
   }
@@ -1456,6 +1480,7 @@ Usage:
 
 Usage:
   agentinbox agent register [--agent-id ID] [--force-rebind] [--notify-lease-ms N] [--min-unacked-items N]
+  agentinbox agent register --agent-id ID --webhook-url URL [--webhook-activation-mode MODE] [--webhook-notify-lease-ms N] [--webhook-min-unacked-items N]
   agentinbox agent list
   agentinbox agent current
   agentinbox agent show <agentId>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -400,6 +400,11 @@ async function main(): Promise<void> {
     const minUnackedItems = parseOptionalNumber(takeFlagValue(normalized, "--min-unacked-items")) ?? undefined;
     const webhookUrl = takeFlagValue(normalized, "--webhook-url");
     if (webhookUrl) {
+      if (!agentId) {
+        throw new Error(
+          "usage: agentinbox agent register --agent-id ID --webhook-url URL [--webhook-activation-mode MODE] [--webhook-notify-lease-ms N] [--webhook-min-unacked-items N]",
+        );
+      }
       const webhookNotifyLeaseMs = parseOptionalNumber(
         takeFlagValue(normalized, "--webhook-notify-lease-ms"),
       ) ?? notifyLeaseMs;

--- a/src/http.ts
+++ b/src/http.ts
@@ -822,7 +822,6 @@ function buildFastifyServer(service: AgentInboxService) {
       body: {
         type: "object",
         additionalProperties: false,
-        required: ["backend"],
         properties: {
           agentId: { type: "string" },
           forceRebind: { type: "boolean" },
@@ -836,6 +835,17 @@ function buildFastifyServer(service: AgentInboxService) {
           itermSessionId: { type: "string" },
           notifyLeaseMs: { type: "integer", minimum: 1 },
           minUnackedItems: { type: "integer", minimum: 1 },
+          webhook: {
+            type: "object",
+            additionalProperties: false,
+            required: ["url"],
+            properties: {
+              url: { type: "string", minLength: 1 },
+              activationMode: { type: "string" },
+              notifyLeaseMs: { type: "integer", minimum: 1 },
+              minUnackedItems: { type: "integer", minimum: 1 },
+            },
+          },
         },
       },
       response: {
@@ -845,10 +855,11 @@ function buildFastifyServer(service: AgentInboxService) {
     },
   }, async (request) => {
     const body = request.body as Record<string, unknown>;
+    const webhookBody = body.webhook as Record<string, unknown> | undefined;
     return service.registerAgent({
       agentId: optionalString(body.agentId) ?? null,
       forceRebind: body.forceRebind === true,
-      backend: String(body.backend) as never,
+      backend: optionalString(body.backend) as never,
       runtimeKind: optionalString(body.runtimeKind) as never,
       runtimeSessionId: optionalString(body.runtimeSessionId),
       runtimePid: typeof body.runtimePid === "number" ? body.runtimePid : null,
@@ -859,6 +870,14 @@ function buildFastifyServer(service: AgentInboxService) {
       itermSessionId: optionalString(body.itermSessionId),
       notifyLeaseMs: typeof body.notifyLeaseMs === "number" ? body.notifyLeaseMs : null,
       minUnackedItems: typeof body.minUnackedItems === "number" ? body.minUnackedItems : null,
+      webhook: webhookBody
+        ? {
+            url: String(webhookBody.url),
+            activationMode: optionalString(webhookBody.activationMode) as never,
+            notifyLeaseMs: typeof webhookBody.notifyLeaseMs === "number" ? webhookBody.notifyLeaseMs : null,
+            minUnackedItems: typeof webhookBody.minUnackedItems === "number" ? webhookBody.minUnackedItems : null,
+          }
+        : null,
     });
   });
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -822,10 +822,34 @@ function buildFastifyServer(service: AgentInboxService) {
       body: {
         type: "object",
         additionalProperties: false,
+        oneOf: [
+          {
+            required: ["backend"],
+            properties: {
+              backend: { type: "string", enum: ["tmux", "iterm2"] },
+            },
+          },
+          {
+            required: ["agentId", "webhook"],
+            properties: {
+              webhook: {
+                type: "object",
+                additionalProperties: false,
+                required: ["url"],
+                properties: {
+                  url: { type: "string", minLength: 1 },
+                  activationMode: { type: "string", enum: ["activation_only", "activation_with_items"] },
+                  notifyLeaseMs: { type: "integer", minimum: 1 },
+                  minUnackedItems: { type: "integer", minimum: 1 },
+                },
+              },
+            },
+          },
+        ],
         properties: {
           agentId: { type: "string" },
           forceRebind: { type: "boolean" },
-          backend: { type: "string", minLength: 1 },
+          backend: { type: "string", enum: ["tmux", "iterm2"] },
           runtimeKind: { type: "string" },
           runtimeSessionId: { type: "string" },
           runtimePid: { type: "integer", minimum: 1 },
@@ -841,7 +865,7 @@ function buildFastifyServer(service: AgentInboxService) {
             required: ["url"],
             properties: {
               url: { type: "string", minLength: 1 },
-              activationMode: { type: "string" },
+              activationMode: { type: "string", enum: ["activation_only", "activation_with_items"] },
               notifyLeaseMs: { type: "integer", minimum: 1 },
               minUnackedItems: { type: "integer", minimum: 1 },
             },
@@ -1878,6 +1902,8 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("expected boolean") ||
     message.startsWith("expected integer") ||
     message.startsWith("expected positive integer") ||
+    message.startsWith("webhook agent registration requires") ||
+    message.startsWith("agent registration requires either") ||
     message.startsWith("notifyLeaseMs must be a positive integer") ||
     message.startsWith("minUnackedItems must be a positive integer") ||
     message.startsWith("invalid webhook activation target") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -346,7 +346,7 @@ export interface RegisterAgentInput {
   runtimeKind?: RuntimeKind | null;
   runtimeSessionId?: string | null;
   runtimePid?: number | null;
-  backend: TerminalBackend;
+  backend?: TerminalBackend;
   mode?: TerminalMode;
   tmuxPaneId?: string | null;
   tty?: string | null;
@@ -354,11 +354,14 @@ export interface RegisterAgentInput {
   itermSessionId?: string | null;
   notifyLeaseMs?: number | null;
   minUnackedItems?: number | null;
+  webhook?: AddWebhookActivationTargetInput | null;
 }
 
 export interface RegisterAgentResult {
   agent: Agent;
-  terminalTarget: TerminalActivationTarget;
+  terminalTarget: TerminalActivationTarget | null;
+  webhookTarget: WebhookActivationTarget | null;
+  activationChannel: ActivationTargetKind | null;
   inbox: Inbox;
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -3856,6 +3856,9 @@ function validateRegisterAgentInput(input: RegisterAgentInput): void {
     }
     return;
   }
+  if (input.backend) {
+    throw new Error(`unsupported terminal backend: ${input.backend}`);
+  }
   throw new Error("agent registration requires either a terminal backend or webhook");
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -2170,6 +2170,15 @@ export class AgentInboxService {
   }
 
   private handleAgentRegistrationConflicts(agentId: string, input: RegisterAgentInput): void {
+    const activeWebhookTarget = this.store
+      .listActivationTargetsForAgent(agentId)
+      .find((target): target is WebhookActivationTarget => target.kind === "webhook" && target.status === "active");
+    if (activeWebhookTarget) {
+      throw new Error(
+        `agent register conflict: agent ${agentId} already has active webhook target ${activeWebhookTarget.targetId}; terminal registration is disabled while webhook is active`,
+      );
+    }
+
     const currentTarget = findExistingTerminalActivationTarget(this.store, input);
     if (currentTarget && currentTarget.agentId !== agentId) {
       if (!input.forceRebind) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -692,19 +692,24 @@ export class AgentInboxService {
   registerAgent(input: RegisterAgentInput): RegisterAgentResult {
     validateNotifyLeaseMs(input.notifyLeaseMs);
     validateMinUnackedItems(input.minUnackedItems);
-    validateTerminalRegistration(input);
+    validateRegisterAgentInput(input);
 
+    const webhookInput = input.webhook ?? null;
     const runtimeKind = input.runtimeKind ?? "unknown";
-    const agentId = input.agentId ?? this.resolveAutoAgentId({
-      runtimeKind,
-      runtimeSessionId: input.runtimeSessionId ?? null,
-      backend: input.backend,
-      tmuxPaneId: input.tmuxPaneId ?? null,
-      itermSessionId: input.itermSessionId ?? null,
-      tty: input.tty ?? null,
-    });
+    const agentId = webhookInput
+      ? input.agentId!
+      : input.agentId ?? this.resolveAutoAgentId({
+          runtimeKind,
+          runtimeSessionId: input.runtimeSessionId ?? null,
+          backend: input.backend!,
+          tmuxPaneId: input.tmuxPaneId ?? null,
+          itermSessionId: input.itermSessionId ?? null,
+          tty: input.tty ?? null,
+        });
     const now = nowIso();
-    this.handleAgentRegistrationConflicts(agentId, input);
+    if (!webhookInput) {
+      this.handleAgentRegistrationConflicts(agentId, input);
+    }
     const existingAgent = this.store.getAgent(agentId);
     const agent = existingAgent
       ? this.store.updateAgent(agentId, {
@@ -730,11 +735,20 @@ export class AgentInboxService {
           return created;
         })();
 
-    const terminalTarget = this.upsertTerminalActivationTarget(agent.agentId, input, now);
+    let terminalTarget: TerminalActivationTarget | null = null;
+    let webhookTarget: WebhookActivationTarget | null = null;
+    if (webhookInput) {
+      webhookTarget = this.upsertWebhookActivationTarget(agent.agentId, webhookInput, now);
+      this.removeTerminalActivationTargets(agent.agentId);
+    } else {
+      terminalTarget = this.upsertTerminalActivationTarget(agent.agentId, input, now);
+    }
     const inbox = this.ensureInboxForAgent(agent.agentId);
     return {
       agent,
       terminalTarget,
+      webhookTarget,
+      activationChannel: webhookTarget ? "webhook" : terminalTarget ? "terminal" : null,
       inbox,
     };
   }
@@ -1462,7 +1476,7 @@ export class AgentInboxService {
     });
     this.notifyInboxWatchers(agentId, [entry]);
 
-    const targets = this.store.listActivationTargetsForAgent(agentId).filter((target) => target.status === "active");
+    const targets = this.listEffectiveActiveActivationTargets(agentId);
     for (const target of targets) {
       this.enqueueActivationTarget(target, {
         agentId,
@@ -1785,7 +1799,7 @@ export class AgentInboxService {
       });
 
       const inbox = this.ensureInboxForAgent(subscription.agentId);
-      const targets = this.store.listActivationTargetsForAgent(subscription.agentId).filter((target) => target.status === "active");
+      const targets = this.listEffectiveActiveActivationTargets(subscription.agentId);
       let matched = 0;
       let inboxItemsCreated = 0;
       let lastProcessedOffset: number | null = null;
@@ -2136,7 +2150,7 @@ export class AgentInboxService {
       const candidate = assignedAgentIdFromContext({
         runtimeKind: input.runtimeKind,
         runtimeSessionId: input.runtimeSessionId,
-        backend: input.backend,
+        backend: input.backend!,
         tmuxPaneId: input.tmuxPaneId,
         itermSessionId: input.itermSessionId,
         tty: input.tty,
@@ -2185,6 +2199,40 @@ export class AgentInboxService {
     }
   }
 
+  private upsertWebhookActivationTarget(
+    agentId: string,
+    input: AddWebhookActivationTargetInput,
+    now: string,
+  ): WebhookActivationTarget {
+    validateNotifyLeaseMs(input.notifyLeaseMs);
+    validateMinUnackedItems(input.minUnackedItems);
+    const mode = normalizeWebhookActivationMode(input.activationMode);
+    const targets = this.store
+      .listActivationTargetsForAgent(agentId)
+      .filter((target): target is WebhookActivationTarget => target.kind === "webhook");
+    const matching = targets.find((target) => target.url === input.url);
+    const existing = matching ?? targets[0] ?? null;
+    if (existing) {
+      const target = this.store.updateWebhookActivationTarget(existing.targetId, {
+        url: input.url,
+        mode,
+        notifyLeaseMs: input.notifyLeaseMs ?? existing.notifyLeaseMs,
+        minUnackedItems: input.minUnackedItems ?? existing.minUnackedItems ?? null,
+        updatedAt: now,
+        lastSeenAt: now,
+      });
+      for (const duplicate of targets) {
+        if (duplicate.targetId !== target.targetId) {
+          this.store.deleteActivationTarget(agentId, duplicate.targetId);
+        }
+      }
+      this.markAgentActive(agentId);
+      return target;
+    }
+
+    return this.addWebhookActivationTarget(agentId, input);
+  }
+
   private upsertTerminalActivationTarget(agentId: string, input: RegisterAgentInput, now: string): TerminalActivationTarget {
     const existing = findExistingTerminalActivationTarget(this.store, input);
     if (existing) {
@@ -2228,7 +2276,7 @@ export class AgentInboxService {
       runtimeKind: input.runtimeKind ?? "unknown",
       runtimeSessionId: input.runtimeSessionId ?? null,
       runtimePid: input.runtimePid ?? null,
-      backend: input.backend,
+      backend: input.backend!,
       tmuxPaneId: input.tmuxPaneId ?? null,
       tty: input.tty ?? null,
       termProgram: input.termProgram ?? null,
@@ -2240,6 +2288,24 @@ export class AgentInboxService {
     this.store.insertActivationTarget(target);
     this.markAgentActive(agentId);
     return target;
+  }
+
+  private removeTerminalActivationTargets(agentId: string): void {
+    const targets = this.store
+      .listActivationTargetsForAgent(agentId)
+      .filter((target): target is TerminalActivationTarget => target.kind === "terminal");
+    for (const target of targets) {
+      this.store.deleteActivationTarget(agentId, target.targetId);
+    }
+  }
+
+  private listEffectiveActiveActivationTargets(agentId: string): ActivationTarget[] {
+    const targets = this.store.listActivationTargetsForAgent(agentId).filter((target) => target.status === "active");
+    return effectiveActiveTargets(targets);
+  }
+
+  private isEffectiveActiveTarget(agentId: string, targetId: string): boolean {
+    return this.listEffectiveActiveActivationTargets(agentId).some((target) => target.targetId === targetId);
   }
 
   private enqueueActivationTarget(
@@ -2502,6 +2568,10 @@ export class AgentInboxService {
       this.store.deleteActivationDispatchState(agentId, targetId);
       return;
     }
+    if (!this.isEffectiveActiveTarget(agentId, targetId)) {
+      this.store.deleteActivationDispatchState(agentId, targetId);
+      return;
+    }
     const inbox = this.ensureInboxForAgent(agentId);
     const unacked = this.store.listInboxEntries(inbox.inboxId, { includeAcked: false }).length;
     if (unacked === 0) {
@@ -2587,6 +2657,15 @@ export class AgentInboxService {
     }
     if (target.status === "offline") {
       return "offline";
+    }
+    if (!this.isEffectiveActiveTarget(input.agentId, input.targetId)) {
+      this.logger.debug("activation.dispatch_suppressed", {
+        agentId: input.agentId,
+        targetId: target.targetId,
+        reason: "non_effective_target",
+        targetKind: target.kind,
+      });
+      return "suppressed";
     }
     const state = this.store.getActivationDispatchState(input.agentId, input.targetId);
     const inbox = this.ensureInboxForAgent(input.agentId);
@@ -3220,7 +3299,7 @@ export class AgentInboxService {
           continue;
         }
         this.notifyInboxWatchers(inbox.ownerAgentId, [entry]);
-        const targets = this.store.listActivationTargetsForAgent(inbox.ownerAgentId).filter((target) => target.status === "active");
+        const targets = this.listEffectiveActiveActivationTargets(inbox.ownerAgentId);
         for (const target of targets) {
           this.enqueueActivationTarget(target, {
             agentId: inbox.ownerAgentId,
@@ -3758,7 +3837,13 @@ export class ActivationDispatcher {
   }
 }
 
-function validateTerminalRegistration(input: RegisterAgentInput): void {
+function validateRegisterAgentInput(input: RegisterAgentInput): void {
+  if (input.webhook) {
+    if (!input.agentId) {
+      throw new Error("webhook agent registration requires agentId");
+    }
+    return;
+  }
   if (input.backend === "tmux") {
     if (!input.tmuxPaneId) {
       throw new Error("tmux agent registration requires tmuxPaneId");
@@ -3771,7 +3856,7 @@ function validateTerminalRegistration(input: RegisterAgentInput): void {
     }
     return;
   }
-  throw new Error(`unsupported terminal backend: ${String(input.backend)}`);
+  throw new Error("agent registration requires either a terminal backend or webhook");
 }
 
 function validateNotifyLeaseMs(value: number | null | undefined): void {
@@ -3871,6 +3956,9 @@ function normalizeWebhookActivationMode(mode: AddWebhookActivationTargetInput["a
 }
 
 function findExistingTerminalActivationTarget(store: AgentInboxStore, input: RegisterAgentInput): TerminalActivationTarget | null {
+  if (!input.backend) {
+    return null;
+  }
   if (input.runtimeSessionId) {
     const target = store.getTerminalActivationTargetByRuntimeSession(input.runtimeKind ?? "unknown", input.runtimeSessionId);
     if (target) {
@@ -3889,6 +3977,14 @@ function findExistingTerminalActivationTarget(store: AgentInboxStore, input: Reg
     }
   }
   return null;
+}
+
+function effectiveActiveTargets(targets: ActivationTarget[]): ActivationTarget[] {
+  const activeWebhookTargets = targets.filter((target): target is WebhookActivationTarget => target.kind === "webhook" && target.status === "active");
+  if (activeWebhookTargets.length > 0) {
+    return activeWebhookTargets;
+  }
+  return targets.filter((target) => target.status === "active");
 }
 
 function isSameTerminalIdentity(target: TerminalActivationTarget, input: RegisterAgentInput): boolean {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1043,6 +1043,42 @@ export class AgentInboxStore {
     return target;
   }
 
+  updateWebhookActivationTarget(
+    targetId: string,
+    input: {
+      url: string;
+      mode: WebhookActivationTarget["mode"];
+      notifyLeaseMs: number;
+      minUnackedItems: number | null;
+      updatedAt: string;
+      lastSeenAt: string;
+    },
+  ): WebhookActivationTarget {
+    this.db.run(
+      `
+      update activation_targets
+      set kind = 'webhook', status = 'active', offline_since = null, last_error = null, consecutive_failures = 0,
+          mode = ?, notify_lease_ms = ?, min_unacked_items = ?, url = ?, updated_at = ?, last_seen_at = ?
+      where target_id = ? and kind = 'webhook'
+    `,
+      [
+        input.mode,
+        input.notifyLeaseMs,
+        input.minUnackedItems,
+        input.url,
+        input.updatedAt,
+        input.lastSeenAt,
+        targetId,
+      ],
+    );
+    this.persist();
+    const target = this.getActivationTarget(targetId);
+    if (!target || target.kind !== "webhook") {
+      throw new Error(`unknown webhook activation target: ${targetId}`);
+    }
+    return target;
+  }
+
   updateActivationTargetRuntime(
     targetId: string,
     input: {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -829,6 +829,38 @@ test("webhook agent registration converges the agent to webhook-only and is idem
   }
 });
 
+test("terminal registration is rejected while an active webhook target exists for the agent", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const webhook = service.registerAgent({
+      agentId: "agent-webhook-sticky",
+      webhook: {
+        url: "http://127.0.0.1:9999/activate",
+        activationMode: "activation_with_items",
+      },
+    });
+    assert.equal(webhook.activationChannel, "webhook");
+
+    assert.throws(() => {
+      service.registerAgent({
+        agentId: "agent-webhook-sticky",
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-webhook-sticky-terminal",
+        tmuxPaneId: "%179",
+      });
+    }, /agent register conflict: agent agent-webhook-sticky already has active webhook target/);
+
+    const targets = service.listActivationTargets("agent-webhook-sticky");
+    assert.equal(targets.length, 1);
+    assert.equal(targets[0]?.kind, "webhook");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("shared source can route one stream event to multiple agent inboxes", async () => {
   const { store, service, dir } = await makeService();
   try {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -3812,7 +3812,8 @@ test("notification thresholds defer activation until minUnackedItems is reached"
       notifyLeaseMs: 100,
       minUnackedItems: 2,
     });
-    service.addWebhookActivationTarget(registered.agent.agentId, {
+    const terminalTarget = requireTerminalTarget(registered);
+    const webhookTarget = service.addWebhookActivationTarget(registered.agent.agentId, {
       url: "http://127.0.0.1:9999/webhook",
       activationMode: "activation_with_items",
       notifyLeaseMs: 100,
@@ -3841,8 +3842,10 @@ test("notification thresholds defer activation until minUnackedItems is reached"
     assert.equal(dispatcher.calls.length, 0);
     assert.equal(terminalDispatcher.calls.length, 0);
     const statesAfterFirst = store.listActivationDispatchStatesForAgent(registered.agent.agentId);
-    assert.equal(statesAfterFirst.length, 2);
+    assert.equal(statesAfterFirst.length, 1);
     assert.ok(statesAfterFirst.every((state) => state.status === "dirty" && state.leaseExpiresAt === null));
+    assert.equal(statesAfterFirst[0]?.targetId, webhookTarget.targetId);
+    assert.equal(store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId), null);
 
     await service.appendSourceEventByCaller(source.sourceId, {
       sourceNativeId: "evt-threshold-2",
@@ -3854,7 +3857,8 @@ test("notification thresholds defer activation until minUnackedItems is reached"
     await sleep(40);
 
     assert.equal(dispatcher.calls.length, 1);
-    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.equal(dispatcher.calls[0]?.activation.targetId, webhookTarget.targetId);
+    assert.equal(terminalDispatcher.calls.length, 0);
   } finally {
     await service.stop();
     store.close();

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -342,10 +342,16 @@ async function registerTmuxAgent(service: AgentInboxService, suffix: string): Pr
     tmuxPaneId: `%${suffix}`,
     notifyLeaseMs: 50,
   });
+  const terminalTarget = requireTerminalTarget(registered);
   return {
     agentId: registered.agent.agentId,
-    targetId: registered.terminalTarget.targetId,
+    targetId: terminalTarget.targetId,
   };
+}
+
+function requireTerminalTarget(result: { terminalTarget: TerminalActivationTarget | null }): TerminalActivationTarget {
+  assert.ok(result.terminalTarget);
+  return result.terminalTarget;
 }
 
 async function createLegacyDb(dbPath: string): Promise<void> {
@@ -647,8 +653,10 @@ test("agent register creates a stable agent, inbox, and terminal activation targ
       itermSessionId: "4B4CB6B2-A73B-4420-94A7-BD2CA216A285",
       tty: "/dev/ttys049",
     }));
+    const firstTerminalTarget = requireTerminalTarget(first);
+    const secondTerminalTarget = requireTerminalTarget(second);
     assert.equal(second.agent.agentId, first.agent.agentId);
-    assert.equal(second.terminalTarget.targetId, first.terminalTarget.targetId);
+    assert.equal(secondTerminalTarget.targetId, firstTerminalTarget.targetId);
     assert.equal(store.listAgents().length, 1);
     assert.equal(store.listActivationTargetsForAgent(first.agent.agentId).length, 1);
     const details = service.getInboxDetailsByAgent(first.agent.agentId) as { inbox: { ownerAgentId: string } };
@@ -680,7 +688,7 @@ test("agent register accepts caller-supplied agent ids and upserts the same logi
 
     assert.equal(first.agent.agentId, "agent-alpha");
     assert.equal(second.agent.agentId, "agent-alpha");
-    assert.equal(second.terminalTarget.targetId, first.terminalTarget.targetId);
+    assert.equal(requireTerminalTarget(second).targetId, requireTerminalTarget(first).targetId);
     assert.equal(store.listAgents().length, 1);
   } finally {
     await service.stop();
@@ -738,11 +746,82 @@ test("agent register force rebind moves the logical agent to the current termina
 
     assert.equal(rebound.agent.agentId, "agent-alpha");
     assert.equal(rebound.agent.runtimeSessionId, "thread-agent-alpha-rebound");
-    assert.notEqual(rebound.terminalTarget.targetId, first.terminalTarget.targetId);
+    assert.notEqual(requireTerminalTarget(rebound).targetId, requireTerminalTarget(first).targetId);
     const targets = service.listActivationTargets("agent-alpha");
     assert.equal(targets.length, 1);
     assert.equal(targets[0].kind, "terminal");
     assert.equal(targets[0].kind === "terminal" ? targets[0].tmuxPaneId : null, "%505");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("webhook agent registration requires an explicit agent id", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    assert.throws(() => {
+      service.registerAgent({
+        webhook: {
+          url: "http://127.0.0.1:9999/activate",
+        },
+      });
+    }, /webhook agent registration requires agentId/);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("webhook agent registration converges the agent to webhook-only and is idempotent for the same url", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const terminal = service.registerAgent({
+      agentId: "agent-webhook-only",
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "thread-webhook-before",
+      tmuxPaneId: "%178",
+      notifyLeaseMs: 100,
+    });
+    assert.equal(terminal.activationChannel, "terminal");
+    assert.ok(terminal.terminalTarget);
+
+    const firstWebhook = service.registerAgent({
+      agentId: "agent-webhook-only",
+      webhook: {
+        url: "http://127.0.0.1:9999/activate",
+        activationMode: "activation_with_items",
+        notifyLeaseMs: 300,
+        minUnackedItems: 2,
+      },
+    });
+    assert.equal(firstWebhook.activationChannel, "webhook");
+    assert.equal(firstWebhook.terminalTarget, null);
+    assert.ok(firstWebhook.webhookTarget);
+    assert.equal(firstWebhook.webhookTarget?.url, "http://127.0.0.1:9999/activate");
+    assert.equal(firstWebhook.webhookTarget?.notifyLeaseMs, 300);
+    assert.equal(firstWebhook.webhookTarget?.minUnackedItems, 2);
+
+    const secondWebhook = service.registerAgent({
+      agentId: "agent-webhook-only",
+      webhook: {
+        url: "http://127.0.0.1:9999/activate",
+        activationMode: "activation_only",
+      },
+    });
+    assert.equal(secondWebhook.activationChannel, "webhook");
+    assert.equal(secondWebhook.terminalTarget, null);
+    assert.ok(secondWebhook.webhookTarget);
+    assert.equal(secondWebhook.webhookTarget?.targetId, firstWebhook.webhookTarget?.targetId);
+    assert.equal(secondWebhook.webhookTarget?.mode, "activation_only");
+
+    const targets = service.listActivationTargets("agent-webhook-only");
+    assert.equal(targets.length, 1);
+    assert.equal(targets[0]?.kind, "webhook");
+    assert.equal(store.listActivationDispatchStatesForAgent("agent-webhook-only").length, 0);
   } finally {
     await service.stop();
     store.close();
@@ -2366,6 +2445,7 @@ test("subscription remove preserves unrelated activation dispatch state", async 
       tmuxPaneId: "%334",
       notifyLeaseMs: 100,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "remove-sub-state-demo",
@@ -2386,7 +2466,7 @@ test("subscription remove preserves unrelated activation dispatch state", async 
 
     store.upsertActivationDispatchState({
       agentId: registered.agent.agentId,
-      targetId: registered.terminalTarget.targetId,
+      targetId: terminalTarget.targetId,
       status: "notified",
       leaseExpiresAt: new Date(Date.now() + 60_000).toISOString(),
       lastNotifiedFingerprint: null,
@@ -2407,7 +2487,7 @@ test("subscription remove preserves unrelated activation dispatch state", async 
 
     const state = store.getActivationDispatchState(
       registered.agent.agentId,
-      registered.terminalTarget.targetId,
+      terminalTarget.targetId,
     );
     assert.ok(state);
     assert.deepEqual(state.pendingSubscriptionIds, [first.subscriptionId]);
@@ -3624,7 +3704,7 @@ test("compact and gc remove only acked inbox items older than retention", async 
   }
 });
 
-test("webhook and terminal targets share ack-gated notification flow", async () => {
+test("active webhook targets suppress terminal activation dispatch for the same agent", async () => {
   const dispatcher = new RecordingActivationDispatcher();
   const terminalDispatcher = new RecordingTerminalDispatcher();
   const { store, service, dir } = await makeService({
@@ -3642,7 +3722,8 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
       tmuxPaneId: "%42",
       notifyLeaseMs: 100,
     });
-    service.addWebhookActivationTarget(registered.agent.agentId, {
+    const terminalTarget = requireTerminalTarget(registered);
+    const webhookTarget = service.addWebhookActivationTarget(registered.agent.agentId, {
       url: "http://127.0.0.1:9999/webhook",
       activationMode: "activation_with_items",
       notifyLeaseMs: 100,
@@ -3668,13 +3749,15 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
     await sleep(40);
 
     assert.equal(dispatcher.calls.length, 1);
-    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.equal(terminalDispatcher.calls.length, 0);
     const activationEntries = dispatcher.calls[0].activation.entries ?? [];
     assert.equal(
       dispatcher.calls[0].activation.latestEntryId,
       activationEntries.length > 0 ? activationEntries[activationEntries.length - 1]?.entryId ?? null : null,
     );
-    assert.match(terminalDispatcher.calls[0]!.prompt, /Latest entryId: ent_/);
+    assert.equal(dispatcher.calls[0].activation.targetId, webhookTarget.targetId);
+    assert.equal(store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId), null);
+    assert.ok(store.getActivationDispatchState(registered.agent.agentId, webhookTarget.targetId));
 
     await service.appendSourceEventByCaller(source.sourceId, {
       sourceNativeId: "evt-2",
@@ -3686,7 +3769,7 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
     await sleep(40);
 
     assert.equal(dispatcher.calls.length, 1);
-    assert.equal(terminalDispatcher.calls.length, 1);
+    assert.equal(terminalDispatcher.calls.length, 0);
 
     const ack = await service.ackAllInboxItems(registered.agent.agentId);
     assert.equal(ack.acked, 2);
@@ -3701,8 +3784,8 @@ test("webhook and terminal targets share ack-gated notification flow", async () 
     await sleep(40);
 
     assert.equal(dispatcher.calls.length, 2);
-    assert.equal(terminalDispatcher.calls.length, 2);
-    assert.equal(store.listActivationDispatchStatesForAgent(registered.agent.agentId).length, 2);
+    assert.equal(terminalDispatcher.calls.length, 0);
+    assert.equal(store.listActivationDispatchStatesForAgent(registered.agent.agentId).length, 1);
   } finally {
     await service.stop();
     store.close();
@@ -3796,6 +3879,7 @@ test("lease reminders stay suppressed while unacked items remain below minUnacke
       notifyLeaseMs: 50,
       minUnackedItems: 2,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "local-event-threshold-reminder",
@@ -3817,7 +3901,7 @@ test("lease reminders stay suppressed while unacked items remain below minUnacke
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 0);
-    let state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    let state = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId);
     assert.ok(state);
     assert.equal(state.status, "dirty");
     assert.equal(state.leaseExpiresAt, null);
@@ -3827,7 +3911,7 @@ test("lease reminders stay suppressed while unacked items remain below minUnacke
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 0);
-    state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    state = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId);
     assert.ok(state);
     assert.equal(state.status, "dirty");
     assert.equal(state.leaseExpiresAt, null);
@@ -3853,6 +3937,7 @@ test("re-registering a terminal agent preserves notification policy when flags a
       notifyLeaseMs: 250,
       minUnackedItems: 4,
     });
+    const registeredTerminalTarget = requireTerminalTarget(registered);
 
     const rebound = service.registerAgent({
       agentId: registered.agent.agentId,
@@ -3861,11 +3946,12 @@ test("re-registering a terminal agent preserves notification policy when flags a
       runtimeSessionId: "thread-policy-preserve",
       tmuxPaneId: "%422",
     });
+    const reboundTerminalTarget = requireTerminalTarget(rebound);
 
-    assert.equal(rebound.terminalTarget.targetId, registered.terminalTarget.targetId);
-    assert.equal(rebound.terminalTarget.notifyLeaseMs, 250);
-    assert.equal(rebound.terminalTarget.minUnackedItems, 4);
-    assert.deepEqual(rebound.terminalTarget.notificationPolicy, {
+    assert.equal(reboundTerminalTarget.targetId, registeredTerminalTarget.targetId);
+    assert.equal(reboundTerminalTarget.notifyLeaseMs, 250);
+    assert.equal(reboundTerminalTarget.minUnackedItems, 4);
+    assert.deepEqual(reboundTerminalTarget.notificationPolicy, {
       notifyLeaseMs: 250,
       minUnackedItems: 4,
     });
@@ -4371,6 +4457,7 @@ test("preview-aware terminal prompts still dedupe unchanged lease reminders", as
       tmuxPaneId: "%58",
       notifyLeaseMs: 50,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "local-event-inline-preview-dedupe",
@@ -4400,7 +4487,7 @@ test("preview-aware terminal prompts still dedupe unchanged lease reminders", as
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 1);
-    const state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    const state = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId);
     assert.ok(state?.lastNotifiedFingerprint);
   } finally {
     await service.stop();
@@ -4425,6 +4512,7 @@ test("lease expiry does not repeat identical terminal prompts for unchanged inbo
       tmuxPaneId: "%53",
       notifyLeaseMs: 50,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "local-event-terminal-reminder-dedupe",
@@ -4452,7 +4540,7 @@ test("lease expiry does not repeat identical terminal prompts for unchanged inbo
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 1);
-    const state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    const state = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId);
     assert.ok(state);
     assert.equal(state.status, "notified");
     assert.ok(state.leaseExpiresAt);
@@ -4480,6 +4568,7 @@ test("dirty terminal reminders re-notify only when the effective prompt changes"
       tmuxPaneId: "%54",
       notifyLeaseMs: 50,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "local-event-terminal-reminder-changes",
@@ -4519,7 +4608,7 @@ test("dirty terminal reminders re-notify only when the effective prompt changes"
 
     assert.equal(terminalDispatcher.calls.length, 2);
     assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 2 unacked items in inbox/);
-    const state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    const state = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId);
     assert.ok(state?.lastNotifiedFingerprint);
     assert.equal(state?.pendingNewItemCount, 0);
     assert.equal(state?.pendingSummary, null);
@@ -4546,6 +4635,7 @@ test("terminal reminder fingerprints use the canonical unacked item set", async 
       tmuxPaneId: "%55",
       notifyLeaseMs: 50,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "local-event-terminal-reminder-canonical-items",
@@ -4566,7 +4656,7 @@ test("terminal reminder fingerprints use the canonical unacked item set", async 
     await service.pollSubscription(subscription.subscriptionId);
     await sleep(40);
 
-    const initialState = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    const initialState = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId);
     assert.ok(initialState?.lastNotifiedFingerprint);
 
     await service.appendSourceEventByCaller(source.sourceId, {
@@ -4586,7 +4676,7 @@ test("terminal reminder fingerprints use the canonical unacked item set", async 
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 2);
-    const updatedState = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId);
+    const updatedState = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId);
     assert.ok(updatedState?.lastNotifiedFingerprint);
     assert.notEqual(updatedState?.lastNotifiedFingerprint, initialState?.lastNotifiedFingerprint);
     assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 1 unacked item in inbox/);
@@ -4720,6 +4810,7 @@ test("busy terminal defer uses capped exponential backoff", async () => {
       termProgram: "iTerm.app",
       notifyLeaseMs: 100,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "busy-gate-backoff",
@@ -4741,7 +4832,7 @@ test("busy terminal defer uses capped exponential backoff", async () => {
     await sleep(40);
 
     for (const [attempt, expectedRetryMs] of [[2, 10_000], [3, 20_000], [4, 40_000], [5, 80_000], [6, 160_000], [7, 300_000]] as const) {
-      const current = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+      const current = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
       store.upsertActivationDispatchState({
         ...current,
         leaseExpiresAt: new Date(Date.now() - 1_000).toISOString(),
@@ -4750,12 +4841,12 @@ test("busy terminal defer uses capped exponential backoff", async () => {
       await (service as any).syncActivationDispatchStates();
       await sleep(20);
 
-      const next = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+      const next = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
       assert.equal(next.deferAttempts, attempt);
       const retryMs = Date.parse(next.leaseExpiresAt!) - Date.now();
       assert.ok(retryMs <= expectedRetryMs && retryMs >= Math.max(0, expectedRetryMs - 10_000));
     }
-    const finalState = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+    const finalState = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     assert.equal(finalState.deferReason, "terminal_busy");
     assert.equal(terminalDispatcher.calls.length, 0);
   } finally {
@@ -4781,6 +4872,7 @@ test("unexpected defer reasons are preserved in deferred state", async () => {
       tmuxPaneId: "%139",
       notifyLeaseMs: 100,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "custom-defer-reason",
@@ -4801,7 +4893,7 @@ test("unexpected defer reasons are preserved in deferred state", async () => {
     await service.pollSubscription(subscription.subscriptionId);
     await sleep(40);
 
-    const state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+    const state = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     assert.equal(state.deferReason, "custom_busy_reason");
     assert.equal(state.deferAttempts, 1);
   } finally {
@@ -4827,6 +4919,7 @@ test("busy terminal defer keeps only the latest pending reminder fingerprint", a
       tmuxPaneId: "%137",
       notifyLeaseMs: 100,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "busy-gate-latest-only",
@@ -4847,7 +4940,7 @@ test("busy terminal defer keeps only the latest pending reminder fingerprint", a
     await service.pollSubscription(subscription.subscriptionId);
     await sleep(40);
 
-    const firstState = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+    const firstState = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     const firstFingerprint = firstState.pendingFingerprint;
     assert.ok(firstFingerprint);
 
@@ -4860,7 +4953,7 @@ test("busy terminal defer keeps only the latest pending reminder fingerprint", a
     await service.pollSubscription(subscription.subscriptionId);
     await sleep(40);
 
-    const secondState = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+    const secondState = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     assert.equal(secondState.pendingFingerprint, null);
     assert.equal(secondState.deferAttempts, 1);
 
@@ -4875,7 +4968,7 @@ test("busy terminal defer keeps only the latest pending reminder fingerprint", a
 
     assert.equal(terminalDispatcher.calls.length, 1);
     assert.match(terminalDispatcher.calls[0]!.prompt, /AgentInbox: 2 unacked items in inbox/);
-    const delivered = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+    const delivered = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     assert.ok(delivered.lastNotifiedFingerprint);
     assert.notEqual(delivered.lastNotifiedFingerprint, firstFingerprint);
     assert.equal(delivered.pendingFingerprint, null);
@@ -4902,6 +4995,7 @@ test("gate reopening suppresses duplicate terminal dispatches for an already-not
       tmuxPaneId: "%138",
       notifyLeaseMs: 50,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "busy-gate-duplicate-suppression",
@@ -4923,7 +5017,7 @@ test("gate reopening suppresses duplicate terminal dispatches for an already-not
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 1);
-    const notifiedState = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+    const notifiedState = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     assert.ok(notifiedState.lastNotifiedFingerprint);
 
     activationGate.set("inject", "gate_unknown_or_idle");
@@ -4946,7 +5040,7 @@ test("gate reopening suppresses duplicate terminal dispatches for an already-not
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 1);
-    const suppressedState = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+    const suppressedState = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     assert.equal(suppressedState.status, "notified");
     assert.equal(suppressedState.pendingFingerprint, null);
   } finally {
@@ -4972,6 +5066,7 @@ test("successful terminal dispatch suppresses unchanged reinjection even outside
       tmuxPaneId: "%140",
       notifyLeaseMs: 50,
     });
+    const terminalTarget = requireTerminalTarget(registered);
     const source = await service.registerSource({
       sourceType: "local_event",
       sourceKey: "terminal-success-suppress",
@@ -4995,7 +5090,7 @@ test("successful terminal dispatch suppresses unchanged reinjection even outside
     assert.equal(terminalDispatcher.calls.length, 0);
 
     activationGate.set("inject", "gate_unknown_or_idle");
-    const deferred = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+    const deferred = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     const deferredSummary = deferred.pendingSummary;
     const deferredNewItemCount = deferred.pendingNewItemCount;
     const deferredSubscriptionIds = deferred.pendingSubscriptionIds;
@@ -5013,7 +5108,7 @@ test("successful terminal dispatch suppresses unchanged reinjection even outside
     const entries = store.listInboxEntries(registered.inbox.inboxId, { includeAcked: false });
     const outcome = await (service as any).dispatchActivationTarget({
       agentId: registered.agent.agentId,
-      targetId: registered.terminalTarget.targetId,
+      targetId: terminalTarget.targetId,
       newItemCount: deferredNewItemCount,
       totalUnackedCount: entries.length,
       summary: deferredSummary,
@@ -5024,7 +5119,7 @@ test("successful terminal dispatch suppresses unchanged reinjection even outside
 
     assert.equal(outcome, "suppressed");
     assert.equal(terminalDispatcher.calls.length, 1);
-    const state = store.getActivationDispatchState(registered.agent.agentId, registered.terminalTarget.targetId)!;
+    const state = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     assert.equal(state.status, "notified");
     assert.equal(state.pendingFingerprint, null);
   } finally {
@@ -5750,7 +5845,7 @@ test("registerAgent clears offline and error runtime fields for the current term
       tmuxPaneId: "%87",
       notifyLeaseMs: 100,
     });
-    const targetId = registered.terminalTarget.targetId;
+    const targetId = requireTerminalTarget(registered).targetId;
     store.updateActivationTargetRuntime(targetId, {
       status: "offline",
       offlineSince: "2026-04-01T00:00:00.000Z",

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1246,6 +1246,53 @@ test("cli agent register accepts min-unacked-items", async () => {
   }
 });
 
+test("cli agent register supports webhook-only registration without terminal context", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-cli-webhook-reg-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "",
+    CODEX_THREAD_ID: "",
+  };
+
+  try {
+    const register = runCli([
+      "agent",
+      "register",
+      "--agent-id",
+      "agent-cli-webhook",
+      "--webhook-url",
+      "http://127.0.0.1:9999/activate",
+      "--webhook-activation-mode",
+      "activation_with_items",
+      "--webhook-notify-lease-ms",
+      "240",
+      "--webhook-min-unacked-items",
+      "2",
+    ], env);
+    assert.equal(register.status, 0, register.stderr);
+    const payload = JSON.parse(register.stdout) as {
+      agent: { agentId: string };
+      terminalTarget: null;
+      webhookTarget: { url: string; mode: string; notifyLeaseMs: number; minUnackedItems: number | null };
+      activationChannel: string | null;
+    };
+    assert.equal(payload.agent.agentId, "agent-cli-webhook");
+    assert.equal(payload.terminalTarget, null);
+    assert.equal(payload.webhookTarget.url, "http://127.0.0.1:9999/activate");
+    assert.equal(payload.webhookTarget.mode, "activation_with_items");
+    assert.equal(payload.webhookTarget.notifyLeaseMs, 240);
+    assert.equal(payload.webhookTarget.minUnackedItems, 2);
+    assert.equal(payload.activationChannel, "webhook");
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli source schema resolves source ids to instance schema", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-schema-"));
   const env = {
@@ -3520,6 +3567,66 @@ test("control plane accepts caller-supplied agent ids and rejects conflicting re
       });
       assert.equal(rebound.statusCode, 200);
       assert.equal(rebound.data.terminalTarget.tmuxPaneId, "%602");
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane supports webhook-only agent registration and removes stale terminal targets", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-webhook-register-"));
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const store = await AgentInboxStore.open(dbPath);
+  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }));
+  const service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  try {
+    await adapters.start();
+    await service.start();
+    const server = createServer(service);
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+      const terminal = await client.request<{ agent: { agentId: string }; activationChannel: string | null }>("/agents", {
+        agentId: "agent-http-webhook",
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-webhook-terminal",
+        tmuxPaneId: "%178",
+      });
+      assert.equal(terminal.statusCode, 200);
+      assert.equal(terminal.data.activationChannel, "terminal");
+
+      const webhook = await client.request<{
+        agent: { agentId: string };
+        terminalTarget: null;
+        webhookTarget: { url: string; mode: string };
+        activationChannel: string | null;
+      }>("/agents", {
+        agentId: "agent-http-webhook",
+        webhook: {
+          url: "http://127.0.0.1:9999/activate",
+          activationMode: "activation_with_items",
+        },
+      });
+      assert.equal(webhook.statusCode, 200);
+      assert.equal(webhook.data.agent.agentId, "agent-http-webhook");
+      assert.equal(webhook.data.terminalTarget, null);
+      assert.equal(webhook.data.webhookTarget.url, "http://127.0.0.1:9999/activate");
+      assert.equal(webhook.data.webhookTarget.mode, "activation_with_items");
+      assert.equal(webhook.data.activationChannel, "webhook");
+
+      const targets = service.listActivationTargets("agent-http-webhook");
+      assert.equal(targets.length, 1);
+      assert.equal(targets[0]?.kind, "webhook");
     } finally {
       await started.close();
     }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1293,6 +1293,33 @@ test("cli agent register supports webhook-only registration without terminal con
   }
 });
 
+test("cli agent register requires --agent-id when --webhook-url is used", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-cli-webhook-agent-id-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "",
+    CODEX_THREAD_ID: "",
+  };
+
+  try {
+    const register = runCli([
+      "agent",
+      "register",
+      "--webhook-url",
+      "http://127.0.0.1:9999/activate",
+    ], env);
+    assert.notEqual(register.status, 0);
+    assert.match(register.stderr, /usage: agentinbox agent register --agent-id ID --webhook-url URL/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli source schema resolves source ids to instance schema", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-schema-"));
   const env = {
@@ -3627,6 +3654,54 @@ test("control plane supports webhook-only agent registration and removes stale t
       const targets = service.listActivationTargets("agent-http-webhook");
       assert.equal(targets.length, 1);
       assert.equal(targets[0]?.kind, "webhook");
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("control plane validates webhook and terminal registration shapes with 400 responses", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-http-reg-val-"));
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const store = await AgentInboxStore.open(dbPath);
+  const adapters = new AdapterRegistry(store, async () => ({ appended: 0, deduped: 0 }));
+  const service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  try {
+    await adapters.start();
+    await service.start();
+    const server = createServer(service);
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    try {
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+
+      const missingMode = await client.request<{ error: string }>("/agents", {});
+      assert.equal(missingMode.statusCode, 400);
+      assert.match(missingMode.data.error, /must match exactly one schema in oneOf/);
+
+      const invalidBackend = await client.request<{ error: string }>("/agents", {
+        backend: "ssh",
+      });
+      assert.equal(invalidBackend.statusCode, 400);
+      assert.match(invalidBackend.data.error, /must be equal to one of the allowed values/);
+
+      const invalidActivationMode = await client.request<{ error: string }>("/agents", {
+        agentId: "agent-http-invalid-webhook",
+        webhook: {
+          url: "http://127.0.0.1:9999/activate",
+          activationMode: "both",
+        },
+      });
+      assert.equal(invalidActivationMode.statusCode, 400);
+      assert.match(invalidActivationMode.data.error, /must be equal to one of the allowed values/);
     } finally {
       await started.close();
     }

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -3654,6 +3654,16 @@ test("control plane supports webhook-only agent registration and removes stale t
       const targets = service.listActivationTargets("agent-http-webhook");
       assert.equal(targets.length, 1);
       assert.equal(targets[0]?.kind, "webhook");
+
+      const terminalConflict = await client.request<{ error: string }>("/agents", {
+        agentId: "agent-http-webhook",
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-webhook-terminal-2",
+        tmuxPaneId: "%179",
+      });
+      assert.equal(terminalConflict.statusCode, 400);
+      assert.match(terminalConflict.data.error, /already has active webhook target/);
     } finally {
       await started.close();
     }


### PR DESCRIPTION
## Summary
- add webhook registration support to `agent register` and `POST /agents`, with explicit `agentId` and webhook-specific flags/body
- converge webhook registrations to webhook-only targets and surface the effective activation channel in responses
- suppress terminal activation routing whenever an agent has any active webhook target, including stale-state dispatch guards

## Testing
- `node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern='webhook agent registration requires an explicit agent id|webhook agent registration converges the agent to webhook-only and is idempotent for the same url|active webhook targets suppress terminal activation dispatch for the same agent|cli agent register supports webhook-only registration without terminal context|control plane supports webhook-only agent registration and removes stale terminal targets|cli agent register accepts min-unacked-items|agent register creates a stable agent, inbox, and terminal activation target|agent register accepts caller-supplied agent ids and upserts the same logical agent|agent register force rebind moves the logical agent to the current terminal target|re-registering a terminal agent preserves notification policy when flags are omitted' test/agentinbox.test.ts test/control_plane.test.ts`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern='webhook|agent register|control plane accepts caller-supplied agent ids and rejects conflicting rebinds without force|e2e control plane can register an agent, route events, watch inbox, and send aggregated activation webhook|control plane accepts notification policy thresholds for agent and webhook targets' test/agentinbox.test.ts test/control_plane.test.ts`

Closes #178
