### PR TITLE
feat: preserve provider raw payloads

### DIFF
--- a/docs/site/concepts/eventbus-backend.md
+++ b/docs/site/concepts/eventbus-backend.md
@@ -187,6 +187,7 @@ export interface StreamEventRecord {
   occurredAt: string;
   metadata: Record<string, unknown>;
   rawPayload: Record<string, unknown>;
+  providerRawPayload?: Record<string, unknown>;
   deliveryHandle: Record<string, unknown> | null;
 }
 

--- a/docs/site/rfcs/source-kinds-and-resolved-schemas.md
+++ b/docs/site/rfcs/source-kinds-and-resolved-schemas.md
@@ -87,7 +87,7 @@ The recommended split remains:
 - source registry
 - resolved source identity and resolved schema
 - implementation/module resolution
-- raw event to `eventVariant` / `metadata` / `rawPayload` mapping
+- raw event to `eventVariant` / `metadata` / normalized `rawPayload` mapping, with optional `providerRawPayload` preservation when the original provider event should remain available to agents
 - subscription filters and shortcuts
 - inbox materialization
 - activation and delivery

--- a/drizzle/migrations/0004_provider_raw_payload.sql
+++ b/drizzle/migrations/0004_provider_raw_payload.sql
@@ -1,0 +1,3 @@
+alter table inbox_items add column provider_raw_payload_json text;
+
+alter table stream_events add column provider_raw_payload_json text;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -173,6 +173,7 @@ export const inboxItems = sqliteTable("inbox_items", {
   occurredAt: text("occurred_at").notNull(),
   metadataJson: text("metadata_json").notNull(),
   rawPayloadJson: text("raw_payload_json").notNull(),
+  providerRawPayloadJson: text("provider_raw_payload_json"),
   deliveryHandleJson: text("delivery_handle_json"),
   ackedAt: text("acked_at"),
 }, (table) => ({
@@ -302,6 +303,7 @@ export const streamEvents = sqliteTable("stream_events", {
   occurredAt: text("occurred_at").notNull(),
   metadataJson: text("metadata_json").notNull(),
   rawPayloadJson: text("raw_payload_json").notNull(),
+  providerRawPayloadJson: text("provider_raw_payload_json"),
   deliveryHandleJson: text("delivery_handle_json"),
   createdAt: text("created_at").notNull(),
 }, (table) => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/swagger": "^9.5.2",
-        "@holon-run/uxc-daemon-client": "^0.15.3",
+        "@holon-run/uxc-daemon-client": "^0.15.4",
         "fastify": "^5.6.1",
         "jexl": "^2.3.0",
         "sql.js": "^1.13.0"
@@ -637,9 +637,9 @@
       }
     },
     "node_modules/@holon-run/uxc-daemon-client": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.15.3.tgz",
-      "integrity": "sha512-YXKohCtKmmYU/LvwLFsDwCtdiHJbLPTlmmk9+1tOihtFEoikQwByNM22G9dxWjPu/B8JX3xUehIHHGDvXB8mWw==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.15.4.tgz",
+      "integrity": "sha512-Rz6qUCPEtgnwanghASX/YJ7kAo+EdaXgdf+m4hAhZl64TDDaoHtFQF+5PB7EutXCD0Yf1ahID2F/jLxhy4+Wxw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@fastify/swagger": "^9.5.2",
-    "@holon-run/uxc-daemon-client": "^0.15.3",
+    "@holon-run/uxc-daemon-client": "^0.15.4",
     "fastify": "^5.6.1",
     "jexl": "^2.3.0",
     "sql.js": "^1.13.0"

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -24,6 +24,7 @@ export interface StreamEventRecord {
   occurredAt: string;
   metadata: Record<string, unknown>;
   rawPayload: Record<string, unknown>;
+  providerRawPayload?: Record<string, unknown>;
   deliveryHandle: Record<string, unknown> | null;
   createdAt: string;
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -578,6 +578,7 @@ function buildFastifyServer(service: AgentInboxService) {
           occurredAt: { type: "string", minLength: 1 },
           metadata: jsonObjectSchema,
           rawPayload: jsonObjectSchema,
+          providerRawPayload: jsonObjectSchema,
         },
       },
       response: {
@@ -592,6 +593,7 @@ function buildFastifyServer(service: AgentInboxService) {
       occurredAt?: string;
       metadata?: Record<string, unknown>;
       rawPayload?: Record<string, unknown>;
+      providerRawPayload?: Record<string, unknown>;
     };
     return service.appendSourceEvent({
       sourceId: decodeURIComponent(params.streamId),
@@ -600,6 +602,7 @@ function buildFastifyServer(service: AgentInboxService) {
       occurredAt: body.occurredAt,
       metadata: body.metadata ?? {},
       rawPayload: body.rawPayload ?? {},
+      providerRawPayload: body.providerRawPayload,
     });
   });
 
@@ -744,6 +747,7 @@ function buildFastifyServer(service: AgentInboxService) {
           occurredAt: { type: "string", minLength: 1 },
           metadata: jsonObjectSchema,
           rawPayload: jsonObjectSchema,
+          providerRawPayload: jsonObjectSchema,
           deliveryHandle: deliveryHandleSchema,
         },
       },
@@ -760,6 +764,7 @@ function buildFastifyServer(service: AgentInboxService) {
       occurredAt?: string;
       metadata?: Record<string, unknown>;
       rawPayload?: Record<string, unknown>;
+      providerRawPayload?: Record<string, unknown>;
       deliveryHandle?: DeliveryHandle;
     };
     return service.appendSourceEventByCaller(decodeURIComponent(params.sourceId), {
@@ -768,6 +773,7 @@ function buildFastifyServer(service: AgentInboxService) {
       occurredAt: optionalString(body.occurredAt),
       metadata: body.metadata ?? {},
       rawPayload: body.rawPayload ?? {},
+      providerRawPayload: body.providerRawPayload,
       deliveryHandle: body.deliveryHandle ?? null,
     });
   });

