### PR TITLE
feat: add Telegram bot source

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -19,6 +19,7 @@ import { AgentInboxStore } from "./store";
 import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubCallClient, GithubDeliveryAdapter } from "./sources/github";
+import { TelegramDeliveryAdapter } from "./sources/telegram";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
 import { ExpandedFollowPlan, ExpandedSubscriptionPlan, ExpandFollowTemplateInput, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry, builtinRemoteSourceTypes } from "./sources/remote_modules";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
@@ -75,6 +76,7 @@ export class AdapterRegistry {
   private readonly defaultDelivery = new NoopDeliveryAdapter();
   private readonly feishuDelivery = new FeishuDeliveryAdapter();
   private readonly githubDelivery = new GithubDeliveryAdapter();
+  private readonly telegramDelivery = new TelegramDeliveryAdapter();
   private readonly homeDir: string;
   private readonly remoteModuleRegistry: RemoteSourceModuleRegistry;
 
@@ -115,6 +117,9 @@ export class AdapterRegistry {
     if (type === "feishu_bot") {
       return this.remoteSource;
     }
+    if (type === "telegram_bot") {
+      return this.remoteSource;
+    }
     return this.localEventSource;
   }
 
@@ -124,6 +129,9 @@ export class AdapterRegistry {
     }
     if (provider === "github") {
       return this.githubDelivery;
+    }
+    if (provider === "telegram") {
+      return this.telegramDelivery;
     }
     return this.defaultDelivery;
   }
@@ -335,6 +343,9 @@ export class AdapterRegistry {
     if (handle.provider === "feishu") {
       return this.remoteModuleRegistry.resolve(syntheticBuiltinSource("feishu_bot"), this.homeDir);
     }
+    if (handle.provider === "telegram") {
+      return this.remoteModuleRegistry.resolve(syntheticBuiltinSource("telegram_bot"), this.homeDir);
+    }
     return null;
   }
 }
@@ -346,6 +357,7 @@ function isExplicitFollowPreviewRef(value: string): boolean {
     value === "github_repo" ||
     value === "github_repo_ci" ||
     value === "feishu_bot" ||
+    value === "telegram_bot" ||
     value.startsWith("remote:")
   );
 }
@@ -355,7 +367,7 @@ function hasRemoteSourceModulePath(config: Record<string, unknown> | undefined):
   return typeof modulePath === "string" && modulePath.trim().length > 0;
 }
 
