### PR TITLE
feat: add limit to one-shot list commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,7 +89,10 @@ async function main(): Promise<void> {
   }
 
   if (command === "host" && normalized[1] === "list") {
-    await printRemote(client, "/hosts", undefined, "GET");
+    const query = buildQuery({
+      limit: parseOptionalLimitArg(normalized),
+    });
+    await printRemote(client, `/hosts${query}`, undefined, "GET");
     return;
   }
 
@@ -127,7 +130,10 @@ async function main(): Promise<void> {
   }
 
   if (command === "stream" && normalized[1] === "list") {
-    await printRemote(client, "/streams", undefined, "GET");
+    const query = buildQuery({
+      limit: parseOptionalLimitArg(normalized),
+    });
+    await printRemote(client, `/streams${query}`, undefined, "GET");
     return;
   }
 
@@ -298,7 +304,10 @@ async function main(): Promise<void> {
   }
 
   if (command === "source" && normalized[1] === "list") {
-    await printRemote(client, "/sources", undefined, "GET");
+    const query = buildQuery({
+      limit: parseOptionalLimitArg(normalized),
+    });
+    await printRemote(client, `/sources${query}`, undefined, "GET");
     return;
   }
 
@@ -448,7 +457,7 @@ async function main(): Promise<void> {
   }
 
   if (command === "agent" && normalized[1] === "list") {
-    await printAgentList(client);
+    await printAgentList(client, parseOptionalLimitArg(normalized));
     return;
   }
 
@@ -503,9 +512,12 @@ async function main(): Promise<void> {
   if (command === "agent" && normalized[1] === "target" && normalized[2] === "list") {
     const agentId = normalized[3];
     if (!agentId) {
-      throw new Error("usage: agentinbox agent target list <agentId>");
+      throw new Error("usage: agentinbox agent target list <agentId> [--limit N]");
     }
-    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/targets`, undefined, "GET");
+    const query = buildQuery({
+      limit: parseOptionalLimitArg(normalized),
+    });
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/targets${query}`, undefined, "GET");
     return;
   }
 