--- a/src/model.ts
+++ b/src/model.ts
@@ -205,6 +205,7 @@ export interface InboxItem {
   occurredAt: string;
   metadata: Record<string, unknown>;
   rawPayload: Record<string, unknown>;
+  providerRawPayload?: Record<string, unknown>;
   deliveryHandle?: DeliveryHandle | null;
   ackedAt?: string | null;
 }
@@ -218,6 +219,7 @@ export interface ActivationItem {
   occurredAt: string;
   metadata: Record<string, unknown>;
   rawPayload: Record<string, unknown>;
+  providerRawPayload?: Record<string, unknown>;
   deliveryHandle?: DeliveryHandle | null;
 }
 
@@ -235,6 +237,7 @@ interface InboxEntryBase {
   occurredAt?: string;
   metadata?: Record<string, unknown>;
   rawPayload?: Record<string, unknown>;
+  providerRawPayload?: Record<string, unknown>;
   summary: string;
   count: number;
   itemIds: string[];
@@ -523,6 +526,7 @@ export interface AppendSourceEventInput {
   occurredAt?: string;
   metadata?: Record<string, unknown>;
   rawPayload?: Record<string, unknown>;
+  providerRawPayload?: Record<string, unknown>;
   deliveryHandle?: DeliveryHandle | null;
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -1456,6 +1456,7 @@ export class AgentInboxService {
       occurredAt,
       metadata: {},
       rawPayload: input.rawPayload,
+      providerRawPayload: undefined,
       deliveryHandle: null,
       ackedAt: null,
     };
@@ -1834,6 +1835,7 @@ export class AgentInboxService {
               subscriptionId: subscription.subscriptionId,
             },
             rawPayload: event.rawPayload,
+            providerRawPayload: event.providerRawPayload,
             deliveryHandle: event.deliveryHandle as DeliveryHandle | null,
             ackedAt: null,
           };
@@ -3920,6 +3922,7 @@ function activationItemFromInboxItem(item: InboxItem): ActivationItem {
     occurredAt: item.occurredAt,
     metadata: item.metadata,
     rawPayload: item.rawPayload,
+    providerRawPayload: item.providerRawPayload,
     deliveryHandle: item.deliveryHandle,
   };
 }

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -43,7 +43,7 @@ export interface GithubCallClient {
     endpoint: string;
     operation: string;
     payload?: Record<string, unknown>;
-    options?: { auth?: string };
+    options?: { auth?: string; artifact_compaction?: boolean };
   }): Promise<{ data: unknown }>;
 }
 
