### PR TITLE
Fix webhook target --url CLI parsing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1181,7 +1181,7 @@ function noCurrentAgentMessage(): string {
 
 function clientArgsForCommand(args: string[]): string[] {
   if (isAgentTargetAddWebhookCommand(args)) {
-    return withoutFlagValue(args, "--url");
+    return withoutFlagValues(args, "--url");
   }
   return args;
 }
@@ -1190,16 +1190,20 @@ function isAgentTargetAddWebhookCommand(args: string[]): boolean {
   return args[0] === "agent" && args[1] === "target" && args[2] === "add" && args[3] === "webhook";
 }
 
-function withoutFlagValue(args: string[], flag: string): string[] {
-  const index = args.indexOf(flag);
-  if (index === -1) {
-    return args;
+function withoutFlagValues(args: string[], flag: string): string[] {
+  const filtered: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value !== flag) {
+      filtered.push(value);
+      continue;
+    }
+    const nextIndex = index + 1;
+    if (nextIndex < args.length && !args[nextIndex].startsWith("--")) {
+      index = nextIndex;
+    }
   }
-  const nextIndex = index + 1;
-  if (nextIndex < args.length && !args[nextIndex].startsWith("--")) {
-    return [...args.slice(0, index), ...args.slice(nextIndex + 1)];
-  }
-  return [...args.slice(0, index), ...args.slice(nextIndex)];
+  return filtered;
 }
 
 function takeFlagValue(args: string[], flag: string): string | undefined {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const client = await createClient(normalized);
+  const client = await createClient(clientArgsForCommand(normalized));
 
   if (command === "host" && normalized[1] === "add") {
     const [hostType, hostKey] = normalized.slice(2, 4);
@@ -1169,13 +1169,37 @@ async function requestRemote<T = unknown>(
 ): Promise<{ data: T }> {
   const response = await client.request<T>(endpoint, body, method);
   if (response.statusCode < 200 || response.statusCode >= 300) {
-    throw new Error(jsonResponse(response.data));
+    const bodyText = jsonResponse(response.data);
+    throw new Error(`request ${method} ${endpoint} failed with HTTP ${response.statusCode}: ${bodyText}`);
   }
   return { data: response.data };
 }
 
 function noCurrentAgentMessage(): string {
   return "no current agent is registered for this terminal/runtime context; run `agentinbox agent list` to inspect offline agents, then `agentinbox agent register` or `agentinbox agent register --force-rebind --agent-id <agentId>` to rebind one";
+}
+
+function clientArgsForCommand(args: string[]): string[] {
+  if (isAgentTargetAddWebhookCommand(args)) {
+    return withoutFlagValue(args, "--url");
+  }
+  return args;
+}
+
+function isAgentTargetAddWebhookCommand(args: string[]): boolean {
+  return args[0] === "agent" && args[1] === "target" && args[2] === "add" && args[3] === "webhook";
+}
+
+function withoutFlagValue(args: string[], flag: string): string[] {
+  const index = args.indexOf(flag);
+  if (index === -1) {
+    return args;
+  }
+  const nextIndex = index + 1;
+  if (nextIndex < args.length && !args[nextIndex].startsWith("--")) {
+    return [...args.slice(0, index), ...args.slice(nextIndex + 1)];
+  }
+  return [...args.slice(0, index), ...args.slice(nextIndex)];
 }
 
 function takeFlagValue(args: string[], flag: string): string | undefined {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1468,6 +1468,48 @@ test("cli agent register supports webhook-only registration without terminal con
   }
 });
 
+test("cli agent target add webhook treats --url as target URL, not daemon URL", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-cli-webhook-target-url-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%904",
+    CODEX_THREAD_ID: "thread-cli-webhook-target-url",
+  };
+
+  try {
+    const register = runCli(["agent", "register", "--agent-id", "agent-cli-webhook-target"], env);
+    assert.equal(register.status, 0, register.stderr);
+
+    const addTarget = runCli([
+      "agent",
+      "target",
+      "add",
+      "webhook",
+      "agent-cli-webhook-target",
+      "--url",
+      "http://127.0.0.1:9999/activate",
+      "--activation-mode",
+      "activation_with_items",
+    ], env);
+    assert.equal(addTarget.status, 0, addTarget.stderr);
+    const payload = JSON.parse(addTarget.stdout) as { kind: string; url: string; mode: string };
+    assert.equal(payload.kind, "webhook");
+    assert.equal(payload.url, "http://127.0.0.1:9999/activate");
+    assert.equal(payload.mode, "activation_with_items");
+
+    const list = runCli(["agent", "target", "list", "agent-cli-webhook-target"], env);
+    assert.equal(list.status, 0, list.stderr);
+    assert.match(list.stdout, /127\.0\.0\.1:9999\/activate/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli agent register requires --agent-id when --webhook-url is used", async () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-cli-webhook-agent-id-"));
   const env = {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1494,6 +1494,8 @@ test("cli agent target add webhook treats --url as target URL, not daemon URL", 
       "http://127.0.0.1:9999/activate",
       "--activation-mode",
       "activation_with_items",
+      "--url",
+      "http://127.0.0.1:9998/duplicate",
     ], env);
     assert.equal(addTarget.status, 0, addTarget.stderr);
     const payload = JSON.parse(addTarget.stdout) as { kind: string; url: string; mode: string };


### PR DESCRIPTION
## Summary
- Prevent `agent target add webhook --url` from being treated as the daemon transport override when constructing the CLI client.
- Keep the webhook command handler receiving the original `--url` so the target URL is still sent in the request body.
- Add a regression test that registers an agent, adds a webhook target URL, and verifies it is listed.
- Improve non-2xx CLI remote request errors with method, endpoint, and HTTP status context.

## Verification
- `npm run build` ✅
- `npm test -- --test-name-pattern "cli agent target add webhook treats --url"` partially verified: the new regression test passed, but the command completed with unrelated existing daemon integration failures (`status null !== 0`) in:
  - `cli auto-starts the daemon for normal commands and daemon stop shuts it down`
  - `daemon status surfaces the configured log level`
  - `cli resolves current agent, auto-registers session workflows, and warns on cross-session targets`