@@ -584,6 +596,7 @@ async function main(): Promise<void> {
     const query = buildQuery({
       source_id: takeFlagValue(normalized, "--source-id"),
       agent_id: takeFlagValue(normalized, "--agent-id"),
+      limit: parseOptionalLimitArg(normalized),
     });
     await printRemote(client, `/subscriptions${query}`, undefined, "GET");
     return;
@@ -668,6 +681,7 @@ async function main(): Promise<void> {
   if (command === "timer" && normalized[1] === "list") {
     const query = buildQuery({
       agent_id: takeFlagValue(normalized, "--agent-id"),
+      limit: parseOptionalLimitArg(normalized),
     });
     await printRemote(client, `/timers${query}`, undefined, "GET");
     return;
@@ -701,7 +715,10 @@ async function main(): Promise<void> {
   }
 
   if (command === "inbox" && normalized[1] === "list") {
-    await printRemote(client, "/agents", undefined, "GET");
+    const query = buildQuery({
+      limit: parseOptionalLimitArg(normalized),
+    });
+    await printRemote(client, `/agents${query}`, undefined, "GET");
     return;
   }
 
@@ -716,9 +733,9 @@ async function main(): Promise<void> {
 
   if (command === "inbox" && normalized[1] === "read") {
     const args = normalized.slice(2);
-    const allowedFlags = ["--agent-id", "--after-entry", "--include-acked"];
-    if (positionalArgs(args, ["--agent-id", "--after-entry"]).length > 0 || unexpectedFlags(args, allowedFlags).length > 0) {
-      throw new Error("usage: agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked]");
+    const allowedFlags = ["--agent-id", "--after-entry", "--include-acked", "--limit"];
+    if (positionalArgs(args, ["--agent-id", "--after-entry", "--limit"]).length > 0 || unexpectedFlags(args, allowedFlags).length > 0) {
+      throw new Error("usage: agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked] [--limit N]");
     }
     const selection = await selectAgentForCommand(client, {
       explicitAgentId: takeFlagValue(normalized, "--agent-id"),
@@ -727,6 +744,7 @@ async function main(): Promise<void> {
     const query = buildQuery({
       after_entry_id: takeFlagValue(normalized, "--after-entry"),
       include_acked: hasFlag(normalized, "--include-acked") ? "true" : undefined,
+      limit: parseOptionalLimitArg(normalized),
     });
     const response = await requestRemote<Record<string, unknown>>(client, `/agents/${encodeURIComponent(selection.agentId)}/inbox/entries${query}`, undefined, "GET");
     console.log(jsonResponse(withCommandMetadata(response.data, selection)));
@@ -1042,8 +1060,8 @@ async function createClient(args: string[]): Promise<AgentInboxClient> {
   return new AgentInboxClient(transport);
 }
 
-async function printAgentList(client: AgentInboxClient): Promise<void> {
-  const records = await listAgentsWithTargets(client);
+async function printAgentList(client: AgentInboxClient, limit?: string): Promise<void> {
+  const records = await listAgentsWithTargets(client, limit);
   console.log(jsonResponse(annotateAgents(records, tryDetectTerminalContext())));
 }
 
@@ -1124,8 +1142,12 @@ async function selectAgentForCommand(
   };
 }
 
-async function listAgentsWithTargets(client: AgentInboxClient): Promise<AgentWithTargets[]> {
-  const response = await requestRemote<{ agents: AgentWithTargets[] }>(client, "/agents?include_targets=true", undefined, "GET");
+async function listAgentsWithTargets(client: AgentInboxClient, limit?: string): Promise<AgentWithTargets[]> {
+  const query = buildQuery({
+    include_targets: "true",
+    limit,
+  });
+  const response = await requestRemote<{ agents: AgentWithTargets[] }>(client, `/agents${query}`, undefined, "GET");
   return response.data.agents;
 }
 
@@ -1253,6 +1275,18 @@ function buildQuery(params: Record<string, string | undefined>): string {
   }
   const query = search.toString();
   return query ? `?${query}` : "";
+}
+
+function parseOptionalLimitArg(args: string[]): string | undefined {
+  const raw = takeFlagValue(args, "--limit");
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1 || String(parsed) !== raw) {
+    throw new Error("`--limit` must be a positive integer");
+  }
+  return String(parsed);
 }
 
 function readSubscriptionFilter(args: string[]): Record<string, unknown> {
@@ -1443,7 +1477,7 @@ Usage:
 
 Usage:
   agentinbox host add <hostType> <hostKey> [--config-json JSON] [--config-ref REF]
-  agentinbox host list
+  agentinbox host list [--limit N]
   agentinbox host show <hostId>
   agentinbox host schema <hostId>
 `,
@@ -1451,7 +1485,7 @@ Usage:
 
 Usage:
   agentinbox stream add <hostId> <streamKind> <streamKey> [--config-json JSON] [--config-ref REF]
-  agentinbox stream list
+  agentinbox stream list [--limit N]
   agentinbox stream show <streamId>
   agentinbox stream update <streamId> [--config-json JSON] [--config-ref REF | --clear-config-ref]
   agentinbox stream remove <streamId> [--with-subscriptions]
@@ -1476,7 +1510,7 @@ Examples:
 
 Usage:
   agentinbox source add <hostId> <streamKind> <streamKey> [--config-json JSON] [--config-ref REF]
-  agentinbox source list
+  agentinbox source list [--limit N]
   agentinbox source show <sourceId>
   agentinbox source update <sourceId> [--config-json JSON] [--config-ref REF | --clear-config-ref]
   agentinbox source remove <sourceId> [--with-subscriptions]
@@ -1491,13 +1525,13 @@ Usage:
 Usage:
   agentinbox agent register [--agent-id ID] [--force-rebind] [--notify-lease-ms N] [--min-unacked-items N]
   agentinbox agent register --agent-id ID --webhook-url URL [--webhook-activation-mode MODE] [--webhook-notify-lease-ms N] [--webhook-min-unacked-items N]
-  agentinbox agent list
+  agentinbox agent list [--limit N]
   agentinbox agent current
   agentinbox agent show <agentId>
   agentinbox agent remove <agentId>
   agentinbox agent resume <agentId>
   agentinbox agent target add webhook <agentId> --url URL [--activation-mode MODE] [--notify-lease-ms N] [--min-unacked-items N]
-  agentinbox agent target list <agentId>
+  agentinbox agent target list <agentId> [--limit N]
   agentinbox agent target remove <agentId> <targetId>
   agentinbox agent target resume <agentId> <targetId>
 `,
@@ -1505,7 +1539,7 @@ Usage:
 
 Usage:
   agentinbox timer add --agent-id ID (--at ISO8601 | --every DURATION | --cron EXPR) --message TEXT [--timezone TZ] [--sender SENDER]
-  agentinbox timer list [--agent-id ID]
+  agentinbox timer list [--agent-id ID] [--limit N]
   agentinbox timer pause <scheduleId>
   agentinbox timer resume <scheduleId>
   agentinbox timer remove <scheduleId>
@@ -1514,7 +1548,7 @@ Usage:
 
 Usage:
   agentinbox subscription add <sourceId> [--agent-id ID] [--shortcut NAME --shortcut-args-json JSON] [--filter-json JSON | --filter-file PATH | --filter-stdin] [--tracked-resource-ref REF] [--cleanup-policy-json JSON] [--start-policy POLICY] [--start-offset N] [--start-time ISO8601]
-  agentinbox subscription list [--source-id ID] [--agent-id ID]
+  agentinbox subscription list [--source-id ID] [--agent-id ID] [--limit N]
   agentinbox subscription show <subscriptionId>
   agentinbox subscription remove <subscriptionId>
   agentinbox subscription poll <subscriptionId>
@@ -1524,9 +1558,9 @@ Usage:
     inbox: `agentinbox inbox
 
 Usage:
-  agentinbox inbox list
+  agentinbox inbox list [--limit N]
   agentinbox inbox show <agentId>
-  agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked]
+  agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked] [--limit N]
   agentinbox inbox send --agent-id ID --message TEXT [--sender SENDER]
   agentinbox inbox watch [--agent-id ID] [--after-entry ID] [--include-acked] [--heartbeat-ms N]
   agentinbox inbox ack [--agent-id ID] (--through <entryId> | --entry <entryId> | --all)

--- a/src/http.ts
+++ b/src/http.ts
@@ -144,6 +144,13 @@ function buildFastifyServer(service: AgentInboxService) {
   app.get("/hosts", {
     schema: {
       tags: ["sources"],
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          limit: { type: "string", pattern: "^[1-9][0-9]*$" },
+        },
+      },
       response: {
         200: {
           type: "object",
@@ -154,7 +161,10 @@ function buildFastifyServer(service: AgentInboxService) {
         },
       },
     },
-  }, async () => ({ hosts: service.listHosts() }));
+  }, async (request) => {
+    const query = request.query as { limit?: string };
+    return { hosts: service.listHosts(parseOptionalPositiveInteger(query.limit)) };
+  });
 
   app.post("/hosts", {
     schema: {
@@ -221,6 +231,13 @@ function buildFastifyServer(service: AgentInboxService) {
   app.get("/streams", {
     schema: {
       tags: ["sources"],
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          limit: { type: "string", pattern: "^[1-9][0-9]*$" },
+        },
+      },
       response: {
         200: {
           type: "object",
@@ -231,7 +248,10 @@ function buildFastifyServer(service: AgentInboxService) {
         },
       },
     },
-  }, async () => ({ streams: service.listStreams() }));
+  }, async (request) => {
+    const query = request.query as { limit?: string };
+    return { streams: service.listStreams(parseOptionalPositiveInteger(query.limit)) };
+  });
 
   app.post("/streams", {
     schema: {
@@ -299,6 +319,13 @@ function buildFastifyServer(service: AgentInboxService) {
   app.get("/sources", {
     schema: {
       tags: ["sources"],
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          limit: { type: "string", pattern: "^[1-9][0-9]*$" },
+        },
+      },
       response: {
         200: {
           type: "object",
@@ -309,7 +336,10 @@ function buildFastifyServer(service: AgentInboxService) {
         },
       },
     },
-  }, async () => ({ sources: await service.listSourceViews() }));
+  }, async (request) => {
+    const query = request.query as { limit?: string };
+    return { sources: await service.listSourceViews(parseOptionalPositiveInteger(query.limit)) };
+  });
 
   app.post("/sources", {
     schema: {
@@ -780,6 +810,7 @@ function buildFastifyServer(service: AgentInboxService) {
         additionalProperties: false,
         properties: {
           include_targets: { type: "string", enum: ["true", "false"] },
+          limit: { type: "string", pattern: "^[1-9][0-9]*$" },
         },
       },
       response: {
@@ -793,8 +824,8 @@ function buildFastifyServer(service: AgentInboxService) {
       },
     },
   }, async (request) => {
-    const query = request.query as { include_targets?: "true" | "false" };
-    const agents = service.listAgents();
+    const query = request.query as { include_targets?: "true" | "false"; limit?: string };
+    const agents = service.listAgents(parseOptionalPositiveInteger(query.limit));
     if (query.include_targets === "true") {
       const activationTargetsByAgentId = service.listActivationTargets().reduce((grouped, target) => {
         const targets = grouped.get(target.agentId);
@@ -974,6 +1005,13 @@ function buildFastifyServer(service: AgentInboxService) {
           agentId: { type: "string", minLength: 1 },
         },
       },
+      querystring: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          limit: { type: "string", pattern: "^[1-9][0-9]*$" },
+        },
+      },
       response: {
         200: {
           type: "object",
@@ -986,7 +1024,8 @@ function buildFastifyServer(service: AgentInboxService) {
     },
   }, async (request) => {
     const params = request.params as { agentId: string };
-    return { targets: service.listActivationTargets(decodeURIComponent(params.agentId)) };
+    const query = request.query as { limit?: string };
+    return { targets: service.listActivationTargets(decodeURIComponent(params.agentId), parseOptionalPositiveInteger(query.limit)) };
   });
 
   app.post("/agents/:agentId/targets", {
@@ -1080,6 +1119,7 @@ function buildFastifyServer(service: AgentInboxService) {
         additionalProperties: false,
         properties: {
           agent_id: { type: "string" },
+          limit: { type: "string", pattern: "^[1-9][0-9]*$" },
         },
       },
       response: {
@@ -1093,8 +1133,8 @@ function buildFastifyServer(service: AgentInboxService) {
       },
     },
   }, async (request) => {
-    const query = request.query as { agent_id?: string };
-    return { timers: service.listTimers(query.agent_id) };
+    const query = request.query as { agent_id?: string; limit?: string };
+    return { timers: service.listTimers(query.agent_id, parseOptionalPositiveInteger(query.limit)) };
   });
 
   app.post("/timers", {
@@ -1203,6 +1243,7 @@ function buildFastifyServer(service: AgentInboxService) {
         properties: {
           source_id: { type: "string" },
           agent_id: { type: "string" },
+          limit: { type: "string", pattern: "^[1-9][0-9]*$" },
         },
       },
       response: {
@@ -1210,11 +1251,12 @@ function buildFastifyServer(service: AgentInboxService) {
       },
     },
   }, async (request) => {
-    const query = request.query as { source_id?: string; agent_id?: string };
+    const query = request.query as { source_id?: string; agent_id?: string; limit?: string };
     return {
       subscriptions: service.listSubscriptions({
         sourceId: query.source_id,
         agentId: query.agent_id,
+        limit: parseOptionalPositiveInteger(query.limit),
       }),
     };
   });
@@ -1424,6 +1466,7 @@ function buildFastifyServer(service: AgentInboxService) {
         properties: {
           after_entry_id: { type: "string" },
           include_acked: { type: "string", enum: ["true", "false"] },
+          limit: { type: "string", pattern: "^[1-9][0-9]*$" },
         },
       },
       response: {
@@ -1438,11 +1481,12 @@ function buildFastifyServer(service: AgentInboxService) {
     },
   }, async (request) => {
     const params = request.params as { agentId: string };
-    const query = request.query as { after_entry_id?: string; include_acked?: "true" | "false" };
+    const query = request.query as { after_entry_id?: string; include_acked?: "true" | "false"; limit?: string };
     return {
       entries: service.listInboxItems(decodeURIComponent(params.agentId), {
         afterEntryId: query.after_entry_id,
         includeAcked: query.include_acked ? query.include_acked === "true" : undefined,
+        limit: parseOptionalPositiveInteger(query.limit),
       }),
     };
   });
@@ -1846,6 +1890,17 @@ function optionalString(value: unknown): string | undefined {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseOptionalPositiveInteger(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1 || String(parsed) !== value) {
+    throw new Error("expected positive integer");
+  }
+  return parsed;
 }
 
 function normalizeValidationMessage(message: string): string {

--- a/src/http.ts
+++ b/src/http.ts
@@ -827,14 +827,11 @@ function buildFastifyServer(service: AgentInboxService) {
     const query = request.query as { include_targets?: "true" | "false"; limit?: string };
     const agents = service.listAgents(parseOptionalPositiveInteger(query.limit));
     if (query.include_targets === "true") {
-      const activationTargetsByAgentId = service.listActivationTargets().reduce((grouped, target) => {
-        const targets = grouped.get(target.agentId);
-        const summarized = summarizeActivationTarget(target);
-        if (targets) {
-          targets.push(summarized);
-        } else {
-          grouped.set(target.agentId, [summarized]);
-        }
+      const activationTargetsByAgentId = agents.reduce((grouped, agent) => {
+        grouped.set(
+          agent.agentId,
+          service.listActivationTargets(agent.agentId).map((target) => summarizeActivationTarget(target)),
+        );
         return grouped;
       }, new Map<string, ReturnType<typeof summarizeActivationTarget>[]>());
       return {
@@ -1896,9 +1893,12 @@ function parseOptionalPositiveInteger(value: string | undefined): number | undef
   if (value === undefined) {
     return undefined;
   }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 1 || String(parsed) !== value) {
+  if (!/^[1-9]\d*$/.test(value)) {
     throw new Error("expected positive integer");
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error("expected positive integer within safe range");
   }
   return parsed;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -601,6 +601,7 @@ export interface SubscriptionPollResult {
 export interface ListInboxItemsOptions {
   afterEntryId?: string;
   includeAcked?: boolean;
+  limit?: number;
 }
 
 export interface WatchInboxOptions extends ListInboxItemsOptions {

--- a/src/service.ts
+++ b/src/service.ts
@@ -274,16 +274,16 @@ export class AgentInboxService {
     return source;
   }
 
-  listSources(): SourceStream[] {
-    return this.store.listSources();
+  listSources(limit?: number): SourceStream[] {
+    return this.store.listSources(limit);
   }
 
-  async listSourceViews(): Promise<Array<SourceStream & { runtime: SourceRuntimeState | null }>> {
-    return this.attachSourceRuntimes(this.store.listSources());
+  async listSourceViews(limit?: number): Promise<Array<SourceStream & { runtime: SourceRuntimeState | null }>> {
+    return this.attachSourceRuntimes(this.store.listSources(limit));
   }
 
-  listHosts(): SourceHost[] {
-    return this.store.listSourceHosts();
+  listHosts(limit?: number): SourceHost[] {
+    return this.store.listSourceHosts(limit);
   }
 
   getHost(hostId: string): SourceHost {
@@ -417,8 +417,8 @@ export class AgentInboxService {
       });
   }
 
-  listStreams(): SourceStream[] {
-    return this.listSources();
+  listStreams(limit?: number): SourceStream[] {
+    return this.listSources(limit);
   }
 
   getStream(streamId: string): SourceStream {
@@ -769,8 +769,8 @@ export class AgentInboxService {
     });
   }
 
-  listAgents(): Agent[] {
-    return this.store.listAgents();
+  listAgents(limit?: number): Agent[] {
+    return this.store.listAgents(limit);
   }
 
   getAgent(agentId: string): Agent {
@@ -852,12 +852,12 @@ export class AgentInboxService {
     return timer;
   }
 
-  listTimers(agentId?: string): AgentTimer[] {
+  listTimers(agentId?: string, limit?: number): AgentTimer[] {
     if (agentId) {
       this.getAgent(agentId);
-      return this.store.listTimersForAgent(agentId);
+      return this.store.listTimersForAgent(agentId, limit);
     }
-    return this.store.listTimers();
+    return this.store.listTimers(limit);
   }
 
   getTimer(scheduleId: string): AgentTimer {
@@ -950,12 +950,12 @@ export class AgentInboxService {
     return target;
   }
 
-  listActivationTargets(agentId?: string): ActivationTarget[] {
+  listActivationTargets(agentId?: string, limit?: number): ActivationTarget[] {
     if (agentId) {
       this.getAgent(agentId);
-      return this.store.listActivationTargetsForAgent(agentId);
+      return this.store.listActivationTargetsForAgent(agentId, limit);
     }
-    return this.store.listActivationTargets();
+    return this.store.listActivationTargets(limit);
   }
 
   getActivationTarget(targetId: string): ActivationTarget {
@@ -1250,16 +1250,9 @@ export class AgentInboxService {
   listSubscriptions(filters?: {
     sourceId?: string;
     agentId?: string;
+    limit?: number;
   }): Subscription[] {
-    return this.store.listSubscriptions().filter((subscription) => {
-      if (filters?.sourceId && subscription.sourceId !== filters.sourceId) {
-        return false;
-      }
-      if (filters?.agentId && subscription.agentId !== filters.agentId) {
-        return false;
-      }
-      return true;
-    });
+    return this.store.listSubscriptionsFiltered(filters);
   }
 
   getSubscription(subscriptionId: string): Subscription {
@@ -1337,8 +1330,8 @@ export class AgentInboxService {
     return this.appendSourceEvent({ ...input, sourceId });
   }
 
-  listInboxAgentIds(): string[] {
-    return this.store.listInboxes().map((inbox) => inbox.ownerAgentId);
+  listInboxAgentIds(limit?: number): string[] {
+    return this.store.listInboxes(limit).map((inbox) => inbox.ownerAgentId);
   }
 
   getInboxDetailsByAgent(agentId: string): Record<string, unknown> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -395,8 +395,10 @@ export class AgentInboxStore {
     this.persist();
   }
 
-  listSourceHosts(): SourceHost[] {
-    const rows = this.getAll("select * from source_hosts order by created_at asc");
+  listSourceHosts(limit?: number): SourceHost[] {
+    const rows = typeof limit === "number"
+      ? this.getAll("select * from source_hosts order by created_at asc limit ?", [limit])
+      : this.getAll("select * from source_hosts order by created_at asc");
     return rows.map((row) => this.mapSourceHost(row));
   }
 
@@ -493,8 +495,10 @@ export class AgentInboxStore {
     this.persist();
   }
 
-  listSources(): SourceStream[] {
-    const rows = this.getAll("select * from sources order by created_at asc");
+  listSources(limit?: number): SourceStream[] {
+    const rows = typeof limit === "number"
+      ? this.getAll("select * from sources order by created_at asc limit ?", [limit])
+      : this.getAll("select * from sources order by created_at asc");
     return rows.map((row) => this.mapSource(row));
   }
 
@@ -681,8 +685,10 @@ export class AgentInboxStore {
     return this.getAgent(agentId)!;
   }
 
-  listAgents(): Agent[] {
-    const rows = this.getAll("select * from agents order by created_at asc");
+  listAgents(limit?: number): Agent[] {
+    const rows = typeof limit === "number"
+      ? this.getAll("select * from agents order by created_at asc limit ?", [limit])
+      : this.getAll("select * from agents order by created_at asc");
     return rows.map((row) => this.mapAgent(row));
   }
 
@@ -743,8 +749,10 @@ export class AgentInboxStore {
     return this.getInbox(inboxId)!;
   }
 
-  listInboxes(): Inbox[] {
-    const rows = this.getAll("select * from inboxes order by created_at asc");
+  listInboxes(limit?: number): Inbox[] {
+    const rows = typeof limit === "number"
+      ? this.getAll("select * from inboxes order by created_at asc limit ?", [limit])
+      : this.getAll("select * from inboxes order by created_at asc");
     return rows.map((row) => this.mapInbox(row));
   }
 
@@ -776,24 +784,56 @@ export class AgentInboxStore {
     this.persist();
   }
 
-  listSubscriptions(): Subscription[] {
-    const rows = this.getAll("select * from subscriptions order by created_at asc");
+  listSubscriptions(limit?: number): Subscription[] {
+    const rows = typeof limit === "number"
+      ? this.getAll("select * from subscriptions order by created_at asc limit ?", [limit])
+      : this.getAll("select * from subscriptions order by created_at asc");
     return rows.map((row) => this.mapSubscription(row));
   }
 
-  listSubscriptionsForSource(sourceId: string): Subscription[] {
-    const rows = this.getAll(
-      "select * from subscriptions where source_id = ? order by created_at asc",
-      [sourceId],
-    );
+  listSubscriptionsFiltered(filters?: { sourceId?: string; agentId?: string; limit?: number }): Subscription[] {
+    const clauses: string[] = [];
+    const params: Array<string | number> = [];
+    if (filters?.sourceId) {
+      clauses.push("source_id = ?");
+      params.push(filters.sourceId);
+    }
+    if (filters?.agentId) {
+      clauses.push("agent_id = ?");
+      params.push(filters.agentId);
+    }
+    const where = clauses.length > 0 ? ` where ${clauses.join(" and ")}` : "";
+    const limitClause = typeof filters?.limit === "number" ? " limit ?" : "";
+    if (typeof filters?.limit === "number") {
+      params.push(filters.limit);
+    }
+    const rows = this.getAll(`select * from subscriptions${where} order by created_at asc${limitClause}`, params);
     return rows.map((row) => this.mapSubscription(row));
   }
 
-  listSubscriptionsForAgent(agentId: string): Subscription[] {
-    const rows = this.getAll(
-      "select * from subscriptions where agent_id = ? order by created_at asc",
-      [agentId],
-    );
+  listSubscriptionsForSource(sourceId: string, limit?: number): Subscription[] {
+    const rows = typeof limit === "number"
+      ? this.getAll(
+        "select * from subscriptions where source_id = ? order by created_at asc limit ?",
+        [sourceId, limit],
+      )
+      : this.getAll(
+        "select * from subscriptions where source_id = ? order by created_at asc",
+        [sourceId],
+      );
+    return rows.map((row) => this.mapSubscription(row));
+  }
+
+  listSubscriptionsForAgent(agentId: string, limit?: number): Subscription[] {
+    const rows = typeof limit === "number"
+      ? this.getAll(
+        "select * from subscriptions where agent_id = ? order by created_at asc limit ?",
+        [agentId, limit],
+      )
+      : this.getAll(
+        "select * from subscriptions where agent_id = ? order by created_at asc",
+        [agentId],
+      );
     return rows.map((row) => this.mapSubscription(row));
   }
 
@@ -1116,16 +1156,23 @@ export class AgentInboxStore {
     return this.getActivationTarget(targetId)!;
   }
 
-  listActivationTargets(): ActivationTarget[] {
-    const rows = this.getAll("select * from activation_targets order by created_at asc");
+  listActivationTargets(limit?: number): ActivationTarget[] {
+    const rows = typeof limit === "number"
+      ? this.getAll("select * from activation_targets order by created_at asc limit ?", [limit])
+      : this.getAll("select * from activation_targets order by created_at asc");
     return rows.map((row) => this.mapActivationTarget(row));
   }
 
-  listActivationTargetsForAgent(agentId: string): ActivationTarget[] {
-    const rows = this.getAll(
-      "select * from activation_targets where agent_id = ? order by created_at asc",
-      [agentId],
-    );
+  listActivationTargetsForAgent(agentId: string, limit?: number): ActivationTarget[] {
+    const rows = typeof limit === "number"
+      ? this.getAll(
+        "select * from activation_targets where agent_id = ? order by created_at asc limit ?",
+        [agentId, limit],
+      )
+      : this.getAll(
+        "select * from activation_targets where agent_id = ? order by created_at asc",
+        [agentId],
+      );
     return rows.map((row) => this.mapActivationTarget(row));
   }
 
@@ -1222,13 +1269,17 @@ export class AgentInboxStore {
     return row ? this.mapTimer(row) : null;
   }
 
-  listTimers(): AgentTimer[] {
-    const rows = this.getAll("select * from timers order by created_at asc");
+  listTimers(limit?: number): AgentTimer[] {
+    const rows = typeof limit === "number"
+      ? this.getAll("select * from timers order by created_at asc limit ?", [limit])
+      : this.getAll("select * from timers order by created_at asc");
     return rows.map((row) => this.mapTimer(row));
   }
 
-  listTimersForAgent(agentId: string): AgentTimer[] {
-    const rows = this.getAll("select * from timers where agent_id = ? order by created_at asc", [agentId]);
+  listTimersForAgent(agentId: string, limit?: number): AgentTimer[] {
+    const rows = typeof limit === "number"
+      ? this.getAll("select * from timers where agent_id = ? order by created_at asc limit ?", [agentId, limit])
+      : this.getAll("select * from timers where agent_id = ? order by created_at asc", [agentId]);
     return rows.map((row) => this.mapTimer(row));
   }
 
@@ -1464,10 +1515,11 @@ export class AgentInboxStore {
       filters.push("sequence > ?");
       params.push(Number(anchor.sequence));
     }
-    const rows = this.getAll(
-      `select * from inbox_entries where ${filters.join(" and ")} order by sequence asc`,
-      params,
-    );
+    const sql = `select * from inbox_entries where ${filters.join(" and ")} order by sequence asc${typeof options?.limit === "number" ? " limit ?" : ""}`;
+    if (typeof options?.limit === "number") {
+      params.push(options.limit);
+    }
+    const rows = this.getAll(sql, params);
     return this.mapInboxEntries(rows);
   }
 
@@ -1733,10 +1785,11 @@ export class AgentInboxStore {
       filters.push("acked_at is null");
     }
 
-    const rows = this.getAll(
-      `select * from inbox_items where ${filters.join(" and ")} order by coalesce(inbox_sequence, rowid) asc`,
-      params,
-    );
+    const sql = `select * from inbox_items where ${filters.join(" and ")} order by coalesce(inbox_sequence, rowid) asc${typeof options?.limit === "number" ? " limit ?" : ""}`;
+    if (typeof options?.limit === "number") {
+      params.push(options.limit);
+    }
+    const rows = this.getAll(sql, params);
     return rows.map((row) => this.mapInboxItem(row));
   }
 
@@ -1908,8 +1961,10 @@ export class AgentInboxStore {
     return row ? this.mapStream(row) : null;
   }
 
-  listStreams(): StreamRecord[] {
-    const rows = this.getAll("select * from streams order by created_at asc");
+  listStreams(limit?: number): StreamRecord[] {
+    const rows = typeof limit === "number"
+      ? this.getAll("select * from streams order by created_at asc limit ?", [limit])
+      : this.getAll("select * from streams order by created_at asc");
     return rows.map((row) => this.mapStream(row));
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -397,8 +397,8 @@ export class AgentInboxStore {
 
   listSourceHosts(limit?: number): SourceHost[] {
     const rows = typeof limit === "number"
-      ? this.getAll("select * from source_hosts order by created_at asc limit ?", [limit])
-      : this.getAll("select * from source_hosts order by created_at asc");
+      ? this.getAll("select * from source_hosts order by created_at asc, host_id asc limit ?", [limit])
+      : this.getAll("select * from source_hosts order by created_at asc, host_id asc");
     return rows.map((row) => this.mapSourceHost(row));
   }
 
@@ -497,8 +497,8 @@ export class AgentInboxStore {
 
   listSources(limit?: number): SourceStream[] {
     const rows = typeof limit === "number"
-      ? this.getAll("select * from sources order by created_at asc limit ?", [limit])
-      : this.getAll("select * from sources order by created_at asc");
+      ? this.getAll("select * from sources order by created_at asc, source_id asc limit ?", [limit])
+      : this.getAll("select * from sources order by created_at asc, source_id asc");
     return rows.map((row) => this.mapSource(row));
   }
 
@@ -687,8 +687,8 @@ export class AgentInboxStore {
 
   listAgents(limit?: number): Agent[] {
     const rows = typeof limit === "number"
-      ? this.getAll("select * from agents order by created_at asc limit ?", [limit])
-      : this.getAll("select * from agents order by created_at asc");
+      ? this.getAll("select * from agents order by created_at asc, agent_id asc limit ?", [limit])
+      : this.getAll("select * from agents order by created_at asc, agent_id asc");
     return rows.map((row) => this.mapAgent(row));
   }
 
@@ -751,8 +751,8 @@ export class AgentInboxStore {
 
   listInboxes(limit?: number): Inbox[] {
     const rows = typeof limit === "number"
-      ? this.getAll("select * from inboxes order by created_at asc limit ?", [limit])
-      : this.getAll("select * from inboxes order by created_at asc");
+      ? this.getAll("select * from inboxes order by created_at asc, inbox_id asc limit ?", [limit])
+      : this.getAll("select * from inboxes order by created_at asc, inbox_id asc");
     return rows.map((row) => this.mapInbox(row));
   }
 
@@ -786,8 +786,8 @@ export class AgentInboxStore {
 
   listSubscriptions(limit?: number): Subscription[] {
     const rows = typeof limit === "number"
-      ? this.getAll("select * from subscriptions order by created_at asc limit ?", [limit])
-      : this.getAll("select * from subscriptions order by created_at asc");
+      ? this.getAll("select * from subscriptions order by created_at asc, subscription_id asc limit ?", [limit])
+      : this.getAll("select * from subscriptions order by created_at asc, subscription_id asc");
     return rows.map((row) => this.mapSubscription(row));
   }
 
@@ -807,18 +807,18 @@ export class AgentInboxStore {
     if (typeof filters?.limit === "number") {
       params.push(filters.limit);
     }
-    const rows = this.getAll(`select * from subscriptions${where} order by created_at asc${limitClause}`, params);
+    const rows = this.getAll(`select * from subscriptions${where} order by created_at asc, subscription_id asc${limitClause}`, params);
     return rows.map((row) => this.mapSubscription(row));
   }
 
   listSubscriptionsForSource(sourceId: string, limit?: number): Subscription[] {
     const rows = typeof limit === "number"
       ? this.getAll(
-        "select * from subscriptions where source_id = ? order by created_at asc limit ?",
+        "select * from subscriptions where source_id = ? order by created_at asc, subscription_id asc limit ?",
         [sourceId, limit],
       )
       : this.getAll(
-        "select * from subscriptions where source_id = ? order by created_at asc",
+        "select * from subscriptions where source_id = ? order by created_at asc, subscription_id asc",
         [sourceId],
       );
     return rows.map((row) => this.mapSubscription(row));
@@ -827,16 +827,15 @@ export class AgentInboxStore {
   listSubscriptionsForAgent(agentId: string, limit?: number): Subscription[] {
     const rows = typeof limit === "number"
       ? this.getAll(
-        "select * from subscriptions where agent_id = ? order by created_at asc limit ?",
+        "select * from subscriptions where agent_id = ? order by created_at asc, subscription_id asc limit ?",
         [agentId, limit],
       )
       : this.getAll(
-        "select * from subscriptions where agent_id = ? order by created_at asc",
+        "select * from subscriptions where agent_id = ? order by created_at asc, subscription_id asc",
         [agentId],
       );
     return rows.map((row) => this.mapSubscription(row));
   }
-
   listSubscriptionsForHostTrackedResourceRef(hostId: string, trackedResourceRef: string): Subscription[] {
     const rows = this.getAll(
       `
@@ -1158,19 +1157,19 @@ export class AgentInboxStore {
 
   listActivationTargets(limit?: number): ActivationTarget[] {
     const rows = typeof limit === "number"
-      ? this.getAll("select * from activation_targets order by created_at asc limit ?", [limit])
-      : this.getAll("select * from activation_targets order by created_at asc");
+      ? this.getAll("select * from activation_targets order by created_at asc, target_id asc limit ?", [limit])
+      : this.getAll("select * from activation_targets order by created_at asc, target_id asc");
     return rows.map((row) => this.mapActivationTarget(row));
   }
 
   listActivationTargetsForAgent(agentId: string, limit?: number): ActivationTarget[] {
     const rows = typeof limit === "number"
       ? this.getAll(
-        "select * from activation_targets where agent_id = ? order by created_at asc limit ?",
+        "select * from activation_targets where agent_id = ? order by created_at asc, target_id asc limit ?",
         [agentId, limit],
       )
       : this.getAll(
-        "select * from activation_targets where agent_id = ? order by created_at asc",
+        "select * from activation_targets where agent_id = ? order by created_at asc, target_id asc",
         [agentId],
       );
     return rows.map((row) => this.mapActivationTarget(row));
@@ -1271,15 +1270,15 @@ export class AgentInboxStore {
 
   listTimers(limit?: number): AgentTimer[] {
     const rows = typeof limit === "number"
-      ? this.getAll("select * from timers order by created_at asc limit ?", [limit])
-      : this.getAll("select * from timers order by created_at asc");
+      ? this.getAll("select * from timers order by created_at asc, schedule_id asc limit ?", [limit])
+      : this.getAll("select * from timers order by created_at asc, schedule_id asc");
     return rows.map((row) => this.mapTimer(row));
   }
 
   listTimersForAgent(agentId: string, limit?: number): AgentTimer[] {
     const rows = typeof limit === "number"
-      ? this.getAll("select * from timers where agent_id = ? order by created_at asc limit ?", [agentId, limit])
-      : this.getAll("select * from timers where agent_id = ? order by created_at asc", [agentId]);
+      ? this.getAll("select * from timers where agent_id = ? order by created_at asc, schedule_id asc limit ?", [agentId, limit])
+      : this.getAll("select * from timers where agent_id = ? order by created_at asc, schedule_id asc", [agentId]);
     return rows.map((row) => this.mapTimer(row));
   }
 
@@ -1963,8 +1962,8 @@ export class AgentInboxStore {
 
   listStreams(limit?: number): StreamRecord[] {
     const rows = typeof limit === "number"
-      ? this.getAll("select * from streams order by created_at asc limit ?", [limit])
-      : this.getAll("select * from streams order by created_at asc");
+      ? this.getAll("select * from streams order by created_at asc, stream_id asc limit ?", [limit])
+      : this.getAll("select * from streams order by created_at asc, stream_id asc");
     return rows.map((row) => this.mapStream(row));
   }
 

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -838,6 +838,172 @@ test("control plane GET /agents can include activation target summaries", async 
   }
 });
 
+test("control plane list endpoints apply limit server-side", async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-limit-"));
+  const socketPath = path.join(homeDir, "agentinbox.sock");
+  const dbPath = path.join(homeDir, "agentinbox.sqlite");
+
+  const store = await AgentInboxStore.open(dbPath);
+  let service: AgentInboxService;
+  const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input));
+  service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
+    stdout: "",
+    stderr: "",
+  })));
+  const server = createServer(service);
+
+  try {
+    await adapters.start();
+    await service.start();
+    const started = await startControlServer(server, { kind: "socket", socketPath });
+    try {
+      const futureAtA = new Date(Date.now() + 60_000).toISOString();
+      const futureAtB = new Date(Date.now() + 120_000).toISOString();
+      const client = new AgentInboxClient({ kind: "socket", socketPath, source: "flag" });
+
+      const hostA = await client.request<{ hostId: string }>("/hosts", {
+        hostType: "local_event",
+        hostKey: "limit-host-a",
+      });
+      const hostB = await client.request<{ hostId: string }>("/hosts", {
+        hostType: "local_event",
+        hostKey: "limit-host-b",
+      });
+      assert.equal(hostA.statusCode, 200);
+      assert.equal(hostB.statusCode, 200);
+
+      const sourceA = await client.request<{ sourceId: string }>("/sources", {
+        hostId: hostA.data.hostId,
+        streamKind: "events",
+        streamKey: "limit-source-a",
+        config: {},
+      });
+      const sourceB = await client.request<{ sourceId: string }>("/sources", {
+        hostId: hostB.data.hostId,
+        streamKind: "events",
+        streamKey: "limit-source-b",
+        config: {},
+      });
+      assert.equal(sourceA.statusCode, 200);
+      assert.equal(sourceB.statusCode, 200);
+
+      const agentA = await client.request<{ agent: { agentId: string } }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-limit-a",
+        tmuxPaneId: "%881",
+      });
+      const agentB = await client.request<{ agent: { agentId: string } }>("/agents", {
+        backend: "tmux",
+        runtimeKind: "codex",
+        runtimeSessionId: "thread-http-limit-b",
+        tmuxPaneId: "%882",
+      });
+      assert.equal(agentA.statusCode, 200);
+      assert.equal(agentB.statusCode, 200);
+
+      const agentAId = agentA.data.agent.agentId;
+      const agentBId = agentB.data.agent.agentId;
+
+      await client.request(`/agents/${encodeURIComponent(agentAId)}/targets`, {
+        kind: "webhook",
+        url: "http://127.0.0.1:9901/a",
+      });
+      await client.request(`/agents/${encodeURIComponent(agentAId)}/targets`, {
+        kind: "webhook",
+        url: "http://127.0.0.1:9901/b",
+      });
+
+      await client.request("/timers", {
+        agentId: agentAId,
+        at: futureAtA,
+        message: "timer a",
+      });
+      await client.request("/timers", {
+        agentId: agentAId,
+        at: futureAtB,
+        message: "timer b",
+      });
+
+      const subA = await client.request<{ subscriptions: Array<{ subscriptionId: string }> }>("/subscriptions", {
+        agentId: agentAId,
+        sourceId: sourceA.data.sourceId,
+        filter: {},
+      });
+      const subB = await client.request<{ subscriptions: Array<{ subscriptionId: string }> }>("/subscriptions", {
+        agentId: agentAId,
+        sourceId: sourceB.data.sourceId,
+        filter: {},
+      });
+      assert.equal(subA.statusCode, 200);
+      assert.equal(subB.statusCode, 200);
+
+      await client.request(`/agents/${encodeURIComponent(agentBId)}/inbox/items`, { message: "one" });
+      await client.request(`/agents/${encodeURIComponent(agentBId)}/inbox/items`, { message: "two" });
+
+      const hosts = await client.request<{ hosts: Array<{ hostId: string }> }>("/hosts?limit=1", undefined, "GET");
+      const streams = await client.request<{ streams: Array<{ sourceId: string }> }>("/streams?limit=1", undefined, "GET");
+      const sources = await client.request<{ sources: Array<{ sourceId: string }> }>("/sources?limit=1", undefined, "GET");
+      const agents = await client.request<{ agents: Array<{ agent: { agentId: string } }> }>("/agents?include_targets=true&limit=1", undefined, "GET");
+      const targets = await client.request<{ targets: Array<{ targetId: string }> }>(
+        `/agents/${encodeURIComponent(agentAId)}/targets?limit=1`,
+        undefined,
+        "GET",
+      );
+      const timers = await client.request<{ timers: Array<{ scheduleId: string }> }>(
+        `/timers?agent_id=${encodeURIComponent(agentAId)}&limit=1`,
+        undefined,
+        "GET",
+      );
+      const subs = await client.request<{ subscriptions: Array<{ subscriptionId: string }> }>(
+        `/subscriptions?agent_id=${encodeURIComponent(agentAId)}&limit=1`,
+        undefined,
+        "GET",
+      );
+      const inboxes = await client.request<{ agents: Array<{ agentId?: string; agent?: { agentId: string } }> }>("/agents?limit=1", undefined, "GET");
+      const entries = await client.request<{ entries: Array<{ entryId: string }> }>(
+        `/agents/${encodeURIComponent(agentBId)}/inbox/entries?include_acked=true&limit=1`,
+        undefined,
+        "GET",
+      );
+
+      assert.equal(hosts.statusCode, 200);
+      assert.equal(hosts.data.hosts.length, 1);
+      assert.equal(streams.statusCode, 200);
+      assert.equal(streams.data.streams.length, 1);
+      assert.equal(sources.statusCode, 200);
+      assert.equal(sources.data.sources.length, 1);
+      assert.equal(agents.statusCode, 200);
+      assert.equal(agents.data.agents.length, 1);
+      assert.equal(targets.statusCode, 200);
+      assert.equal(targets.data.targets.length, 1);
+      assert.equal(timers.statusCode, 200);
+      assert.equal(timers.data.timers.length, 1);
+      assert.equal(subs.statusCode, 200);
+      assert.equal(subs.data.subscriptions.length, 1);
+      assert.equal(inboxes.statusCode, 200);
+      assert.equal(inboxes.data.agents.length, 1);
+      assert.equal(entries.statusCode, 200);
+      assert.equal(entries.data.entries.length, 1);
+
+      const limitedAfter = await client.request<{ entries: Array<{ entryId: string }> }>(
+        `/agents/${encodeURIComponent(agentBId)}/inbox/entries?include_acked=true&after_entry_id=${encodeURIComponent(entries.data.entries[0]!.entryId)}&limit=1`,
+        undefined,
+        "GET",
+      );
+      assert.equal(limitedAfter.statusCode, 200);
+      assert.equal(limitedAfter.data.entries.length, 1);
+    } finally {
+      await started.close();
+    }
+  } finally {
+    await adapters.stop();
+    await service.stop();
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("control plane source views surface backend managed runtime state", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-http-source-runtime-"));
   const socketPath = path.join(homeDir, "agentinbox.sock");
@@ -1510,7 +1676,67 @@ test("cli inbox read rejects unsupported flags like --ack", () => {
   try {
     const read = runCli(["inbox", "read", "--ack"], env);
     assert.notEqual(read.status, 0);
-    assert.match(read.stderr, /usage: agentinbox inbox read \[--agent-id ID] \[--after-entry ID] \[--include-acked]/);
+    assert.match(read.stderr, /usage: agentinbox inbox read \[--agent-id ID] \[--after-entry ID] \[--include-acked] \[--limit N]/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli one-shot list and read commands accept --limit", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-limit-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%983",
+    CODEX_THREAD_ID: "thread-cli-limit",
+  };
+
+  try {
+    const futureAt = new Date(Date.now() + 60_000).toISOString();
+    const register = runCli(["agent", "register"], env);
+    assert.equal(register.status, 0, register.stderr);
+    const registered = JSON.parse(register.stdout) as { agent: { agentId: string } };
+    const agentId = registered.agent.agentId;
+
+    const timer = runCli([
+      "timer",
+      "add",
+      "--agent-id",
+      agentId,
+      "--at",
+      futureAt,
+      "--message",
+      "cap timer results",
+    ], env);
+    assert.equal(timer.status, 0, timer.stderr);
+
+    const sendOne = runCli(["inbox", "send", "--agent-id", agentId, "--message", "first"], env);
+    assert.equal(sendOne.status, 0, sendOne.stderr);
+    const sendTwo = runCli(["inbox", "send", "--agent-id", agentId, "--message", "second"], env);
+    assert.equal(sendTwo.status, 0, sendTwo.stderr);
+
+    for (const args of [
+      ["host", "list", "--limit", "1"],
+      ["stream", "list", "--limit", "1"],
+      ["source", "list", "--limit", "1"],
+      ["agent", "list", "--limit", "1"],
+      ["agent", "target", "list", agentId, "--limit", "1"],
+      ["timer", "list", "--agent-id", agentId, "--limit", "1"],
+      ["subscription", "list", "--agent-id", agentId, "--limit", "1"],
+      ["inbox", "list", "--limit", "1"],
+    ] as string[][]) {
+      const result = runCli(args, env);
+      assert.equal(result.status, 0, result.stderr);
+    }
+
+    const read = runCli(["inbox", "read", "--agent-id", agentId, "--include-acked", "--limit", "1"], env);
+    assert.equal(read.status, 0, read.stderr);
+    const payload = JSON.parse(read.stdout) as { entries: Array<unknown> };
+    assert.equal(payload.entries.length, 1);
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add `--limit` support to one-shot list/read CLI commands including inbox read
- accept `limit` on matching HTTP list endpoints and parse it consistently
- push limit into store/service query paths so results are capped server-side with stable ordering

## Verification
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `node --require ts-node/register --test --test-name-pattern='control plane list endpoints apply limit server-side' test/control_plane.test.ts`
- `node /tmp/cli-limit-debug.js`

Closes #183