@@ -65,7 +65,7 @@ export class GithubUxcClient {
         issue_number: input.issueNumber,
         body: input.body,
       },
-      options: { auth: input.auth },
+      options: githubInvokeOptions(input.auth),
     });
   }
 
@@ -80,7 +80,7 @@ export class GithubUxcClient {
         comment_id: input.commentId,
         body: input.body,
       },
-      options: { auth: input.auth },
+      options: githubInvokeOptions(input.auth),
     });
   }
 
@@ -100,7 +100,7 @@ export class GithubUxcClient {
         issue_number: input.issueNumber,
         state: input.state,
       },
-      options: { auth: input.auth },
+      options: githubInvokeOptions(input.auth),
     });
   }
 
@@ -124,7 +124,7 @@ export class GithubUxcClient {
         commit_title: input.commitTitle ?? null,
         commit_message: input.commitMessage ?? null,
       },
-      options: { auth: input.auth },
+      options: githubInvokeOptions(input.auth),
     });
   }
 
@@ -142,7 +142,7 @@ export class GithubUxcClient {
         repo: input.repo,
         pull_number: input.pullNumber,
       },
-      options: { auth: input.auth },
+      options: githubInvokeOptions(input.auth),
     });
     const data = asRecord(response.data);
     const head = asRecord(data.head);
@@ -398,7 +398,7 @@ export async function hydrateGithubRepoEventIfNeeded(
           per_page: perPage,
           page,
         },
-        options: { auth: config.uxcAuth },
+        options: githubInvokeOptions(config.uxcAuth),
       });
     } catch {
       return raw;
@@ -823,6 +823,13 @@ function computeGithubHydrationPerPage(perPage: number | undefined): number {
     ? perPage
     : GITHUB_EVENT_HYDRATION_MIN_PER_PAGE;
   return Math.min(GITHUB_EVENT_HYDRATION_MAX_PER_PAGE, Math.max(GITHUB_EVENT_HYDRATION_MIN_PER_PAGE, configured));
+}
+
+function githubInvokeOptions(auth?: string): { auth?: string; artifact_compaction: false } {
+  return {
+    auth,
+    artifact_compaction: false,
+  };
 }
 
 function extractGithubRepoEventUrl(

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -65,7 +65,7 @@ export class GithubUxcClient {
         issue_number: input.issueNumber,
         body: input.body,
       },
-      options: githubInvokeOptions(input.auth),
+      options: githubAuthOptions(input.auth),
     });
   }
 
@@ -80,7 +80,7 @@ export class GithubUxcClient {
         comment_id: input.commentId,
         body: input.body,
       },
-      options: githubInvokeOptions(input.auth),
+      options: githubAuthOptions(input.auth),
     });
   }
 
@@ -100,7 +100,7 @@ export class GithubUxcClient {
         issue_number: input.issueNumber,
         state: input.state,
       },
-      options: githubInvokeOptions(input.auth),
+      options: githubAuthOptions(input.auth),
     });
   }
 
@@ -124,7 +124,7 @@ export class GithubUxcClient {
         commit_title: input.commitTitle ?? null,
         commit_message: input.commitMessage ?? null,
       },
-      options: githubInvokeOptions(input.auth),
+      options: githubAuthOptions(input.auth),
     });
   }
 
@@ -142,7 +142,7 @@ export class GithubUxcClient {
         repo: input.repo,
         pull_number: input.pullNumber,
       },
-      options: githubInvokeOptions(input.auth),
+      options: githubReadOptions(input.auth),
     });
     const data = asRecord(response.data);
     const head = asRecord(data.head);
@@ -398,7 +398,7 @@ export async function hydrateGithubRepoEventIfNeeded(
           per_page: perPage,
           page,
         },