-function syntheticBuiltinSource(sourceType: "github_repo" | "feishu_bot"): SourceStream {
+function syntheticBuiltinSource(sourceType: "github_repo" | "feishu_bot" | "telegram_bot"): SourceStream {
   return {
     sourceId: `builtin:${sourceType}`,
     hostId: `builtin-host:${sourceType}`,

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,5 @@
-export type SourceType = "local_event" | "remote_source" | "github_repo" | "github_repo_ci" | "feishu_bot";
-export type HostType = "local_event" | "remote_source" | "github" | "feishu";
+export type SourceType = "local_event" | "remote_source" | "github_repo" | "github_repo_ci" | "feishu_bot" | "telegram_bot";
+export type HostType = "local_event" | "remote_source" | "github" | "feishu" | "telegram";
 
 export type SubscriptionStartPolicy = "latest" | "earliest" | "at_offset" | "at_time";
 export type ActivationMode = "activation_only" | "activation_with_items";

--- a/src/service.ts
+++ b/src/service.ts
@@ -3595,7 +3595,14 @@ function mergeFollowPreviewConfig(
 }
 
 function sourceTypeForPreviewRef(sourceRef: string): SourceStream["sourceType"] {
-  if (sourceRef === "local_event" || sourceRef === "remote_source" || sourceRef === "github_repo" || sourceRef === "github_repo_ci" || sourceRef === "feishu_bot") {
+  if (
+    sourceRef === "local_event" ||
+    sourceRef === "remote_source" ||
+    sourceRef === "github_repo" ||
+    sourceRef === "github_repo_ci" ||
+    sourceRef === "feishu_bot" ||
+    sourceRef === "telegram_bot"
+  ) {
     return sourceRef;
   }
   if (sourceRef.startsWith("remote:")) {
@@ -3945,6 +3952,9 @@ function providerForSourceType(sourceType: SourceStream["sourceType"]): string |
   }
   if (sourceType === "feishu_bot") {
     return "feishu";
+  }
+  if (sourceType === "telegram_bot") {
+    return "telegram";
   }
   return null;
 }
@@ -4604,6 +4614,8 @@ function listHostStreamKinds(hostType: SourceHost["hostType"]): string[] {
       return ["repo_events", "ci_runs"];
     case "feishu":
       return ["message_events"];
+    case "telegram":
+      return ["message_updates"];
     case "local_event":
       return ["events"];
     case "remote_source":
@@ -4683,6 +4695,12 @@ function getHostConfigFields(hostType: SourceHost["hostType"]): Array<{ name: st
       return [
         { name: "uxcAuth", type: "string", description: "Optional shared Feishu/Lark UXC auth profile.", required: false },
       ];
+    case "telegram":
+      return [
+        { name: "botToken", type: "string", description: "Telegram Bot API token.", required: false },
+        { name: "tokenEnv", type: "string", description: "Environment variable containing the Telegram Bot API token.", required: false },
+        { name: "botUsername", type: "string", description: "Optional bot username used for shared host identity.", required: false },
+      ];
     case "local_event":
       return [];
     case "remote_source":
@@ -4699,6 +4717,9 @@ function sourceTypeForStreamRegistration(hostType: SourceHost["hostType"], strea
   }
   if (hostType === "feishu") {
     return "feishu_bot";
+  }
+  if (hostType === "telegram") {
+    return "telegram_bot";
   }
   if (hostType === "local_event") {
     return "local_event";

--- a/src/source_hosts.ts
+++ b/src/source_hosts.ts
@@ -53,6 +53,22 @@ export function resolveSourceRegistration(input: RegisterSourceInput): SourceReg
       sourceType: input.sourceType,
     };
   }
+  if (input.sourceType === "telegram_bot") {
+    return {
+      hostType: "telegram",
+      hostKey: `bot:${stringOrDefault(config.botUsername, input.configRef ?? input.sourceKey)}`,
+      hostConfig: {
+        ...(valueOrUndefined(config.botToken) ? { botToken: config.botToken } : {}),
+        ...(valueOrUndefined(config.tokenEnv) ? { tokenEnv: config.tokenEnv } : {}),
+        ...(valueOrUndefined(config.apiBaseUrl) ? { apiBaseUrl: config.apiBaseUrl } : {}),
+        ...(valueOrUndefined(config.botUsername) ? { botUsername: config.botUsername } : {}),
+      },
+      streamKind: "message_updates",
+      streamKey: input.sourceKey,
+      streamConfig: config,
+      sourceType: input.sourceType,
+    };
+  }
   if (input.sourceType === "local_event") {
     return {
       hostType: "local_event",

--- a/src/source_schema.ts
+++ b/src/source_schema.ts
@@ -152,6 +152,41 @@ const SOURCE_SCHEMAS: Record<SourceType, SourceSchema> = {
       { name: "replyInThread", type: "boolean", required: false, description: "Reply in thread when sending outbound messages." },
     ],
   },
+  telegram_bot: {
+    sourceType: "telegram_bot",
+    metadataFields: [
+      { name: "updateId", type: "string", description: "Telegram update_id." },
+      { name: "chatId", type: "string", description: "Telegram chat ID." },
+      { name: "chatType", type: "string|null", description: "Telegram chat type such as private, group, or channel." },
+      { name: "messageId", type: "string", description: "Telegram message_id." },
+      { name: "messageType", type: "string", description: "Normalized Telegram message type such as text or photo." },
+      { name: "fromId", type: "string|null", description: "Telegram sender user ID when present." },
+      { name: "fromUsername", type: "string|null", description: "Telegram sender username when present." },
+      { name: "fromFirstName", type: "string|null", description: "Telegram sender first_name when present." },
+      { name: "content", type: "string|null", description: "Message text or caption when present." },
+    ],
+    payloadExamples: [
+      {
+        update_id: 123,
+        message: {
+          message_id: 7,
+          date: 1710000000,
+          text: "hello",
+          chat: { id: 456, type: "private" },
+          from: { id: 111, username: "operator", first_name: "Op" },
+        },
+      },
+    ],
+    eventVariantExamples: ["message.text", "edited_message.text", "channel_post.photo"],
+    configFields: [
+      { name: "botToken", type: "string", required: false, description: "Telegram bot token. Prefer tokenEnv for shared/local configuration." },
+      { name: "tokenEnv", type: "string", required: false, description: "Environment variable name containing the Telegram bot token." },
+      { name: "botUsername", type: "string", required: false, description: "Optional bot username used for source host identity." },
+      { name: "chatIds", type: "string[]", required: false, description: "Optional Telegram chat ID allowlist." },
+      { name: "allowedUpdates", type: "string[]", required: false, description: "Optional Telegram Bot API allowed_updates value." },
+      { name: "endpoint", type: "string", required: false, description: "Optional Telegram Bot API endpoint override." },
+    ],
+  },
 };
 
 export function getSourceSchema(sourceType: SourceType): SourceSchema {

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -28,11 +28,15 @@ import {
   RemoteSourceModuleRegistry,
 } from "./remote_modules";
 
+type UxcSourceEnsureArgs = Parameters<UxcDaemonClient["sourceEnsure"]>[0];
+type UxcSourceEnsureSpec = UxcSourceEnsureArgs["spec"];
+
 const REMOTE_SOURCE_TYPES = new Set<SourceStream["sourceType"]>([
   "remote_source",
   "github_repo",
   "github_repo_ci",
   "feishu_bot",
+  "telegram_bot",
 ]);
 
 const DEFAULT_SYNC_INTERVAL_MS = 2_000;
@@ -83,6 +87,8 @@ export class RpcUxcRemoteSourceClient implements UxcRemoteSourceClient {
   constructor(private readonly client: UxcDaemonClient = new UxcDaemonClient({ env: process.env })) {}
 
   sourceEnsure(args: { namespace: string; sourceKey: string; spec: ManagedSourceSpec }): Promise<ManagedSourceEnsureResponse> {
+    const transportHint = args.spec.transport_hint ?? null;
+
     return this.client.sourceEnsure({
       namespace: args.namespace,
       sourceKey: args.sourceKey,
@@ -91,7 +97,7 @@ export class RpcUxcRemoteSourceClient implements UxcRemoteSourceClient {
         operation_id: args.spec.operation_id ?? null,
         resource_uri: args.spec.resource_uri ?? null,
         read_resource: args.spec.read_resource ?? false,
-        transport_hint: args.spec.transport_hint ?? null,
+        transport_hint: transportHint as UxcSourceEnsureSpec["transport_hint"],
         subprotocols: args.spec.subprotocols ?? [],
         initial_text_frames: args.spec.initial_text_frames ?? [],
         poll_config: args.spec.poll_config ?? null,

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -52,6 +52,13 @@ import {
   normalizeFeishuBotEvent,
   parseFeishuSourceConfig,
 } from "./feishu";
+import {
+  TELEGRAM_BOT_API_ENDPOINT,
+  invokeTelegramDeliveryOperation,
+  normalizeTelegramBotUpdate,
+  parseTelegramSourceConfig,
+  telegramDeliveryOperationsForHandle,
+} from "./telegram";
 
 export interface ManagedSourceSpec {
   endpoint: string;
@@ -59,7 +66,7 @@ export interface ManagedSourceSpec {
   args?: Record<string, unknown> | null;
   resource_uri?: string | null;
   read_resource?: boolean;
-  transport_hint?: "websocket" | "discord_gateway" | "slack_socket_mode" | "feishu_long_connection" | null;
+  transport_hint?: "websocket" | "discord_gateway" | "slack_socket_mode" | "feishu_long_connection" | "telegram_get_updates" | null;
   subprotocols?: string[];
   initial_text_frames?: string[];
   mode: "stream" | "poll";
@@ -195,8 +202,8 @@ export interface RemoteSourceModule {
 }
 
 const REMOTE_USER_MODULE_ROOT_DIR = "source-modules";
-const BUILTIN_MODULE_IDS = new Set(["builtin.github_repo", "builtin.github_repo_ci", "builtin.feishu_bot"]);
-const BUILTIN_REMOTE_SOURCE_TYPES = ["github_repo", "github_repo_ci", "feishu_bot"] as const;
+const BUILTIN_MODULE_IDS = new Set(["builtin.github_repo", "builtin.github_repo_ci", "builtin.feishu_bot", "builtin.telegram_bot"]);
+const BUILTIN_REMOTE_SOURCE_TYPES = ["github_repo", "github_repo_ci", "feishu_bot", "telegram_bot"] as const;
 
 export class RemoteSourceModuleRegistry {
   private readonly moduleCache = new Map<string, RemoteSourceModule>();
@@ -215,6 +222,9 @@ export class RemoteSourceModuleRegistry {
     }
     if (source.sourceType === "feishu_bot") {
       return Promise.resolve(FEISHU_BOT_MODULE);
+    }
+    if (source.sourceType === "telegram_bot") {
+      return Promise.resolve(TELEGRAM_BOT_MODULE);
     }
     if (source.sourceType !== "remote_source") {
       throw new Error(`unsupported source type for remote module: ${source.sourceType}`);
@@ -265,6 +275,9 @@ export function builtInModuleIdForSourceType(sourceType: SourceStream["sourceTyp
   }
   if (sourceType === "feishu_bot") {
     return "builtin.feishu_bot";
+  }
+  if (sourceType === "telegram_bot") {
+    return "builtin.telegram_bot";
   }
   return null;
 }
@@ -736,6 +749,75 @@ const FEISHU_BOT_MODULE: RemoteSourceModule = {
       metadata: normalized.metadata ?? {},
       rawPayload: normalized.rawPayload ?? rawPayload,
       providerRawPayload: rawPayload,
+      occurredAt: normalized.occurredAt,
+      deliveryHandle: normalized.deliveryHandle,
+    };
+  },
+};
+
+const TELEGRAM_BOT_MODULE: RemoteSourceModule = {
+  id: "builtin.telegram_bot",
+  listDeliveryOperations(input: ListDeliveryOperationsInput): DeliveryOperationDescriptor[] {
+    return telegramDeliveryOperationsForHandle(input.handle);
+  },
+  async invokeDeliveryOperation(input: InvokeDeliveryOperationInput): Promise<{ status: DeliveryAttempt["status"]; note: string }> {
+    return invokeTelegramDeliveryOperation(input.handle, input.operation, input.input);
+  },
+  describeCapabilities(): RemoteSourceCapabilityDescription {
+    return {
+      sourceKind: "telegram_bot",
+      aliases: ["telegram_bot"],
+      configSchema: [
+        { name: "botToken", type: "string", required: false, description: "Telegram bot token. Prefer tokenEnv for shared/local configuration." },
+        { name: "tokenEnv", type: "string", required: false, description: "Environment variable name containing the Telegram bot token." },
+        { name: "botUsername", type: "string", required: false, description: "Optional bot username used for source host identity." },
+        { name: "chatIds", type: "string[]", required: false, description: "Optional Telegram chat ID allowlist." },
+        { name: "allowedUpdates", type: "string[]", required: false, description: "Optional Telegram Bot API allowed_updates value." },
+        { name: "endpoint", type: "string", required: false, description: "Optional Telegram Bot API endpoint override." },
+      ],
+      metadataFields: [
+        { name: "updateId", type: "string", description: "Telegram update_id." },
+        { name: "chatId", type: "string", description: "Telegram chat ID." },
+        { name: "chatType", type: "string|null", description: "Telegram chat type such as private, group, or channel." },
+        { name: "messageId", type: "string", description: "Telegram message_id." },
+        { name: "messageType", type: "string", description: "Normalized Telegram message type such as text or photo." },
+        { name: "fromId", type: "string|null", description: "Telegram sender user ID when present." },
+        { name: "fromUsername", type: "string|null", description: "Telegram sender username when present." },
+        { name: "fromFirstName", type: "string|null", description: "Telegram sender first_name when present." },
+        { name: "content", type: "string|null", description: "Message text or caption when present." },
+      ],
+      eventVariantExamples: ["message.text", "edited_message.text", "channel_post.photo"],
+    };
+  },
+  validateConfig(source: SourceStream): void {
+    parseTelegramSourceConfig(source);
+  },
+  buildManagedSourceSpec(source: SourceStream): ManagedSourceSpec {
+    const config = parseTelegramSourceConfig(source);
+    return {
+      endpoint: config.endpoint ?? TELEGRAM_BOT_API_ENDPOINT,
+      operation_id: "getUpdates",
+      mode: "poll",
+      transport_hint: "telegram_get_updates",
+      args: {
+        ...(config.botToken ? { botToken: config.botToken } : {}),
+        ...(config.tokenEnv ? { tokenEnv: config.tokenEnv } : {}),
+        ...(config.chatIds && config.chatIds.length > 0 ? { chatIds: config.chatIds } : {}),
+        ...(config.allowedUpdates && config.allowedUpdates.length > 0 ? { allowedUpdates: config.allowedUpdates } : {}),
+      },
+    };
+  },
+  mapRawEvent(rawPayload: Record<string, unknown>, source: SourceStream): MappedRemoteEvent | null {
+    const config = parseTelegramSourceConfig(source);
+    const normalized = normalizeTelegramBotUpdate(source, config, rawPayload);
+    if (!normalized) {
+      return null;
+    }
+    return {
+      sourceNativeId: normalized.sourceNativeId,
+      eventVariant: normalized.eventVariant,
+      metadata: normalized.metadata ?? {},
+      rawPayload: normalized.rawPayload ?? rawPayload,
       occurredAt: normalized.occurredAt,
       deliveryHandle: normalized.deliveryHandle,
     };

--- a/src/sources/telegram.ts
+++ b/src/sources/telegram.ts
@@ -1,0 +1,337 @@
+import {
+  AppendSourceEventInput,
+  DeliveryAttempt,
+  DeliveryHandle,
+  DeliveryOperationDescriptor,
+  DeliveryRequest,
+  SourceStream,
+} from "../model";
+
+export const TELEGRAM_BOT_API_ENDPOINT = "https://api.telegram.org";
+
+export interface TelegramBotSourceConfig {
+  endpoint?: string;
+  botToken?: string;
+  tokenEnv?: string;
+  botUsername?: string;
+  chatIds?: string[];
+  allowedUpdates?: string[];
+}
+
+export interface TelegramFetchResponse {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}
+
+export interface TelegramFetchClient {
+  fetch(url: string, init?: RequestInit): Promise<TelegramFetchResponse>;
+}
+
+export class TelegramBotApiClient {
+  constructor(private readonly client: TelegramFetchClient = { fetch: (url, init) => fetch(url, init) }) {}
+
+  async sendMessage(input: {
+    endpoint?: string;
+    botToken: string;
+    chatId: string;
+    text: string;
+    replyToMessageId?: number;
+    parseMode?: string;
+  }): Promise<void> {
+    const endpoint = stripTrailingSlash(input.endpoint ?? TELEGRAM_BOT_API_ENDPOINT);
+    const body: Record<string, unknown> = {
+      chat_id: input.chatId,
+      text: input.text,
+    };
+    if (input.replyToMessageId !== undefined) {
+      body.reply_to_message_id = input.replyToMessageId;
+    }
+    if (input.parseMode) {
+      body.parse_mode = input.parseMode;
+    }
+    const response = await this.client.fetch(`${endpoint}/bot${input.botToken}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`Telegram sendMessage failed with status ${response.status}: ${await response.text()}`);
+    }
+  }
+}
+
+export class TelegramDeliveryAdapter {
+  private readonly client: TelegramBotApiClient;
+
+  constructor(client?: TelegramBotApiClient) {
+    this.client = client ?? new TelegramBotApiClient();
+  }
+
+  async send(request: DeliveryRequest, attempt: DeliveryAttempt): Promise<{ status: "sent"; note: string }> {
+    return invokeTelegramDeliveryOperation(attempt, "send_text", request.payload, this.client);
+  }
+}
+
+export function telegramDeliveryOperationsForHandle(handle: DeliveryHandle): DeliveryOperationDescriptor[] {
+  if (handle.provider !== "telegram") {
+    return [];
+  }
+  if (handle.surface !== "message_reply" && handle.surface !== "chat_message") {
+    return [];
+  }
+  return [{
+    name: "send_text",
+    title: handle.surface === "message_reply" ? "Reply With Text" : "Send Text Message",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["text"],
+      properties: {
+        text: { type: "string", minLength: 1 },
+        endpoint: { type: "string", minLength: 1 },
+        botToken: { type: "string", minLength: 1 },
+        token: { type: "string", minLength: 1 },
+        tokenEnv: { type: "string", minLength: 1 },
+        chatId: { type: "string", minLength: 1 },
+        chat_id: { type: "string", minLength: 1 },
+        replyToMessageId: { type: "number" },
+        reply_to_message_id: { type: "number" },
+        parseMode: { type: "string", minLength: 1 },
+        parse_mode: { type: "string", minLength: 1 },
+      },
+    },
+    canonicalTextAlias: true,
+  }];
+}
+
+export async function invokeTelegramDeliveryOperation(
+  handle: DeliveryHandle,
+  operation: string,
+  input: Record<string, unknown>,
+  client: TelegramBotApiClient = new TelegramBotApiClient(),
+): Promise<{ status: "sent"; note: string }> {
+  if (operation !== "send_text") {
+    throw new Error(`unknown Telegram delivery operation: ${operation}`);
+  }
+  if (handle.provider !== "telegram") {
+    throw new Error(`Telegram delivery operation requires a telegram handle, got ${handle.provider}`);
+  }
+  if (handle.surface !== "message_reply" && handle.surface !== "chat_message") {
+    throw new Error(`deliver send only supports canonical Telegram text surfaces; use deliver invoke for ${handle.surface}`);
+  }
+  const text = asString(input.text);
+  if (!text || text.trim().length === 0) {
+    throw new Error("send_text requires input.text");
+  }
+  const botToken = asString(input.botToken)
+    ?? asString(input.token)
+    ?? tokenFromEnv(asString(input.tokenEnv));
+  if (!botToken) {
+    throw new Error("send_text requires input.botToken, input.token, or input.tokenEnv");
+  }
+  const chatId = stringFromUnknown(input.chatId) ?? stringFromUnknown(input.chat_id) ?? handle.targetRef;
+  const replyToMessageId = numberFromUnknown(input.replyToMessageId)
+    ?? numberFromUnknown(input.reply_to_message_id)
+    ?? (handle.surface === "message_reply" ? numberFromUnknown(handle.threadRef) : undefined);
+
+  await client.sendMessage({
+    endpoint: asString(input.endpoint) ?? undefined,
+    botToken,
+    chatId,
+    text,
+    replyToMessageId,
+    parseMode: asString(input.parseMode) ?? asString(input.parse_mode) ?? undefined,
+  });
+
+  return {
+    status: "sent",
+    note: handle.surface === "message_reply" ? "sent Telegram message reply" : "sent Telegram chat message",
+  };
+}
+
+export function normalizeTelegramBotUpdate(
+  source: SourceStream,
+  config: TelegramBotSourceConfig,
+  raw: unknown,
+): AppendSourceEventInput | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+  const payload = raw as Record<string, unknown>;
+  const updateId = stringFromUnknown(payload.update_id);
+  if (!updateId) {
+    return null;
+  }
+  const selected = selectTelegramMessage(payload);
+  if (!selected) {
+    return null;
+  }
+  const message = selected.message;
+  const messageId = stringFromUnknown(message.message_id);
+  const chat = asRecord(message.chat);
+  const chatId = stringFromUnknown(chat.id);
+  if (!messageId || !chatId) {
+    return null;
+  }
+  if (config.chatIds && config.chatIds.length > 0 && !config.chatIds.includes(chatId)) {
+    return null;
+  }
+
+  const from = asRecord(message.from);
+  const content = asString(message.text) ?? asString(message.caption);
+  const messageType = telegramMessageType(message);
+  return {
+    sourceId: source.sourceId,
+    sourceNativeId: `telegram:${source.sourceId}:${updateId}`,
+    eventVariant: `${selected.kind}.${messageType}`,
+    occurredAt: fromUnixSeconds(message.date) ?? new Date().toISOString(),
+    metadata: {
+      provider: "telegram",
+      updateId,
+      chatId,
+      chatType: asString(chat.type),
+      messageId,
+      messageType,
+      fromId: stringFromUnknown(from.id),
+      fromUsername: asString(from.username),
+      fromFirstName: asString(from.first_name),
+      content,
+    },
+    rawPayload: payload,
+    deliveryHandle: {
+      provider: "telegram",
+      surface: "message_reply",
+      targetRef: chatId,
+      threadRef: messageId,
+      replyMode: "reply",
+    },
+  };
+}
+
+export function parseTelegramSourceConfig(source: SourceStream): TelegramBotSourceConfig {
+  const config = source.config ?? {};
+  return {
+    endpoint: asString(config.endpoint) ?? asString(config.apiBaseUrl) ?? TELEGRAM_BOT_API_ENDPOINT,
+    botToken: asString(config.botToken) ?? undefined,
+    tokenEnv: asString(config.tokenEnv) ?? undefined,
+    botUsername: asString(config.botUsername) ?? undefined,
+    chatIds: asStringArray(config.chatIds) ?? undefined,
+    allowedUpdates: asStringArray(config.allowedUpdates) ?? undefined,
+  };
+}
+
+function selectTelegramMessage(payload: Record<string, unknown>): { kind: string; message: Record<string, unknown> } | null {
+  const candidates = [
+    ["message", payload.message],
+    ["edited_message", payload.edited_message],
+    ["channel_post", payload.channel_post],
+    ["edited_channel_post", payload.edited_channel_post],
+  ] as const;
+  for (const [kind, value] of candidates) {
+    const message = asRecord(value);
+    if (Object.keys(message).length > 0) {
+      return { kind, message };
+    }
+  }
+  return null;
+}
+
+function telegramMessageType(message: Record<string, unknown>): string {
+  if (typeof message.text === "string") {
+    return "text";
+  }
+  if (typeof message.caption === "string") {
+    return "caption";
+  }
+  if (Array.isArray(message.photo)) {
+    return "photo";
+  }
+  if (message.document && typeof message.document === "object") {
+    return "document";
+  }
+  if (message.audio && typeof message.audio === "object") {
+    return "audio";
+  }
+  if (message.video && typeof message.video === "object") {
+    return "video";
+  }
+  if (message.voice && typeof message.voice === "object") {
+    return "voice";
+  }
+  if (message.sticker && typeof message.sticker === "object") {
+    return "sticker";
+  }
+  return "unknown";
+}
+
+function fromUnixSeconds(value: unknown): string | null {
+  const seconds = numberFromUnknown(value);
+  if (seconds === undefined) {
+    return null;
+  }
+  return new Date(seconds * 1000).toISOString();
+}
+
+function tokenFromEnv(name: string | null): string | null {
+  if (!name) {
+    return null;
+  }
+  return asString(process.env[name]);
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asStringArray(value: unknown): string[] | null {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => stringFromUnknown(item))
+      .filter((item): item is string => Boolean(item));
+  }
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }
+  return null;
+}
+
+function stringFromUnknown(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return null;
+}
+
+function numberFromUnknown(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -582,6 +582,74 @@ test("github_repo_ci builtin module emits status transitions for one workflow ru
   }
 });
 
+test("telegram_bot builtin module ingests getUpdates messages", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const source = await service.registerSource({
+      sourceType: "telegram_bot",
+      sourceKey: "operator-bot",
+      config: { tokenEnv: "TELEGRAM_BOT_TOKEN", chatIds: ["456"], allowedUpdates: ["message"] },
+    });
+    const agent = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "remote-telegram-thread",
+      tmuxPaneId: "%905",
+    });
+    const subscription = await service.registerSubscription({
+      agentId: agent.agent.agentId,
+      sourceId: source.sourceId,
+      filter: { metadata: { chatId: "456" } },
+      startPolicy: "earliest",
+    });
+
+    fake.push("stream:telegram_bot:operator-bot", {
+      update_id: 123,
+      message: {
+        message_id: 7,
+        date: 1710000000,
+        text: "Hello from Telegram",
+        chat: { id: 456, type: "private" },
+        from: { id: 111, username: "operator", first_name: "Op" },
+      },
+    });
+
+    const sourcePoll = await service.pollSource(source.sourceId);
+    const subscriptionPoll = await service.pollSubscription(subscription.subscriptionId);
+    const items = service.listInboxItems(agent.agent.agentId);
+    const spec = (fake as unknown as { streamSpecs: Map<string, ManagedSourceSpec> })
+      .streamSpecs.get("stream:telegram_bot:operator-bot");
+
+    assert.equal(sourcePoll.appended, 1);
+    assert.equal(subscriptionPoll.inboxItemsCreated, 1);
+    assert.equal(items.length, 1);
+    assert.equal(items[0]?.sourceNativeId, `telegram:${source.sourceId}:123`);
+    assert.equal(items[0]?.eventVariant, "message.text");
+    assert.equal(items[0]?.metadata?.chatId, "456");
+    assert.equal(items[0]?.metadata?.content, "Hello from Telegram");
+    assert.deepEqual(items[0]?.deliveryHandle, {
+      provider: "telegram",
+      surface: "message_reply",
+      targetRef: "456",
+      threadRef: "7",
+      replyMode: "reply",
+    });
+    assert.equal(spec?.endpoint, "https://api.telegram.org");
+    assert.equal(spec?.operation_id, "getUpdates");
+    assert.equal(spec?.transport_hint, "telegram_get_updates");
+    assert.deepEqual(spec?.args, {
+      tokenEnv: "TELEGRAM_BOT_TOKEN",
+      chatIds: ["456"],
+      allowedUpdates: ["message"],
+    });
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("removeSource deletes managed source binding when no subscriptions remain", async () => {
   const fake = new FakeRemoteSourceClient();
   const { dir, store, service } = await makeService(fake);

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -1,0 +1,146 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { DeliveryAttempt, SourceStream } from "../src/model";
+import {
+  TelegramBotApiClient,
+  TelegramDeliveryAdapter,
+  type TelegramFetchClient,
+  invokeTelegramDeliveryOperation,
+  normalizeTelegramBotUpdate,
+  telegramDeliveryOperationsForHandle,
+} from "../src/sources/telegram";
+
+class FakeTelegramFetchClient implements TelegramFetchClient {
+  public calls: Array<{ url: string; init?: Parameters<TelegramFetchClient["fetch"]>[1] }> = [];
+
+  async fetch(url: string, init?: Parameters<TelegramFetchClient["fetch"]>[1]) {
+    this.calls.push({ url, init });
+    return { ok: true, status: 200, text: async () => "{\"ok\":true}" };
+  }
+}
+
+function telegramSource(config: Record<string, unknown> = {}): SourceStream {
+  const now = new Date().toISOString();
+  return {
+    sourceId: "src_telegram",
+    sourceType: "telegram_bot",
+    sourceKey: "bot-default",
+    configRef: null,
+    config,
+    status: "active",
+    checkpoint: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function telegramMessageUpdate(chatId = 456): Record<string, unknown> {
+  return {
+    update_id: 123,
+    message: {
+      message_id: 7,
+      date: 1710000000,
+      text: "Hello",
+      chat: { id: chatId, type: "private" },
+      from: { id: 111, username: "operator", first_name: "Op" },
+    },
+  };
+}
+
+test("normalizeTelegramBotUpdate extracts metadata and delivery handle", () => {
+  const normalized = normalizeTelegramBotUpdate(telegramSource(), {}, telegramMessageUpdate());
+
+  assert.ok(normalized);
+  assert.equal(normalized.sourceNativeId, "telegram:src_telegram:123");
+  assert.equal(normalized.eventVariant, "message.text");
+  assert.equal(normalized.metadata?.chatId, "456");
+  assert.equal(normalized.metadata?.fromUsername, "operator");
+  assert.equal(normalized.metadata?.content, "Hello");
+  assert.equal(normalized.deliveryHandle?.provider, "telegram");
+  assert.equal(normalized.deliveryHandle?.surface, "message_reply");
+  assert.equal(normalized.deliveryHandle?.targetRef, "456");
+  assert.equal(normalized.deliveryHandle?.threadRef, "7");
+});
+
+test("normalizeTelegramBotUpdate filters chats outside allowlist", () => {
+  const normalized = normalizeTelegramBotUpdate(telegramSource(), { chatIds: ["999"] }, telegramMessageUpdate());
+
+  assert.equal(normalized, null);
+});
+
+test("telegram delivery adapter sends message replies through bot API", async () => {
+  const fake = new FakeTelegramFetchClient();
+  const adapter = new TelegramDeliveryAdapter(new TelegramBotApiClient(fake));
+  const attempt: DeliveryAttempt = {
+    deliveryId: "dlv_tg_1",
+    provider: "telegram",
+    surface: "message_reply",
+    targetRef: "456",
+    threadRef: "7",
+    replyMode: "reply",
+    kind: "reply",
+    payload: { text: "hello", botToken: "TOKEN", endpoint: "https://telegram.test/" },
+    status: "accepted",
+    createdAt: new Date().toISOString(),
+  };
+
+  await adapter.send({ kind: "reply", payload: attempt.payload } as never, attempt);
+
+  assert.equal(fake.calls[0]?.url, "https://telegram.test/botTOKEN/sendMessage");
+  assert.deepEqual(JSON.parse(String(fake.calls[0]?.init?.body)), {
+    chat_id: "456",
+    text: "hello",
+    reply_to_message_id: 7,
+  });
+});
+
+test("telegram delivery operations expose a canonical send_text action", () => {
+  assert.deepEqual(
+    telegramDeliveryOperationsForHandle({
+      provider: "telegram",
+      surface: "message_reply",
+      targetRef: "456",
+    }).map((operation) => operation.name),
+    ["send_text"],
+  );
+});
+
+test("telegram delivery invoke maps send_text to bot API", async () => {
+  const fake = new FakeTelegramFetchClient();
+  const client = new TelegramBotApiClient(fake);
+
+  await invokeTelegramDeliveryOperation(
+    {
+      provider: "telegram",
+      surface: "chat_message",
+      targetRef: "456",
+    },
+    "send_text",
+    {
+      text: "team update",
+      botToken: "TOKEN",
+      endpoint: "https://telegram.test",
+    },
+    client,
+  );
+
+  assert.equal(fake.calls[0]?.url, "https://telegram.test/botTOKEN/sendMessage");
+  assert.deepEqual(JSON.parse(String(fake.calls[0]?.init?.body)), {
+    chat_id: "456",
+    text: "team update",
+  });
+});
+
+test("telegram delivery invoke can read token from an environment alias", async () => {
+  process.env.TEST_TELEGRAM_BOT_TOKEN = "TOKEN";
+  const fake = new FakeTelegramFetchClient();
+  const client = new TelegramBotApiClient(fake);
+
+  await invokeTelegramDeliveryOperation({ provider: "telegram", surface: "chat_message", targetRef: "456" }, "send_text", {
+    text: "team update",
+    tokenEnv: "TEST_TELEGRAM_BOT_TOKEN",
+    endpoint: "https://telegram.test",
+  }, client);
+
+  assert.equal(fake.calls[0]?.url, "https://telegram.test/botTOKEN/sendMessage");
+});


### PR DESCRIPTION
## Summary
- add telegram_bot source schema, host registration, remote module, and adapter wiring
- normalize Telegram updates into inbox items and delivery handles
- add Telegram send_text delivery support and tests

## Verification
- npm test
- npm run build