### PR TITLE
fix: prefer agentId in reminder messages

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -2678,7 +2678,7 @@ export class AgentInboxService {
     }
     const state = this.store.getActivationDispatchState(input.agentId, input.targetId);
     const inbox = this.ensureInboxForAgent(input.agentId);
-    const summary = summarizeActivation(inbox.inboxId, input.newItemCount, input.summary);
+    const summary = summarizeActivation(input.agentId, input.newItemCount, input.summary);
     const totalUnackedCount = input.totalUnackedCount ?? this.store.listInboxEntries(inbox.inboxId, { includeAcked: false }).length;
     const notificationPolicy = notificationPolicyForTarget(target);
     if (!meetsNotificationThreshold(notificationPolicy, totalUnackedCount)) {
@@ -2737,7 +2737,6 @@ export class AgentInboxService {
         }
         const reminder = await this.buildTerminalReminder(
           target,
-          inbox.inboxId,
           totalUnackedCount,
           input.summary,
           input.entries,
@@ -2970,7 +2969,6 @@ export class AgentInboxService {
 
   private async buildTerminalReminder(
     target: TerminalActivationTarget,
-    inboxId: string,
     totalUnackedCount: number,
     summary: string | null,
     entries: InboxEntry[],
@@ -2990,7 +2988,7 @@ export class AgentInboxService {
       preview ??= deriveInlineItemPreview(singleItem, summary);
     }
     const prompt = renderAgentPrompt({
-      inboxId,
+      agentId: target.agentId,
       totalUnackedCount,
       summary,
       preview,
@@ -4029,12 +4027,12 @@ function notificationBufferKey(agentId: string, targetId: string): string {
   return `${agentId}::${targetId}`;
 }
 
-function summarizeActivation(inboxId: string, newItemCount: number, firstSummary: string | null): string {
+function summarizeActivation(agentId: string, newItemCount: number, firstSummary: string | null): string {
   const itemWord = newItemCount === 1 ? "item" : "items";
   if (firstSummary) {
-    return `${newItemCount} new ${itemWord} in ${inboxId} from ${firstSummary}`;
+    return `${newItemCount} new ${itemWord} for agent ${agentId} from ${firstSummary}`;
   }
-  return `${newItemCount} new ${itemWord} in ${inboxId}`;
+  return `${newItemCount} new ${itemWord} for agent ${agentId}`;
 }
 
 function latestEntryIdForNotification(entries: InboxEntry[]): string | null {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -88,7 +88,8 @@ export function detectTerminalContext(env: NodeJS.ProcessEnv = process.env): Det
 }
 
 export function renderAgentPrompt(input: {
-  agentId: string;
+  agentId?: string | null;
+  inboxId?: string | null;
   totalUnackedCount: number;
   summary?: string | null;
   preview?: string | null;
@@ -96,7 +97,14 @@ export function renderAgentPrompt(input: {
 }): string {
   const totalUnackedCount = input.totalUnackedCount;
   const itemWord = totalUnackedCount === 1 ? "item" : "items";
-  const base = `AgentInbox: ${totalUnackedCount} unacked ${itemWord} for agent ${input.agentId}.`;
+  const agentId = normalizeOptionalString(input.agentId ?? null);
+  const inboxId = normalizeOptionalString(input.inboxId ?? null);
+  const targetLabel = agentId
+    ? `for agent ${agentId}`
+    : inboxId
+      ? `in inbox ${inboxId}`
+      : "in inbox";
+  const base = `AgentInbox: ${totalUnackedCount} unacked ${itemWord} ${targetLabel}.`;
   const latestEntryIdSuffix = input.latestEntryId ? ` Latest entryId: ${input.latestEntryId}.` : "";
   if (totalUnackedCount === 1 && input.preview) {
     const suffix = /(?:[.!?…]|\.{3})$/.test(input.preview) ? "" : ".";

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -88,7 +88,7 @@ export function detectTerminalContext(env: NodeJS.ProcessEnv = process.env): Det
 }
 
 export function renderAgentPrompt(input: {
-  inboxId: string;
+  agentId: string;
   totalUnackedCount: number;
   summary?: string | null;
   preview?: string | null;
@@ -96,7 +96,7 @@ export function renderAgentPrompt(input: {
 }): string {
   const totalUnackedCount = input.totalUnackedCount;
   const itemWord = totalUnackedCount === 1 ? "item" : "items";
-  const base = `AgentInbox: ${totalUnackedCount} unacked ${itemWord} in inbox ${input.inboxId}.`;
+  const base = `AgentInbox: ${totalUnackedCount} unacked ${itemWord} for agent ${input.agentId}.`;
   const latestEntryIdSuffix = input.latestEntryId ? ` Latest entryId: ${input.latestEntryId}.` : "";
   if (totalUnackedCount === 1 && input.preview) {
     const suffix = /(?:[.!?…]|\.{3})$/.test(input.preview) ? "" : ".";

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -4035,7 +4035,7 @@ test("terminal activation prompts use the current unacked inbox total", async ()
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 1);
-    assert.match(terminalDispatcher.calls[0]!.prompt, /AgentInbox: 1 unacked item in inbox/);
+    assert.match(terminalDispatcher.calls[0]!.prompt, /AgentInbox: 1 unacked item for agent agt_/);
 
     await service.appendSourceEventByCaller(source.sourceId, {
       sourceNativeId: "evt-2",
@@ -4055,7 +4055,7 @@ test("terminal activation prompts use the current unacked inbox total", async ()
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 2);
-    assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 1 unacked item in inbox/);
+    assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 1 unacked item for agent agt_/);
     assert.doesNotMatch(terminalDispatcher.calls[1]!.prompt, /2 new items arrived/);
   } finally {
     await service.stop();
@@ -4643,7 +4643,7 @@ test("dirty terminal reminders re-notify only when the effective prompt changes"
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 2);
-    assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 2 unacked items in inbox/);
+    assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 2 unacked items for agent agt_/);
     const state = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId);
     assert.ok(state?.lastNotifiedFingerprint);
     assert.equal(state?.pendingNewItemCount, 0);
@@ -4715,7 +4715,7 @@ test("terminal reminder fingerprints use the canonical unacked item set", async 
     const updatedState = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId);
     assert.ok(updatedState?.lastNotifiedFingerprint);
     assert.notEqual(updatedState?.lastNotifiedFingerprint, initialState?.lastNotifiedFingerprint);
-    assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 1 unacked item in inbox/);
+    assert.match(terminalDispatcher.calls[1]!.prompt, /AgentInbox: 1 unacked item for agent agt_/);
   } finally {
     await service.stop();
     store.close();
@@ -5003,7 +5003,7 @@ test("busy terminal defer keeps only the latest pending reminder fingerprint", a
     await sleep(40);
 
     assert.equal(terminalDispatcher.calls.length, 1);
-    assert.match(terminalDispatcher.calls[0]!.prompt, /AgentInbox: 2 unacked items in inbox/);
+    assert.match(terminalDispatcher.calls[0]!.prompt, /AgentInbox: 2 unacked items for agent agt_/);
     const delivered = store.getActivationDispatchState(registered.agent.agentId, terminalTarget.targetId)!;
     assert.ok(delivered.lastNotifiedFingerprint);
     assert.notEqual(delivered.lastNotifiedFingerprint, firstFingerprint);

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -98,6 +98,19 @@ test("renderAgentPrompt uses agentId in summary prompts", () => {
   );
 });
 
+test("renderAgentPrompt keeps backward compatibility for inboxId callers", () => {
+  const prompt = renderAgentPrompt({
+    inboxId: "inbox_123",
+    totalUnackedCount: 1,
+    latestEntryId: "ent_abc123",
+  });
+
+  assert.equal(
+    prompt,
+    "AgentInbox: 1 unacked item in inbox inbox_123. Latest entryId: ent_abc123. Please read the inbox, process them, and ack when finished.",
+  );
+});
+
 test("deriveInlineItemPreview truncates short text payloads and skips structured payloads", () => {
   const preview = deriveInlineItemPreview({
     itemId: "itm_1",

--- a/test/terminal.test.ts
+++ b/test/terminal.test.ts
@@ -45,20 +45,20 @@ test("assignedAgentIdFromContext prefers runtime session ids", () => {
 
 test("renderAgentPrompt renders a single-item prompt without preview text", () => {
   const prompt = renderAgentPrompt({
-    inboxId: "inbox_123",
+    agentId: "agt_copper-fox",
     totalUnackedCount: 1,
     latestEntryId: "ent_abc123",
   });
 
   assert.equal(
     prompt,
-    "AgentInbox: 1 unacked item in inbox inbox_123. Latest entryId: ent_abc123. Please read the inbox, process them, and ack when finished.",
+    "AgentInbox: 1 unacked item for agent agt_copper-fox. Latest entryId: ent_abc123. Please read the inbox, process them, and ack when finished.",
   );
 });
 
 test("renderAgentPrompt includes inline preview for single-item prompts", () => {
   const prompt = renderAgentPrompt({
-    inboxId: "inbox_123",
+    agentId: "agt_copper-fox",
     totalUnackedCount: 1,
     preview: "Review PR #51 CI failure and push a fix",
     latestEntryId: "ent_abc123",
@@ -66,13 +66,13 @@ test("renderAgentPrompt includes inline preview for single-item prompts", () => 
 
   assert.equal(
     prompt,
-    "AgentInbox: 1 unacked item in inbox inbox_123. Latest entryId: ent_abc123. Preview: Review PR #51 CI failure and push a fix. Read the inbox for full details if needed.",
+    "AgentInbox: 1 unacked item for agent agt_copper-fox. Latest entryId: ent_abc123. Preview: Review PR #51 CI failure and push a fix. Read the inbox for full details if needed.",
   );
 });
 
 test("renderAgentPrompt does not add duplicate punctuation after previews", () => {
   const prompt = renderAgentPrompt({
-    inboxId: "inbox_123",
+    agentId: "agt_copper-fox",
     totalUnackedCount: 1,
     preview: "Review PR #51 CI failure and push a fix...",
     latestEntryId: "ent_abc123",
@@ -80,7 +80,21 @@ test("renderAgentPrompt does not add duplicate punctuation after previews", () =
 
   assert.equal(
     prompt,
-    "AgentInbox: 1 unacked item in inbox inbox_123. Latest entryId: ent_abc123. Preview: Review PR #51 CI failure and push a fix... Read the inbox for full details if needed.",
+    "AgentInbox: 1 unacked item for agent agt_copper-fox. Latest entryId: ent_abc123. Preview: Review PR #51 CI failure and push a fix... Read the inbox for full details if needed.",
+  );
+});
+
+test("renderAgentPrompt uses agentId in summary prompts", () => {
+  const prompt = renderAgentPrompt({
+    agentId: "agt_copper-fox",
+    totalUnackedCount: 2,
+    summary: "2 new items for agent agt_copper-fox from github review updates",
+    latestEntryId: "ent_abc123",
+  });
+
+  assert.equal(
+    prompt,
+    "AgentInbox: 2 unacked items for agent agt_copper-fox. Latest entryId: ent_abc123. Summary: 2 new items for agent agt_copper-fox from github review updates. Please read the inbox, process them, and ack when finished.",
   );
 });
 


### PR DESCRIPTION
## Summary
- use `agentId` instead of `inboxId` as the primary identifier in reminder prompts
- update activation summary text so human-facing reminder summaries no longer surface `inboxId`
- refresh terminal reminder tests to assert the new wording

## Verification
- `node --require ts-node/register --test test/terminal.test.ts`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern='notification thresholds defer activation until minUnackedItems is reached|terminal reminder fingerprints use the canonical unacked item set|dirty terminal reminders re-notify only when the effective prompt changes' test/agentinbox.test.ts`
- `node_modules/.bin/tsc -p tsconfig.json --noEmit`

Closes #180