-        options: githubInvokeOptions(config.uxcAuth),
+        options: githubReadOptions(config.uxcAuth),
       });
     } catch {
       return raw;
@@ -825,7 +825,11 @@ function computeGithubHydrationPerPage(perPage: number | undefined): number {
   return Math.min(GITHUB_EVENT_HYDRATION_MAX_PER_PAGE, Math.max(GITHUB_EVENT_HYDRATION_MIN_PER_PAGE, configured));
 }
 
-function githubInvokeOptions(auth?: string): { auth?: string; artifact_compaction: false } {
+function githubAuthOptions(auth?: string): { auth?: string } {
+  return { auth };
+}
+
+function githubReadOptions(auth?: string): { auth?: string; artifact_compaction: false } {
   return {
     auth,
     artifact_compaction: false,

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -497,6 +497,7 @@ export class RemoteSourceRuntime {
           occurredAt: mapped.occurredAt,
           metadata: mapped.metadata,
           rawPayload: mapped.rawPayload,
+          providerRawPayload: mapped.providerRawPayload,
           deliveryHandle: mapped.deliveryHandle ?? null,
         });
         appended += result.appended;

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -67,6 +67,7 @@ export interface MappedRemoteEvent {
   eventVariant: string;
   metadata: Record<string, unknown>;
   rawPayload: Record<string, unknown>;
+  providerRawPayload?: Record<string, unknown>;
   occurredAt?: string;
   deliveryHandle?: AppendSourceEventInput["deliveryHandle"];
 }
@@ -474,7 +475,10 @@ export function createGithubRepoRemoteModule(options?: { callClient?: GithubCall
             seen_window: 1024,
           },
         },
-        options: { auth: config.uxcAuth },
+        options: {
+          auth: config.uxcAuth,
+          artifact_compaction: false,
+        },
       };
     },
     async mapRawEvent(rawPayload: Record<string, unknown>, source: SourceStream): Promise<MappedRemoteEvent | null> {
@@ -489,6 +493,7 @@ export function createGithubRepoRemoteModule(options?: { callClient?: GithubCall
         eventVariant: normalized.eventVariant,
         metadata: normalized.metadata ?? {},
         rawPayload: normalized.rawPayload ?? hydratedPayload,
+        providerRawPayload: hydratedPayload,
         occurredAt: normalized.occurredAt,
         deliveryHandle: normalized.deliveryHandle,
       };
@@ -613,7 +618,10 @@ const GITHUB_REPO_CI_MODULE: RemoteSourceModule = {
           seen_window: 1024,
         },
       },
-      options: { auth: config.uxcAuth },
+      options: {
+        auth: config.uxcAuth,
+        artifact_compaction: false,
+      },
     };
   },
   mapRawEvent(rawPayload: Record<string, unknown>, source: SourceStream): MappedRemoteEvent | null {
@@ -627,6 +635,7 @@ const GITHUB_REPO_CI_MODULE: RemoteSourceModule = {
       eventVariant: normalized.eventVariant,
       metadata: normalized.metadata ?? {},
       rawPayload: normalized.rawPayload ?? rawPayload,
+      providerRawPayload: rawPayload,
       occurredAt: normalized.occurredAt,
       deliveryHandle: normalized.deliveryHandle,
     };
@@ -680,7 +689,10 @@ const FEISHU_BOT_MODULE: RemoteSourceModule = {
       endpoint: config.endpoint ?? FEISHU_OPENAPI_ENDPOINT,
       mode: "stream",
       transport_hint: "feishu_long_connection",
-      options: { auth: config.uxcAuth },
+      options: {
+        auth: config.uxcAuth,
+        artifact_compaction: false,
+      },
     };
   },
   mapRawEvent(rawPayload: Record<string, unknown>, source: SourceStream): MappedRemoteEvent | null {
@@ -694,6 +706,7 @@ const FEISHU_BOT_MODULE: RemoteSourceModule = {
       eventVariant: normalized.eventVariant,
       metadata: normalized.metadata ?? {},
       rawPayload: normalized.rawPayload ?? rawPayload,
+      providerRawPayload: rawPayload,
       occurredAt: normalized.occurredAt,
       deliveryHandle: normalized.deliveryHandle,
     };

--- a/src/store.ts
+++ b/src/store.ts
@@ -1367,8 +1367,8 @@ export class AgentInboxStore {
       `
       insert or ignore into inbox_items (
         item_id, source_id, source_native_id, event_variant, inbox_id, occurred_at,
-        metadata_json, raw_payload_json, delivery_handle_json, acked_at
-      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        metadata_json, raw_payload_json, provider_raw_payload_json, delivery_handle_json, acked_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         item.itemId,
@@ -1379,6 +1379,7 @@ export class AgentInboxStore {
         item.occurredAt,
         JSON.stringify(item.metadata),
         JSON.stringify(item.rawPayload),
+        item.providerRawPayload ? JSON.stringify(item.providerRawPayload) : null,
         item.deliveryHandle ? JSON.stringify(item.deliveryHandle) : null,
         item.ackedAt ?? null,
       ],
@@ -1424,6 +1425,7 @@ export class AgentInboxStore {
         occurredAt: item.occurredAt,
         metadata: item.metadata,
         rawPayload: item.rawPayload,
+        providerRawPayload: item.providerRawPayload,
         deliveryHandle: item.deliveryHandle ?? null,
       }),
       count: 1,
@@ -1922,6 +1924,7 @@ export class AgentInboxStore {
     const occurredAt = event.occurredAt ?? nowIso();
     const metadataJson = JSON.stringify(event.metadata ?? {});
     const rawPayloadJson = JSON.stringify(event.rawPayload ?? {});
+    const providerRawPayloadJson = event.providerRawPayload ? JSON.stringify(event.providerRawPayload) : null;
     const deliveryHandleJson = event.deliveryHandle ? JSON.stringify(event.deliveryHandle) : null;
 
     for (let attempt = 0; attempt < 5; attempt += 1) {
@@ -1930,8 +1933,8 @@ export class AgentInboxStore {
         `
         insert or ignore into stream_events (
           stream_event_id, stream_id, source_id, source_native_id, event_variant,
-          occurred_at, metadata_json, raw_payload_json, delivery_handle_json, created_at
-        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          occurred_at, metadata_json, raw_payload_json, provider_raw_payload_json, delivery_handle_json, created_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         [
           generateCanonicalId("evt"),
@@ -1942,6 +1945,7 @@ export class AgentInboxStore {
           occurredAt,
           metadataJson,
           rawPayloadJson,
+          providerRawPayloadJson,
           deliveryHandleJson,
           nowIso(),
         ],
@@ -2391,6 +2395,9 @@ export class AgentInboxStore {
       occurredAt: String(row.occurred_at),
       metadata: parseJson<Record<string, unknown>>(row.metadata_json as string),
       rawPayload: parseJson<Record<string, unknown>>(row.raw_payload_json as string),
+      providerRawPayload: row.provider_raw_payload_json
+        ? parseJson<Record<string, unknown>>(row.provider_raw_payload_json as string)
+        : undefined,
       deliveryHandle: row.delivery_handle_json
         ? parseJson<InboxItem["deliveryHandle"]>(row.delivery_handle_json as string)
         : null,
@@ -2429,6 +2436,7 @@ export class AgentInboxStore {
         occurredAt: item.occurredAt,
         metadata: item.metadata,
         rawPayload: item.rawPayload,
+        providerRawPayload: item.providerRawPayload,
         item,
       } as InboxEntry;
     }
@@ -2766,6 +2774,9 @@ export class AgentInboxStore {
       occurredAt: String(row.occurred_at),
       metadata: parseJson<Record<string, unknown>>(row.metadata_json as string),
       rawPayload: parseJson<Record<string, unknown>>(row.raw_payload_json as string),
+      providerRawPayload: row.provider_raw_payload_json
+        ? parseJson<Record<string, unknown>>(row.provider_raw_payload_json as string)
+        : undefined,
       deliveryHandle: row.delivery_handle_json
         ? parseJson<Record<string, unknown>>(row.delivery_handle_json as string)
         : null,

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -504,6 +504,7 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
       "0001_activation_entry_boundary",
       "0002_host_scoped_lifecycle_retirements",
       "0003_subscription_tracked_resource_indexes",
+      "0004_provider_raw_payload",
     ]);
     assert.equal(state.hasNewIndex, true);
     assert.deepEqual(state.retirementColumns.includes("host_id"), true);
@@ -535,6 +536,7 @@ test("store reopens an existing v1 database without archiving it", async () => {
       "0001_activation_entry_boundary",
       "0002_host_scoped_lifecycle_retirements",
       "0003_subscription_tracked_resource_indexes",
+      "0004_provider_raw_payload",
     ]);
     assert.equal(warnings.length, 0);
     assert.equal(state.hasTrackedResourceIndex, true);
@@ -564,6 +566,7 @@ test("store archives a pre-v1 database and starts fresh with the v1 baseline", a
       "0001_activation_entry_boundary",
       "0002_host_scoped_lifecycle_retirements",
       "0003_subscription_tracked_resource_indexes",
+      "0004_provider_raw_payload",
     ]);
     assert.equal(state.hasNewIndex, true);
     assert.equal(state.hasTrackedResourceIndex, true);
@@ -591,6 +594,7 @@ test("store upgrades source-scoped lifecycle retirements to host-scoped retireme
       "0001_activation_entry_boundary",
       "0002_host_scoped_lifecycle_retirements",
       "0003_subscription_tracked_resource_indexes",
+      "0004_provider_raw_payload",
     ]);
     assert.deepEqual(state.retirementColumns.includes("host_id"), true);
     assert.deepEqual(state.retirementColumns.includes("source_id"), false);

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -223,6 +223,26 @@ test("github_repo remote module hydrates truncated review events before mapping"
   assert.equal(mapped.metadata.reviewState, "approved");
   assert.equal(mapped.metadata.url, "https://github.com/holon-run/agentinbox/pull/252#pullrequestreview-9");
   assert.equal(mapped.deliveryHandle?.targetRef, "holon-run/agentinbox#252");
+  assert.deepEqual(mapped.providerRawPayload, {
+    id: "8568075837",
+    type: "PullRequestReviewEvent",
+    created_at: "2026-04-19T09:37:09Z",
+    actor: { login: "jolestar" },
+    repo: { name: "holon-run/agentinbox" },
+    payload: {
+      action: "created",
+      review: {
+        state: "approved",
+        body: "ship it",
+        html_url: "https://github.com/holon-run/agentinbox/pull/252#pullrequestreview-9",
+      },
+      pull_request: {
+        number: 252,
+        title: "feat: hydrate truncated review events",
+        html_url: "https://github.com/holon-run/agentinbox/pull/252",
+      },
+    },
+  });
   assert.equal(fake.calls.length, 1);
   assert.deepEqual(fake.calls[0], {
     endpoint: "https://api.github.com",
@@ -233,7 +253,7 @@ test("github_repo remote module hydrates truncated review events before mapping"
       per_page: 10,
       page: 1,
     },
-    options: { auth: "github-default" },
+    options: { auth: "github-default", artifact_compaction: false },
   });
 });
 

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -358,6 +358,28 @@ test("github_repo source uses remote runtime builtin module mapping", async () =
     assert.equal(items.length, 1);
     assert.equal(items[0]?.eventVariant, "IssueCommentEvent.created");
     assert.equal(items[0]?.deliveryHandle?.provider, "github");
+    assert.deepEqual(items[0]?.providerRawPayload, {
+      id: "100",
+      type: "IssueCommentEvent",
+      created_at: "2026-04-04T11:00:00Z",
+      actor: { login: "jolestar" },
+      repo: { name: "holon-run/agentinbox" },
+      payload: {
+        action: "created",
+        issue: {
+          number: 12,
+          title: "hello",
+          body: "body",
+          labels: [{ name: "agent" }],
+          html_url: "https://github.com/holon-run/agentinbox/issues/12",
+        },
+        comment: { id: 9, body: "ping @alpha" },
+      },
+    });
+    assert.deepEqual(
+      (fake as unknown as { streamSpecs: Map<string, ManagedSourceSpec> }).streamSpecs.get("stream:github_repo:holon-run/agentinbox")?.options,
+      { auth: undefined, artifact_compaction: false },
+    );
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
## Summary

Fixes #185.

Preserve provider-origin payloads for UXC-backed sources while keeping AgentInbox's normalized payload shape available to existing readers.

## Changes

- add `providerRawPayload` to stored stream/inbox item records and HTTP/CLI read surfaces
- keep `rawPayload` as the normalized AgentInbox payload shape for mapped events
- preserve the full provider event as `providerRawPayload` for remote GitHub/CI/Feishu sources
- request `artifact_compaction: false` for UXC-backed managed source reads and GitHub hydration calls
- upgrade `@holon-run/uxc-daemon-client` to `^0.15.4`
- add regression coverage for GitHub hydration and remote-source inbox materialization

## Verification

- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `node --require ts-node/register --test test/github.test.ts`
- `node --require ts-node/register --test --test-name-pattern='github_repo source uses remote runtime builtin module mapping|github_repo source materializes PullRequestReviewEvent items for PR filters' test/remote_source.test.ts`
