### PR TITLE
feat: add Feishu IM agent context actions

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -48,6 +48,9 @@ webhook targets.
 
 <!-- INDEX:START -->
 
+- [assets](./assets/)
+  <!-- mdorigin:index kind=directory -->
+
 - [Concepts](./concepts/)
   <!-- mdorigin:index kind=directory -->
 

--- a/docs/site/guides/README.md
+++ b/docs/site/guides/README.md
@@ -11,7 +11,7 @@
   <!-- mdorigin:index kind=article -->
 
 - [Onboarding With The AgentInbox Skill](./onboarding-with-agent-skill.md)
-  If you are already using Codex or Claude Code, the recommended onboarding path is to hand the bundled `AgentInbox` skill to the agent and let it configure the local workflow for you.
+  If you are already using Codex, Claude Code, or Holon, the recommended onboarding path is to hand the bundled `AgentInbox` skill to the agent and let it configure the local workflow for you.
   <!-- mdorigin:index kind=article -->
 
 - [Review Workflows](./review-workflows.md)

--- a/docs/site/reference/README.md
+++ b/docs/site/reference/README.md
@@ -15,7 +15,7 @@
   <!-- mdorigin:index kind=article -->
 
 - [Source Types](./source-types.md)
-  `AgentInbox` currently supports a mix of local and provider-specific source adapters.
+  `AgentInbox` v1 uses a host + stream model.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/docs/site/rfcs/README.md
+++ b/docs/site/rfcs/README.md
@@ -8,6 +8,10 @@
 
 <!-- INDEX:START -->
 
+- [IM Agent Interaction Model](./im-agent-interaction-model.md)
+  2026-05-18 · Define how AgentInbox should model IM reminders, on-demand context fetching, and feedback operations, with Feishu/Lark as the first implementation case.
+  <!-- mdorigin:index kind=article -->
+
 - [Follow Command And Template Expansion](./follow-command-and-template-expansion.md)
   2026-04-19 · Add a high-level `follow` command that expands module-defined templates into reusable host, stream, and subscription ensures without hardcoding providers into the AgentInbox core.
   <!-- mdorigin:index kind=article -->
@@ -16,32 +20,32 @@
   2026-04-19 · Evaluate X pay-per-use API as an AgentInbox source host, define viable stream kinds, and recommend a staged rollout.
   <!-- mdorigin:index kind=article -->
 
-- [Current Agent Resolution And Safe Agent-Scoped CLI Behavior](./current-agent-resolution.md)
-  2026-04-09 · Define how AgentInbox CLI should resolve the current agent, warn on cross-session targeting, and auto-register session-bound agents.
-  <!-- mdorigin:index kind=article -->
-
-- [Delivery Handles And Source-Specific Operations](./delivery-handles-and-operations.md)
-  2026-04-16 · Keep outbound delivery in AgentInbox, but standardize handle routing and source-specific operations instead of forcing all providers into one generic send action.
+- [Public And Internal Identifier Strategy](./public-and-internal-identifier-strategy.md)
+  2026-04-18 · Replace long prefix_uuid identifiers with canonical short IDs, keep only sequence and revision as numeric ordering fields, and align fresh v1 databases on one identifier scheme before release.
   <!-- mdorigin:index kind=article -->
 
 - [Inbox Digests And Threaded Notification Entries](./inbox-digests-and-threaded-notification-entries.md)
   2026-04-17 · Reduce bursty notification noise by keeping raw inbox items immutable, while materializing agent-facing digest threads and immutable digest snapshots for read, activation, and ack.
   <!-- mdorigin:index kind=article -->
 
-- [Public And Internal Identifier Strategy](./public-and-internal-identifier-strategy.md)
-  2026-04-18 · Replace long prefix_uuid identifiers with canonical short IDs, move entry/thread to stored string IDs, and standardize how AgentInbox creates and persists durable identifiers before v1 release.
+- [Delivery Handles And Source-Specific Operations](./delivery-handles-and-operations.md)
+  2026-04-16 · Keep outbound delivery automation in AgentInbox, but stop forcing all providers into one generic send action. Standardize handle routing and source-specific operations instead.
   <!-- mdorigin:index kind=article -->
 
 - [Source Hosts And Streams](./source-hosts-and-streams.md)
-  2026-04-16 · Split provider/account hosting from concrete feeds so AgentInbox can support many provider streams without exploding top-level source kinds.
+  2026-04-16 · Split provider/account hosting from concrete feeds so AgentInbox can support many provider streams without exploding top-level source types.
   <!-- mdorigin:index kind=article -->
 
 - [Source Kinds And Resolved Schemas](./source-kinds-and-resolved-schemas.md)
-  2026-04-13 · Separate runtime host types from user-facing source kinds, make source capability discovery implementation-backed through resolved per-source schemas, and define the UXC/AgentInbox boundary for remote-hosted sources.
+  2026-04-13 · Separate runtime host types from user-facing source kinds, and make source capability discovery implementation-backed through resolved per-source schemas.
   <!-- mdorigin:index kind=article -->
 
 - [Subscription Lifecycle And Terminal Auto-Retire](./subscription-lifecycle-and-terminal-retire.md)
   2026-04-13 · Replace temporary-subscription semantics with explicit cleanup policies, source-scoped tracked resources, deadline cleanup, and terminal-state auto-retire for task-scoped subscriptions.
+  <!-- mdorigin:index kind=article -->
+
+- [Current Agent Resolution And Safe Agent-Scoped CLI Behavior](./current-agent-resolution.md)
+  2026-04-09 · Define how AgentInbox CLI should resolve the current agent, warn on cross-session targeting, and auto-register session-bound agents.
   <!-- mdorigin:index kind=article -->
 
 - [RFC: Agent-First Event Filtering](./event-filtering.md)

--- a/docs/site/rfcs/im-agent-interaction-model.md
+++ b/docs/site/rfcs/im-agent-interaction-model.md
@@ -298,7 +298,7 @@ the normal agent path should consume the normalized shape.
 Low-level operation:
 
 ```bash
-agentinbox source invoke src_xxx get_message_context \
+agentinbox source invoke src_xxx --operation get_message_context \
   --input-json '{"messageId":"om_xxx","chatId":"oc_xxx","windowBefore":20,"windowAfter":5}'
 ```
 

--- a/docs/site/rfcs/im-agent-interaction-model.md
+++ b/docs/site/rfcs/im-agent-interaction-model.md
@@ -1,0 +1,442 @@
+---
+title: IM Agent Interaction Model
+date: 2026-05-18
+type: page
+summary: Define how AgentInbox should model IM reminders, on-demand context fetching, and feedback operations, with Feishu/Lark as the first implementation case.
+---
+
+# IM Agent Interaction Model
+
+## Summary
+
+`AgentInbox` should model IM integrations as three separate capabilities:
+
+- durable reminder subscriptions
+- on-demand context fetching
+- feedback and reply operations
+
+For IM providers such as Feishu/Lark, the provider usually exposes an app-level
+message event stream rather than a separate provider-side subscription for each
+chat or mention target. `AgentInbox` should keep that provider stream shared,
+then represent chat-level and mention-level interest as agent-specific
+subscriptions.
+
+When an agent receives an IM reminder, the inbox item should include enough
+stable anchors to fetch more context later, but it should not eagerly store the
+whole chat window. Context fetching should be an explicit source-specific read
+operation routed through `AgentInbox` and backed by UXC provider credentials.
+
+The first implementation target is Feishu/Lark.
+
+## Problem
+
+The desired user experience is:
+
+1. an agent follows a group mention
+2. someone mentions the agent in a group
+3. the agent receives a concise reminder
+4. the agent asks for message context before responding
+5. the agent replies in the right place
+
+This does not fit cleanly into a single "message received" event.
+
+If the inbox item stores only the mention event, the agent lacks enough context
+to answer well. If the inbox item eagerly stores a large chat window, the source
+will do unnecessary provider reads, create large inbox entries, and make the
+subscription path depend on runtime-specific reasoning needs.
+
+There is also a product-boundary question. Agents can call provider CLIs such as
+`lark-cli`, but making that the normal path leaks provider tooling, credentials,
+and output shape into every agent runtime.
+
+## Goals
+
+- make IM reminders first-class without turning each chat into a private source
+- keep provider credentials and API access behind UXC-backed source modules
+- let agents fetch context only when they need it
+- expose stable, structured context data instead of provider CLI output
+- preserve delivery and feedback as `DeliveryHandle` plus source-specific
+  operations
+- make Feishu/Lark the first case without hardcoding Feishu/Lark semantics into
+  the core
+- keep `lark-cli` useful for development, debugging, and smoke testing, not as
+  the required runtime contract
+
+## Non-Goals
+
+- do not make `AgentInbox` an IM client
+- do not build a general chat UI or conversation memory layer
+- do not copy all provider messages into AgentInbox by default
+- do not require every IM provider to expose identical event or context APIs
+- do not let agents directly manage provider credentials
+- do not make `lark-cli` the product contract for agents
+
+## Terms
+
+### IM Host
+
+A provider account or app identity that can receive and send IM events.
+
+For Feishu/Lark this is the app/bot identity configured in UXC.
+
+### IM Message Stream
+
+A shared source stream of provider message events.
+
+For Feishu/Lark this maps to app-level `im.message.receive_v1` event
+consumption. It is not scoped to one chat.
+
+### Reminder Subscription
+
+An agent-specific interest over a shared IM message stream.
+
+Examples:
+
+- messages in chat `oc_xxx`
+- messages in chat `oc_xxx` that mention open id `ou_xxx`
+- direct messages to the bot
+
+### Context Anchor
+
+Stable metadata on an inbox item that lets a source module fetch context later.
+
+Examples:
+
+- `chatId`
+- `messageId`
+- `messageType`
+- `senderOpenId`
+- `occurredAt`
+- `threadId`
+- `parentId`
+- `rootId`
+
+### Context Operation
+
+A source-specific read operation that uses a context anchor to fetch nearby
+messages, thread messages, or message details.
+
+### Feedback Operation
+
+A source-specific write operation that sends a reply, reaction, acknowledgement,
+or follow-up message through the provider.
+
+## Conceptual Model
+
+IM integrations should split the interaction into three planes.
+
+### 1. Reminder Plane
+
+The reminder plane decides which provider events become agent-visible inbox
+items.
+
+This is normal `AgentInbox` source and subscription behavior:
+
+- a shared source receives provider events
+- source mapping extracts normalized metadata
+- subscriptions match on metadata and payload
+- matching items are delivered to the agent inbox
+- activations notify the runtime
+
+The reminder plane should stay cheap and deterministic. It should not fetch a
+large context window on every event.
+
+### 2. Context Plane
+
+The context plane answers: "What does the agent need to know before responding?"
+
+It should be explicit and on demand. A runtime or operator should be able to ask
+for context using either:
+
+- an inbox item id
+- a delivery/context handle
+- explicit provider anchors such as `chatId` and `messageId`
+
+The source module should decide the provider-specific retrieval strategy.
+
+For an IM provider, the module may:
+
+- fetch the anchor message
+- fetch a thread if the message is in a thread
+- fetch a bounded chat window around the anchor message
+- fetch sender or participant display data when useful
+
+The return shape should be stable AgentInbox JSON, not raw CLI text.
+
+### 3. Feedback Plane
+
+The feedback plane sends provider-visible output.
+
+This should reuse the existing delivery direction:
+
+- inbox items expose or preserve a `DeliveryHandle`
+- source modules expose operation descriptors for available actions
+- callers execute `handle + operation + input`
+
+For IM providers, common operations include:
+
+- reply to the anchor message
+- reply in thread
+- send a chat message
+- add a reaction
+- mark or acknowledge if the provider supports it
+
+## Reminder Subscriptions
+
+Source modules should expose follow templates for common IM intents.
+
+Illustrative examples:
+
+```bash
+agentinbox follow im chat --arg chatId=oc_xxx
+agentinbox follow im mention --arg chatId=oc_xxx --arg openId=ou_agent
+agentinbox follow feishu mention --arg chatId=oc_xxx --arg openId=ou_agent
+```
+
+The compiled subscription should use normal filter semantics.
+
+Example mention filter:
+
+```json
+{
+  "metadata": {
+    "chatId": "oc_xxx"
+  },
+  "expr": "contains(metadata.mentionOpenIds, \"ou_agent\")"
+}
+```
+
+The exact metadata fields are source-specific, but IM source modules should
+prefer a common vocabulary where provider data allows it:
+
+- `provider`
+- `chatId`
+- `chatType`
+- `messageId`
+- `messageType`
+- `senderId`
+- `senderOpenId`
+- `mentions`
+- `mentionOpenIds`
+- `content`
+- `threadId`
+- `parentId`
+- `rootId`
+
+## Context Handles
+
+An IM inbox item should preserve enough information to fetch context later.
+
+The minimal handle shape should be source-specific but predictable:
+
+```json
+{
+  "provider": "feishu",
+  "surface": "message_context",
+  "targetRef": "om_xxx",
+  "threadRef": "omt_xxx",
+  "chatId": "oc_xxx",
+  "occurredAt": "2026-05-18T06:00:00.000Z"
+}
+```
+
+The existing `DeliveryHandle` is write-oriented. `AgentInbox` may either add a
+separate `contextHandle` field or derive a context handle from existing item
+metadata and raw payload. The important contract is that the source module owns
+provider-specific context retrieval.
+
+## Context Operations
+
+Source modules should expose read operations separately from delivery
+operations.
+
+A minimal IM context operation can be:
+
+```json
+{
+  "name": "get_message_context",
+  "inputSchema": {
+    "type": "object",
+    "required": ["messageId"],
+    "properties": {
+      "messageId": { "type": "string" },
+      "chatId": { "type": "string" },
+      "threadId": { "type": "string" },
+      "windowBefore": { "type": "number" },
+      "windowAfter": { "type": "number" }
+    }
+  }
+}
+```
+
+The output should separate the anchor from retrieved context:
+
+```json
+{
+  "anchorMessage": {
+    "messageId": "om_xxx",
+    "chatId": "oc_xxx",
+    "senderId": "ou_xxx",
+    "content": "Can you check this?",
+    "createdAt": "2026-05-18T06:00:00.000Z"
+  },
+  "threadMessages": [],
+  "chatWindowMessages": [],
+  "deliveryHandle": {
+    "provider": "feishu",
+    "surface": "message_reply",
+    "targetRef": "om_xxx"
+  }
+}
+```
+
+Provider-specific raw responses may be included under a debug or raw field, but
+the normal agent path should consume the normalized shape.
+
+## Proposed UX
+
+Low-level operation:
+
+```bash
+agentinbox source invoke src_xxx get_message_context \
+  --input-json '{"messageId":"om_xxx","chatId":"oc_xxx","windowBefore":20,"windowAfter":5}'
+```
+
+Inbox-item oriented convenience:
+
+```bash
+agentinbox inbox context itm_xxx --before 20 --after 5
+```
+
+The inbox-oriented command should:
+
+1. read the item
+2. resolve the source and context anchor
+3. call the source context operation
+4. return normalized context JSON
+
+This keeps agents from needing provider-specific CLI knowledge for the common
+path.
+
+## Feishu/Lark Case
+
+Feishu/Lark should be the first implementation.
+
+### Runtime Boundary
+
+Credentials should live in UXC auth profiles. `AgentInbox` should store the
+UXC auth reference, source routing config, and subscription filters.
+
+`lark-cli` is useful for:
+
+- API exploration
+- manual smoke testing
+- comparing response shapes
+- temporary operational fallback
+
+It should not be the normal agent-facing runtime contract.
+
+### Event Source
+
+The shared source should consume the app-level message event stream.
+
+For Feishu/Lark, `lark-cli event schema im.message.receive_v1` shows that the
+event exposes useful anchors such as:
+
+- `chat_id`
+- `chat_type`
+- `message_id`
+- `message_type`
+- `sender_id`
+- `content`
+- `create_time`
+
+The provider event does not expose a chat-scoped event subscription parameter,
+so "follow this chat" and "follow mentions in this chat" belong in
+`AgentInbox` subscription filters.
+
+### Context Retrieval
+
+The Feishu/Lark source module should implement `get_message_context`.
+
+The retrieval strategy should be:
+
+1. fetch or hydrate the anchor message by `messageId`
+2. if the message has a thread or topic id, fetch thread messages
+3. otherwise fetch a bounded chat window around the message creation time
+4. normalize messages into a stable message list
+
+Useful provider capabilities observed in `lark-cli`:
+
+```bash
+lark-cli im +messages-mget --message-ids om_xxx --as bot
+lark-cli im +threads-messages-list --thread om_xxx --as bot
+lark-cli im +chat-messages-list --chat-id oc_xxx --start ... --end ... --sort asc --as bot
+```
+
+The production implementation should call the same Lark APIs through UXC,
+using the source's UXC auth profile.
+
+### Feedback
+
+The existing Feishu delivery path already supports:
+
+- reply to message
+- send chat message
+
+The Feishu module should continue to expose those as delivery operations.
+
+Future feedback operations may include:
+
+- reply with rich text
+- reply in thread
+- send interactive card
+- add reaction
+
+## Core Changes
+
+The core does not need to understand IM semantics.
+
+It should only need generic extension points:
+
+- source modules can describe read/context operations
+- source modules can invoke read/context operations
+- inbox items can preserve or derive context anchors
+- CLI and HTTP can route context operation calls
+
+This parallels the existing delivery operation model without treating reads as
+deliveries.
+
+## Implementation Plan
+
+1. Define source-module hooks for read/context operation discovery and
+   invocation.
+2. Add a Feishu/Lark `get_message_context` operation.
+3. Add an inbox-item oriented context command.
+4. Add Feishu/Lark follow templates for `chat` and `mention`.
+5. Add tests for filter expansion, context operation invocation, and normalized
+   output shape.
+6. Add a Feishu/Lark user guide after the developer boundary is settled.
+
+## Open Questions
+
+- Should `contextHandle` be stored on inbox items, or derived from
+  metadata/raw payload at read time?
+- Should source read operations share the same descriptor schema as delivery
+  operations with a different operation category?
+- How should context reads be logged for audit and rate-limit visibility?
+- Should context fetch results be cached, and if so, should the cache live in
+  `AgentInbox` or in the source runtime layer?
+- What is the minimum normalized IM message schema that works across Feishu,
+  Slack, Discord, and Telegram without overfitting?
+
+## Decision
+
+Adopt the following product boundary:
+
+- IM event streams are shared sources.
+- Chat and mention tracking are agent-specific reminder subscriptions.
+- Message context is fetched on demand through source-specific read operations.
+- Replies and other provider-visible actions use delivery operations.
+- Provider CLIs such as `lark-cli` are development and fallback tools, not the
+  normal agent product contract.

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,7 +12,7 @@ For `AgentInbox`, the preferred first-run path is skill-first onboarding:
 <!-- INDEX:START -->
 
 - [agentinbox](./agentinbox/)
-  Use the local AgentInbox service to onboard the current runtime/session, connect GitHub through UXC, and operate sources, subscriptions, and the agent inbox.
+  Use the local AgentInbox service to onboard the current runtime/session, manage shared sources and subscriptions, connect external providers such as GitHub through UXC, and operate the agent inbox.
   <!-- mdorigin:index kind=article -->
 
 <!-- INDEX:END -->

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -9,6 +9,7 @@ import {
   NotificationGrouping,
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
+  SourceOperationDescriptor,
   SourcePollResult,
   SourceRuntimeState,
   SourceStream,
@@ -295,6 +296,24 @@ export class AdapterRegistry {
       throw new Error(`delivery operations are not supported for provider ${handle.provider}`);
     }
     return module.invokeDeliveryOperation({ handle, operation, input, attempt, source });
+  }
+
+  async listSourceOperations(source: SourceStream): Promise<SourceOperationDescriptor[]> {
+    if (source.sourceType === "local_event") {
+      return [];
+    }
+    return this.remoteSource.listSourceOperations(source);
+  }
+
+  async invokeSourceOperation(
+    source: SourceStream,
+    operation: string,
+    input: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (source.sourceType === "local_event") {
+      throw new Error(`source operations are not supported for source type ${source.sourceType}`);
+    }
+    return this.remoteSource.invokeSourceOperation(source, operation, input);
   }
 
   status(): Record<string, unknown> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -391,6 +391,29 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "source" && normalized[1] === "actions") {
+    const sourceId = normalized[2];
+    if (!sourceId) {
+      throw new Error("usage: agentinbox source actions <sourceId>");
+    }
+    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}/actions`, undefined, "GET");
+    return;
+  }
+
+  if (command === "source" && normalized[1] === "invoke") {
+    const sourceId = normalized[2];
+    const operation = takeFlagValue(normalized, "--operation");
+    const inputJson = takeFlagValue(normalized, "--input-json");
+    if (!sourceId || !operation || !inputJson) {
+      throw new Error("usage: agentinbox source invoke <sourceId> --operation NAME --input-json JSON");
+    }
+    await printRemote(client, `/sources/${encodeURIComponent(sourceId)}/invoke`, {
+      operation,
+      input: parseJsonArg(inputJson, "--input-json"),
+    });
+    return;
+  }
+
   if (command === "source" && normalized[1] === "poll") {
     const sourceId = normalized[2];
     if (!sourceId) {
@@ -1615,6 +1638,8 @@ Usage:
   agentinbox source pause <remoteSourceId>
   agentinbox source resume <remoteSourceId>
   agentinbox source schema <sourceId>
+  agentinbox source actions <sourceId>
+  agentinbox source invoke <sourceId> --operation NAME --input-json JSON
   agentinbox source poll <sourceId>
   agentinbox source event <sourceId> --native-id ID --event EVENT [--occurred-at ISO8601] [--metadata-json JSON] [--payload-json JSON]
 `,

--- a/src/http.ts
+++ b/src/http.ts
@@ -3,7 +3,7 @@ import Fastify from "fastify";
 import swagger from "@fastify/swagger";
 import { summarizeActivationTarget } from "./current_agent";
 import { AgentInboxService } from "./service";
-import { ActivationMode, DeliveryHandle, FollowInput, PreviewSourceSchemaInput, WatchInboxOptions } from "./model";
+import { ActivationMode, DeliveryHandle, FollowInput, PreviewSourceSchemaInput, SourceInvokeRequest, WatchInboxOptions } from "./model";
 import { jsonResponse } from "./util";
 
 function sendSse(res: http.ServerResponse, event: string, data: unknown): void {
@@ -402,6 +402,62 @@ function buildFastifyServer(service: AgentInboxService) {
   }, async (request) => {
     const params = request.params as { sourceId: string };
     return service.getResolvedSourceSchema(decodeURIComponent(params.sourceId));
+  });
+
+  app.get("/sources/:sourceId/actions", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    return service.listSourceOperations(decodeURIComponent(params.sourceId));
+  });
+
+  app.post("/sources/:sourceId/invoke", {
+    schema: {
+      tags: ["sources"],
+      params: {
+        type: "object",
+        required: ["sourceId"],
+        properties: {
+          sourceId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["operation", "input"],
+        properties: {
+          operation: { type: "string", minLength: 1 },
+          input: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { sourceId: string };
+    const body = request.body as Omit<SourceInvokeRequest, "sourceId">;
+    return service.invokeSourceOperation({
+      sourceId: decodeURIComponent(params.sourceId),
+      operation: body.operation,
+      input: body.input,
+    });
   });
 
   app.patch("/streams/:streamId", {
@@ -1935,8 +1991,10 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("deliver send is not supported") ||
     message.startsWith("deliveryHandle requires") ||
     message.startsWith("delivery operations are not supported") ||
+    message.startsWith("source operations are not supported") ||
     message.startsWith("unknown GitHub delivery operation") ||
     message.startsWith("unknown Feishu delivery operation") ||
+    message.startsWith("unknown Feishu source operation") ||
     message.startsWith("invalid GitHub targetRef") ||
     message.includes("requires input.text") ||
     message.includes("requires input.body") ||

--- a/src/http.ts
+++ b/src/http.ts
@@ -1996,6 +1996,7 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("unknown Feishu delivery operation") ||
     message.startsWith("unknown Feishu source operation") ||
     message.startsWith("invalid GitHub targetRef") ||
+    message.startsWith("get_message_context requires") ||
     message.includes("requires input.text") ||
     message.includes("requires input.body") ||
     message.startsWith("subscriptions/reset requires") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -556,6 +556,25 @@ export interface DeliveryOperationDescriptor {
   canonicalTextAlias?: boolean;
 }
 
+export interface SourceOperationDescriptor {
+  name: string;
+  title: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+}
+
+export interface SourceInvokeRequest {
+  sourceId: string;
+  operation: string;
+  input: Record<string, unknown>;
+}
+
+export interface SourceInvokeResult {
+  sourceId: string;
+  operation: string;
+  data: Record<string, unknown>;
+}
+
 export interface DeliveryActionsRequest {
   sourceId?: string;
   deliveryHandle?: DeliveryHandle | null;

--- a/src/service.ts
+++ b/src/service.ts
@@ -34,6 +34,9 @@ import {
   RegisterTimerInput,
   ResolvedSourceIdentity,
   ResolvedSourceSchema,
+  SourceInvokeRequest,
+  SourceInvokeResult,
+  SourceOperationDescriptor,
   SourceHost,
   SourceRuntimeState,
   SourceSchema,
@@ -432,6 +435,24 @@ export class AgentInboxService {
   async getResolvedSourceSchema(sourceId: string): Promise<ResolvedSourceSchema> {
     const source = this.getSource(sourceId);
     return this.adapters.resolveSourceSchema(source);
+  }
+
+  async listSourceOperations(sourceId: string): Promise<{ sourceId: string; operations: SourceOperationDescriptor[] }> {
+    const source = this.getSource(sourceId);
+    return {
+      sourceId: source.sourceId,
+      operations: await this.adapters.listSourceOperations(source),
+    };
+  }
+
+  async invokeSourceOperation(request: SourceInvokeRequest): Promise<SourceInvokeResult> {
+    const source = this.getSource(request.sourceId);
+    const data = await this.adapters.invokeSourceOperation(source, request.operation, request.input);
+    return {
+      sourceId: source.sourceId,
+      operation: request.operation,
+      data,
+    };
   }
 
   async previewSourceSchema(input: PreviewSourceSchemaInput): Promise<SourceSchemaPreview> {
@@ -4475,9 +4496,7 @@ function getHostConfigFields(hostType: SourceHost["hostType"]): Array<{ name: st
       ];
     case "feishu":
       return [
-        { name: "appId", type: "string", description: "Feishu app ID.", required: true },
-        { name: "appSecret", type: "string", description: "Feishu app secret.", required: true },
-        { name: "uxcAuth", type: "string", description: "Optional shared Feishu auth/runtime profile.", required: false },
+        { name: "uxcAuth", type: "string", description: "Optional shared Feishu/Lark UXC auth profile.", required: false },
       ];
     case "local_event":
       return [];

--- a/src/source_hosts.ts
+++ b/src/source_hosts.ts
@@ -41,13 +41,11 @@ export function resolveSourceRegistration(input: RegisterSourceInput): SourceReg
   if (input.sourceType === "feishu_bot") {
     return {
       hostType: "feishu",
-      hostKey: `app:${stringOrDefault(config.appId, input.configRef ?? input.sourceKey)}`,
+      hostKey: `uxcAuth:${stringOrDefault(config.uxcAuth, input.configRef ?? input.sourceKey)}`,
       hostConfig: {
-        ...(valueOrUndefined(config.appId) ? { appId: config.appId } : {}),
-        ...(valueOrUndefined(config.appSecret) ? { appSecret: config.appSecret } : {}),
+        ...(valueOrUndefined(config.uxcAuth) ? { uxcAuth: config.uxcAuth } : {}),
         ...(valueOrUndefined(config.schemaUrl) ? { schemaUrl: config.schemaUrl } : {}),
         ...(valueOrUndefined(config.replyInThread) ? { replyInThread: config.replyInThread } : {}),
-        ...(valueOrUndefined(config.uxcAuth) ? { uxcAuth: config.uxcAuth } : {}),
       },
       streamKind: "message_events",
       streamKey: input.sourceKey,

--- a/src/source_schema.ts
+++ b/src/source_schema.ts
@@ -144,13 +144,11 @@ const SOURCE_SCHEMAS: Record<SourceType, SourceSchema> = {
     ],
     eventVariantExamples: ["im.message.receive_v1.text"],
     configFields: [
-      { name: "appId", type: "string", required: true, description: "Feishu app ID." },
-      { name: "appSecret", type: "string", required: true, description: "Feishu app secret." },
+      { name: "uxcAuth", type: "string", required: false, description: "Optional UXC auth profile for the Feishu/Lark app." },
       { name: "eventTypes", type: "string[]", required: false, description: "Optional Feishu event type allowlist." },
       { name: "chatIds", type: "string[]", required: false, description: "Optional Feishu chat allowlist." },
       { name: "schemaUrl", type: "string", required: false, description: "Optional Feishu OpenAPI schema URL." },
       { name: "replyInThread", type: "boolean", required: false, description: "Reply in thread when sending outbound messages." },
-      { name: "uxcAuth", type: "string", required: false, description: "Optional uxc auth profile." },
     ],
   },
 };

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -16,6 +16,7 @@ export const FEISHU_OPENAPI_ENDPOINT = "https://open.feishu.cn/open-apis";
 export const FEISHU_IM_SCHEMA_URL =
   "https://raw.githubusercontent.com/holon-run/uxc/main/skills/feishu-openapi-skill/references/feishu-im.openapi.json";
 export const DEFAULT_FEISHU_EVENT_TYPES = ["im.message.receive_v1"];
+const DEFAULT_CONTEXT_BOUND_SECONDS = 7 * 24 * 60 * 60;
 
 export interface FeishuBotSourceConfig {
   endpoint?: string;
@@ -356,14 +357,14 @@ export async function invokeFeishuSourceOperation(
     const windowBefore = positiveInteger(input.windowBefore) ?? 5;
     const windowAfter = positiveInteger(input.windowAfter) ?? 5;
     try {
-      const windowRaw = await client.listMessages({
-        endpoint: config.endpoint,
-        schemaUrl: config.schemaUrl,
-        auth: config.uxcAuth,
+      chatWindowMessages = await fetchFeishuChatWindow({
+        client,
+        config,
         chatId,
-        pageSize: Math.max(1, Math.min(windowBefore + windowAfter + 1, 50)),
+        anchorMessage,
+        windowBefore,
+        windowAfter,
       });
-      chatWindowMessages = normalizeFeishuMessages(windowRaw);
     } catch (error) {
       warnings.push({
         code: "chat_window_unavailable",
@@ -604,6 +605,93 @@ function normalizeFeishuMessages(raw: unknown): NormalizedFeishuMessage[] {
     .filter((item): item is NormalizedFeishuMessage => item !== null);
 }
 
+async function fetchFeishuChatWindow(input: {
+  client: FeishuUxcClient;
+  config: FeishuBotSourceConfig;
+  chatId: string;
+  anchorMessage: NormalizedFeishuMessage | null;
+  windowBefore: number;
+  windowAfter: number;
+}): Promise<NormalizedFeishuMessage[]> {
+  const anchorSeconds = feishuMessageCreateSeconds(input.anchorMessage);
+  const pageSize = Math.max(1, Math.min(input.windowBefore + input.windowAfter + 1, 50));
+  if (!anchorSeconds) {
+    const fallbackRaw = await input.client.listMessages({
+      endpoint: input.config.endpoint,
+      schemaUrl: input.config.schemaUrl,
+      auth: input.config.uxcAuth,
+      chatId: input.chatId,
+      pageSize,
+    });
+    return normalizeFeishuMessages(fallbackRaw);
+  }
+
+  const beforeRaw = input.windowBefore > 0
+    ? await input.client.listMessages({
+      endpoint: input.config.endpoint,
+      schemaUrl: input.config.schemaUrl,
+      auth: input.config.uxcAuth,
+      chatId: input.chatId,
+      startTime: String(Math.max(0, anchorSeconds - DEFAULT_CONTEXT_BOUND_SECONDS)),
+      endTime: String(anchorSeconds + 1),
+      pageSize: Math.max(1, Math.min(input.windowBefore + 1, 50)),
+      sort: "ByCreateTimeDesc",
+    })
+    : null;
+  const afterRaw = input.windowAfter > 0
+    ? await input.client.listMessages({
+      endpoint: input.config.endpoint,
+      schemaUrl: input.config.schemaUrl,
+      auth: input.config.uxcAuth,
+      chatId: input.chatId,
+      startTime: String(anchorSeconds),
+      endTime: String(anchorSeconds + DEFAULT_CONTEXT_BOUND_SECONDS),
+      pageSize: Math.max(1, Math.min(input.windowAfter + 1, 50)),
+      sort: "ByCreateTimeAsc",
+    })
+    : null;
+
+  return mergeFeishuMessages([
+    ...(beforeRaw ? normalizeFeishuMessages(beforeRaw) : []),
+    ...(input.anchorMessage ? [input.anchorMessage] : []),
+    ...(afterRaw ? normalizeFeishuMessages(afterRaw) : []),
+  ]);
+}
+
+function mergeFeishuMessages(messages: NormalizedFeishuMessage[]): NormalizedFeishuMessage[] {
+  const byId = new Map<string, NormalizedFeishuMessage>();
+  for (const message of messages) {
+    if (message.messageId) {
+      byId.set(message.messageId, message);
+    }
+  }
+  return Array.from(byId.values()).sort((left, right) => {
+    const leftTime = feishuMessageCreateMillis(left) ?? 0;
+    const rightTime = feishuMessageCreateMillis(right) ?? 0;
+    return leftTime - rightTime;
+  });
+}
+
+function feishuMessageCreateSeconds(message: NormalizedFeishuMessage | null): number | null {
+  const millis = feishuMessageCreateMillis(message);
+  return millis == null ? null : Math.floor(millis / 1000);
+}
+
+function feishuMessageCreateMillis(message: NormalizedFeishuMessage | null): number | null {
+  if (!message) {
+    return null;
+  }
+  const rawMillis = Number(asString(message.raw.create_time));
+  if (Number.isFinite(rawMillis)) {
+    return rawMillis;
+  }
+  if (message.createdAt) {
+    const parsed = Date.parse(message.createdAt);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
 function firstFeishuMessage(raw: unknown): Record<string, unknown> | null {
   const items = feishuMessageItems(raw);
   if (items[0]) {
@@ -619,13 +707,16 @@ function firstFeishuMessage(raw: unknown): Record<string, unknown> | null {
 function feishuMessageItems(raw: unknown): Record<string, unknown>[] {
   const record = asRecord(raw);
   const data = asRecord(record.data);
-  const items = Array.isArray(data.items)
-    ? data.items
-    : Array.isArray(record.items)
-      ? record.items
-      : Array.isArray(raw)
-        ? raw
-        : [];
+  const nestedData = asRecord(data.data);
+  const items = Array.isArray(nestedData.items)
+    ? nestedData.items
+    : Array.isArray(data.items)
+      ? data.items
+      : Array.isArray(record.items)
+        ? record.items
+        : Array.isArray(raw)
+          ? raw
+          : [];
   return items.map((item) => asRecord(item)).filter((item) => Object.keys(item).length > 0);
 }
 

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -5,8 +5,12 @@ import {
   DeliveryHandle,
   DeliveryOperationDescriptor,
   DeliveryRequest,
+  FollowTemplateSpec,
+  SourceOperationDescriptor,
   SourceStream,
+  SubscriptionFilter,
 } from "../model";
+import type { ExpandFollowTemplateInput, ExpandedFollowPlan } from "./remote_modules";
 
 export const FEISHU_OPENAPI_ENDPOINT = "https://open.feishu.cn/open-apis";
 export const FEISHU_IM_SCHEMA_URL =
@@ -84,6 +88,61 @@ export class FeishuUxcClient {
         schema_url: input.schemaUrl ?? FEISHU_IM_SCHEMA_URL,
       },
     });
+  }
+
+  async getMessage(input: {
+    endpoint?: string;
+    schemaUrl?: string;
+    auth?: string;
+    messageId: string;
+  }): Promise<unknown> {
+    const response = await this.client.call({
+      endpoint: input.endpoint ?? FEISHU_OPENAPI_ENDPOINT,
+      operation: "get:/im/v1/messages/{message_id}",
+      payload: {
+        message_id: input.messageId,
+      },
+      options: {
+        auth: input.auth,
+        schema_url: input.schemaUrl ?? FEISHU_IM_SCHEMA_URL,
+      },
+    });
+    return response.data;
+  }
+
+  async listMessages(input: {
+    endpoint?: string;
+    schemaUrl?: string;
+    auth?: string;
+    chatId: string;
+    startTime?: string;
+    endTime?: string;
+    pageSize?: number;
+    sort?: "ByCreateTimeAsc" | "ByCreateTimeDesc";
+  }): Promise<unknown> {
+    const payload: Record<string, unknown> = {
+      container_id_type: "chat",
+      container_id: input.chatId,
+      page_size: input.pageSize ?? 20,
+      sort_type: input.sort ?? "ByCreateTimeAsc",
+      card_msg_content_type: "raw_card_content",
+    };
+    if (input.startTime) {
+      payload.start_time = input.startTime;
+    }
+    if (input.endTime) {
+      payload.end_time = input.endTime;
+    }
+    const response = await this.client.call({
+      endpoint: input.endpoint ?? FEISHU_OPENAPI_ENDPOINT,
+      operation: "get:/im/v1/messages",
+      payload,
+      options: {
+        auth: input.auth,
+        schema_url: input.schemaUrl ?? FEISHU_IM_SCHEMA_URL,
+      },
+    });
+    return response.data;
   }
 }
 
@@ -172,6 +231,162 @@ export async function invokeFeishuDeliveryOperation(
   throw new Error(`deliver send only supports canonical Feishu text surfaces; use deliver invoke for ${handle.surface}`);
 }
 
+export function feishuFollowTemplateSpec(): FollowTemplateSpec[] {
+  return [
+    {
+      templateId: "feishu.chat",
+      providerOrKind: "feishu",
+      label: "Feishu Chat",
+      description: "Follow messages from one Feishu/Lark chat.",
+      argsSchema: [
+        { name: "chatId", type: "string", required: true, description: "Feishu chat ID." },
+      ],
+    },
+    {
+      templateId: "feishu.mention",
+      providerOrKind: "feishu",
+      label: "Feishu Mention",
+      description: "Follow messages in one Feishu/Lark chat that mention a user or bot.",
+      argsSchema: [
+        { name: "chatId", type: "string", required: true, description: "Feishu chat ID." },
+        { name: "openId", type: "string", required: true, description: "Mentioned user or bot open_id." },
+      ],
+    },
+  ];
+}
+
+export function expandFeishuFollowTemplate(input: ExpandFollowTemplateInput): ExpandedFollowPlan | null {
+  if (input.template !== "chat" && input.template !== "mention") {
+    return null;
+  }
+  const args = input.args ?? {};
+  const chatId = asString(args.chatId);
+  if (!chatId) {
+    throw new Error(`follow template feishu.${input.template} requires argument chatId`);
+  }
+  const config = parseFeishuSourceConfig(input.source);
+  const sourceKey = `feishu:${config.uxcAuth ?? input.source.configRef ?? "default"}:messages`;
+  const filter: SubscriptionFilter = {
+    metadata: { chatId },
+  };
+
+  let trackedResourceRef = `chat:${chatId}`;
+  if (input.template === "mention") {
+    const openId = asString(args.openId);
+    if (!openId) {
+      throw new Error("follow template feishu.mention requires argument openId");
+    }
+    filter.expr = `contains(metadata.mentionOpenIds, ${JSON.stringify(openId)})`;
+    trackedResourceRef = `chat:${chatId}:mention:${openId}`;
+  }
+
+  return {
+    templateId: `feishu.${input.template}`,
+    sources: [
+      {
+        logicalName: "messages",
+        sourceType: "feishu_bot",
+        sourceKey,
+        configRef: input.source.configRef ?? null,
+        config: feishuFollowSourceConfig(input.source),
+      },
+    ],
+    subscriptions: [
+      {
+        sourceLogicalName: "messages",
+        filter,
+        trackedResourceRef,
+        cleanupPolicy: { mode: "manual" },
+      },
+    ],
+  };
+}
+
+export function feishuSourceOperations(): SourceOperationDescriptor[] {
+  return [
+    {
+      name: "get_message_context",
+      title: "Get Message Context",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["messageId"],
+        properties: {
+          messageId: { type: "string", minLength: 1 },
+          chatId: { type: "string", minLength: 1 },
+          windowBefore: { type: "number", minimum: 0 },
+          windowAfter: { type: "number", minimum: 0 },
+        },
+      },
+      outputSchema: {
+        type: "object",
+        additionalProperties: true,
+        required: ["anchorMessage", "chatWindowMessages", "threadMessages", "warnings", "deliveryHandle"],
+      },
+    },
+  ];
+}
+
+export async function invokeFeishuSourceOperation(
+  source: SourceStream,
+  operation: string,
+  input: Record<string, unknown>,
+  client: FeishuUxcClient = new FeishuUxcClient(),
+): Promise<Record<string, unknown>> {
+  if (operation !== "get_message_context") {
+    throw new Error(`unknown Feishu source operation: ${operation}`);
+  }
+  const messageId = asString(input.messageId);
+  if (!messageId) {
+    throw new Error("get_message_context requires input.messageId");
+  }
+  const config = parseFeishuSourceConfig(source);
+  const anchorRaw = await client.getMessage({
+    endpoint: config.endpoint,
+    schemaUrl: config.schemaUrl,
+    auth: config.uxcAuth,
+    messageId,
+  });
+  const anchorMessage = normalizeFeishuMessage(anchorRaw);
+  const chatId = asString(input.chatId) ?? anchorMessage?.chatId ?? null;
+  const warnings: Array<{ code: string; message: string }> = [];
+  let chatWindowMessages: NormalizedFeishuMessage[] = [];
+
+  if (chatId) {
+    const windowBefore = positiveInteger(input.windowBefore) ?? 5;
+    const windowAfter = positiveInteger(input.windowAfter) ?? 5;
+    try {
+      const windowRaw = await client.listMessages({
+        endpoint: config.endpoint,
+        schemaUrl: config.schemaUrl,
+        auth: config.uxcAuth,
+        chatId,
+        pageSize: Math.max(1, Math.min(windowBefore + windowAfter + 1, 50)),
+      });
+      chatWindowMessages = normalizeFeishuMessages(windowRaw);
+    } catch (error) {
+      warnings.push({
+        code: "chat_window_unavailable",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    anchorMessage,
+    chatWindowMessages,
+    threadMessages: [],
+    warnings,
+    deliveryHandle: {
+      provider: "feishu",
+      surface: "message_reply",
+      targetRef: messageId,
+      threadRef: anchorMessage?.threadId ?? anchorMessage?.parentId ?? null,
+      replyMode: "reply",
+    },
+  };
+}
+
 export function normalizeFeishuBotEvent(
   source: SourceStream,
   config: FeishuBotSourceConfig,
@@ -183,17 +398,17 @@ export function normalizeFeishuBotEvent(
 
   const payload = raw as Record<string, unknown>;
   const header = asRecord(payload.header);
-  const eventType = asString(payload.event_type) ?? asString(header.event_type);
+  const eventType = asString(payload.event_type) ?? asString(payload.type) ?? asString(header.event_type);
   if (!eventType || !(config.eventTypes ?? DEFAULT_FEISHU_EVENT_TYPES).includes(eventType)) {
     return null;
   }
 
   const event = asRecord(payload.event);
-  const message = nonEmptyRecord(payload.message) ?? nonEmptyRecord(event.message) ?? {};
-  const sender = nonEmptyRecord(payload.sender) ?? nonEmptyRecord(event.sender) ?? {};
+  const message = nonEmptyRecord(payload.message) ?? nonEmptyRecord(event.message) ?? flatFeishuMessage(payload);
+  const sender = nonEmptyRecord(payload.sender) ?? nonEmptyRecord(event.sender) ?? flatFeishuSender(payload);
 
   const messageId = asString(message.message_id);
-  const eventId = asString(header.event_id) ?? messageId;
+  const eventId = asString(payload.event_id) ?? asString(header.event_id) ?? messageId;
   const chatId = asString(message.chat_id);
   if (!eventId || !messageId || !chatId) {
     return null;
@@ -206,7 +421,7 @@ export function normalizeFeishuBotEvent(
   const mentions = extractMentionNames(message.mentions);
   const mentionOpenIds = extractMentionOpenIds(message.mentions);
   const messageType = asString(message.message_type) ?? "unknown";
-  const senderId = asString(asRecord(sender.sender_id).open_id);
+  const senderId = asString(asRecord(sender.sender_id).open_id) ?? asString(sender.sender_id);
   const senderType = asString(sender.sender_type);
   const content = stringifyFeishuMessageContent(messageType, asString(message.content), message.mentions);
   const threadId = asString(message.thread_id) ?? asString(message.root_id);
@@ -248,6 +463,28 @@ export function normalizeFeishuBotEvent(
       threadRef: threadId ?? parentId ?? null,
       replyMode: "reply",
     },
+  };
+}
+
+function flatFeishuMessage(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    message_id: payload.message_id,
+    chat_id: payload.chat_id,
+    chat_type: payload.chat_type,
+    message_type: payload.message_type ?? payload.msg_type,
+    content: payload.content,
+    create_time: payload.create_time,
+    mentions: payload.mentions,
+    thread_id: payload.thread_id,
+    root_id: payload.root_id,
+    parent_id: payload.parent_id,
+  };
+}
+
+function flatFeishuSender(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    sender_id: payload.sender_id,
+    sender_type: payload.sender_type,
   };
 }
 
@@ -300,6 +537,110 @@ function normalizeDeliveryMessage(payload: Record<string, unknown>): { msgType: 
   };
 }
 
+interface NormalizedFeishuMessage {
+  messageId: string;
+  chatId: string | null;
+  chatType: string | null;
+  messageType: string;
+  senderOpenId: string | null;
+  senderType: string | null;
+  mentions: string[];
+  mentionOpenIds: string[];
+  content: string | null;
+  createdAt: string | null;
+  threadId: string | null;
+  parentId: string | null;
+  raw: Record<string, unknown>;
+}
+
+function feishuFollowSourceConfig(source: SourceStream): Record<string, unknown> {
+  const config = parseFeishuSourceConfig(source);
+  return {
+    ...(config.endpoint && config.endpoint !== FEISHU_OPENAPI_ENDPOINT ? { endpoint: config.endpoint } : {}),
+    ...(config.schemaUrl && config.schemaUrl !== FEISHU_IM_SCHEMA_URL ? { schemaUrl: config.schemaUrl } : {}),
+    ...(config.uxcAuth ? { uxcAuth: config.uxcAuth } : {}),
+    ...(config.eventTypes ? { eventTypes: config.eventTypes } : {}),
+  };
+}
+
+function normalizeFeishuMessage(raw: unknown): NormalizedFeishuMessage | null {
+  const message = firstFeishuMessage(raw);
+  if (!message) {
+    return null;
+  }
+  const sender = asRecord(message.sender);
+  const messageType = asString(message.msg_type) ?? asString(message.message_type) ?? "unknown";
+  return {
+    messageId: asString(message.message_id) ?? "",
+    chatId: asString(message.chat_id),
+    chatType: asString(message.chat_type),
+    messageType,
+    senderOpenId: senderOpenId(sender),
+    senderType: asString(sender.sender_type) ?? asString(asRecord(sender.id).user_id) ?? null,
+    mentions: extractMentionNames(message.mentions),
+    mentionOpenIds: extractMentionOpenIds(message.mentions),
+    content: stringifyFeishuMessageContent(messageType, messageContentString(message), message.mentions),
+    createdAt: fromUnixMillisString(asString(message.create_time)),
+    threadId: asString(message.thread_id) ?? asString(message.root_id),
+    parentId: asString(message.parent_id),
+    raw: message,
+  };
+}
+
+function senderOpenId(sender: Record<string, unknown>): string | null {
+  const nested = asString(asRecord(sender.id).open_id) ?? asString(asRecord(sender.sender_id).open_id);
+  if (nested) {
+    return nested;
+  }
+  const id = asString(sender.id) ?? asString(sender.sender_id);
+  const idType = asString(sender.id_type);
+  return id && (!idType || idType === "open_id") ? id : null;
+}
+
+function normalizeFeishuMessages(raw: unknown): NormalizedFeishuMessage[] {
+  const items = feishuMessageItems(raw);
+  return items
+    .map((item) => normalizeFeishuMessage(item))
+    .filter((item): item is NormalizedFeishuMessage => item !== null);
+}
+
+function firstFeishuMessage(raw: unknown): Record<string, unknown> | null {
+  const items = feishuMessageItems(raw);
+  if (items[0]) {
+    return items[0];
+  }
+  const record = asRecord(raw);
+  if (asString(record.message_id)) {
+    return record;
+  }
+  return null;
+}
+
+function feishuMessageItems(raw: unknown): Record<string, unknown>[] {
+  const record = asRecord(raw);
+  const data = asRecord(record.data);
+  const items = Array.isArray(data.items)
+    ? data.items
+    : Array.isArray(record.items)
+      ? record.items
+      : Array.isArray(raw)
+        ? raw
+        : [];
+  return items.map((item) => asRecord(item)).filter((item) => Object.keys(item).length > 0);
+}
+
+function messageContentString(message: Record<string, unknown>): string | null {
+  const body = asRecord(message.body);
+  return asString(body.content) ?? asString(message.content);
+}
+
+function positiveInteger(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
 function extractMentionNames(raw: unknown): string[] {
   if (!Array.isArray(raw)) {
     return [];
@@ -344,7 +685,8 @@ function stringifyFeishuMessageContent(
   }
 
   if (messageType === "text") {
-    return asString(asRecord(parsed).text) ?? rawContent;
+    const text = asString(asRecord(parsed).text) ?? rawContent;
+    return replaceMentionKeys(text, mentions);
   }
 
   if (messageType === "post") {
@@ -381,6 +723,14 @@ function buildMentionMap(raw: unknown): Map<string, string> {
     }
   }
   return map;
+}
+
+function replaceMentionKeys(text: string, mentions: unknown): string {
+  let result = text;
+  for (const [key, name] of buildMentionMap(mentions)) {
+    result = result.split(key).join(name);
+  }
+  return result;
 }
 
 function flattenPostContent(raw: unknown, mentionMap: Map<string, string>): string[] {

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -10,6 +10,7 @@ import {
   AppendSourceEventInput,
   FollowTemplateSpec,
   NotificationGrouping,
+  SourceOperationDescriptor,
   SourcePollResult,
   SourceRuntimeState,
   SourceStream,
@@ -403,6 +404,36 @@ export class RemoteSourceRuntime {
       return null;
     }
     return module.summarizeDigestThread(items, moduleInputSource(source), grouping);
+  }
+
+  async listSourceOperations(source: SourceStream): Promise<SourceOperationDescriptor[]> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      return [];
+    }
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    if (typeof module.listSourceOperations !== "function") {
+      return [];
+    }
+    return module.listSourceOperations({ source: moduleInputSource(source) });
+  }
+
+  async invokeSourceOperation(
+    source: SourceStream,
+    operation: string,
+    input: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!REMOTE_SOURCE_TYPES.has(source.sourceType)) {
+      throw new Error(`source operations are not supported for source type ${source.sourceType}`);
+    }
+    const module = await this.moduleRegistry.resolve(source, this.homeDir);
+    if (typeof module.invokeSourceOperation !== "function") {
+      throw new Error(`source operations are not supported for source type ${source.sourceType}`);
+    }
+    return module.invokeSourceOperation({
+      source: moduleInputSource(source),
+      operation,
+      input,
+    });
   }
 
   private async syncAll(): Promise<void> {

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -13,6 +13,7 @@ import {
   NotificationGrouping,
   RegisterSourceInput,
   SourceSchemaField,
+  SourceOperationDescriptor,
   SourceStream,
   SubscriptionFilter,
   SubscriptionStartPolicy,
@@ -42,8 +43,12 @@ import {
 } from "./github_ci";
 import {
   FEISHU_OPENAPI_ENDPOINT,
+  expandFeishuFollowTemplate,
   feishuDeliveryOperationsForHandle,
+  feishuFollowTemplateSpec,
+  feishuSourceOperations,
   invokeFeishuDeliveryOperation,
+  invokeFeishuSourceOperation,
   normalizeFeishuBotEvent,
   parseFeishuSourceConfig,
 } from "./feishu";
@@ -154,6 +159,16 @@ export interface InvokeDeliveryOperationInput {
   source?: SourceStream | null;
 }
 
+export interface ListSourceOperationsInput {
+  source: SourceStream;
+}
+
+export interface InvokeSourceOperationInput {
+  source: SourceStream;
+  operation: string;
+  input: Record<string, unknown>;
+}
+
 export interface RemoteSourceModule {
   id: string;
   validateConfig(source: SourceStream): void;
@@ -174,6 +189,8 @@ export interface RemoteSourceModule {
   deriveNotificationGrouping?(item: ActivationItem, source: SourceStream): NotificationGrouping | null;
   listDeliveryOperations?(input: ListDeliveryOperationsInput): DeliveryOperationDescriptor[];
   invokeDeliveryOperation?(input: InvokeDeliveryOperationInput): Promise<{ status: DeliveryAttempt["status"]; note: string }>;
+  listSourceOperations?(input: ListSourceOperationsInput): SourceOperationDescriptor[];
+  invokeSourceOperation?(input: InvokeSourceOperationInput): Promise<Record<string, unknown>>;
   summarizeDigestThread?(items: ActivationItem[], source: SourceStream, grouping: NotificationGrouping): string | null;
 }
 
@@ -283,6 +300,8 @@ function validateModuleContract(module: RemoteSourceModule, sourcePath: string):
   validateOptionalHook(module.deriveNotificationGrouping, "deriveNotificationGrouping", sourcePath);
   validateOptionalHook(module.listDeliveryOperations, "listDeliveryOperations", sourcePath);
   validateOptionalHook(module.invokeDeliveryOperation, "invokeDeliveryOperation", sourcePath);
+  validateOptionalHook(module.listSourceOperations, "listSourceOperations", sourcePath);
+  validateOptionalHook(module.invokeSourceOperation, "invokeSourceOperation", sourcePath);
   validateOptionalHook(module.summarizeDigestThread, "summarizeDigestThread", sourcePath);
 }
 
@@ -650,18 +669,22 @@ const FEISHU_BOT_MODULE: RemoteSourceModule = {
   async invokeDeliveryOperation(input: InvokeDeliveryOperationInput): Promise<{ status: DeliveryAttempt["status"]; note: string }> {
     return invokeFeishuDeliveryOperation(input.handle, input.operation, input.input);
   },
+  listSourceOperations(): SourceOperationDescriptor[] {
+    return feishuSourceOperations();
+  },
+  async invokeSourceOperation(input: InvokeSourceOperationInput): Promise<Record<string, unknown>> {
+    return invokeFeishuSourceOperation(input.source, input.operation, input.input);
+  },
   describeCapabilities(): RemoteSourceCapabilityDescription {
     return {
       sourceKind: "feishu_bot",
       aliases: ["feishu_bot"],
       configSchema: [
-        { name: "appId", type: "string", required: true, description: "Feishu app ID." },
-        { name: "appSecret", type: "string", required: true, description: "Feishu app secret." },
+        { name: "uxcAuth", type: "string", required: false, description: "Optional UXC auth profile for the Feishu/Lark app." },
         { name: "eventTypes", type: "string[]", required: false, description: "Optional Feishu event type allowlist." },
         { name: "chatIds", type: "string[]", required: false, description: "Optional Feishu chat allowlist." },
         { name: "schemaUrl", type: "string", required: false, description: "Optional Feishu OpenAPI schema URL." },
         { name: "replyInThread", type: "boolean", required: false, description: "Reply in thread when sending outbound messages." },
-        { name: "uxcAuth", type: "string", required: false, description: "Optional uxc auth profile." },
       ],
       metadataFields: [
         { name: "eventType", type: "string", description: "Feishu event type." },
@@ -682,6 +705,12 @@ const FEISHU_BOT_MODULE: RemoteSourceModule = {
   },
   validateConfig(source: SourceStream): void {
     parseFeishuSourceConfig(source);
+  },
+  listFollowTemplates(): FollowTemplateSpec[] {
+    return feishuFollowTemplateSpec();
+  },
+  expandFollowTemplate(input: ExpandFollowTemplateInput): ExpandedFollowPlan | null {
+    return expandFeishuFollowTemplate(input);
   },
   buildManagedSourceSpec(source: SourceStream): ManagedSourceSpec {
     const config = parseFeishuSourceConfig(source);

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -3,9 +3,13 @@ import assert from "node:assert/strict";
 import { DeliveryAttempt, SourceStream } from "../src/model";
 import {
   feishuDeliveryOperationsForHandle,
+  feishuFollowTemplateSpec,
+  feishuSourceOperations,
   FeishuDeliveryAdapter,
   FeishuUxcClient,
+  expandFeishuFollowTemplate,
   invokeFeishuDeliveryOperation,
+  invokeFeishuSourceOperation,
   type FeishuCallClient,
   normalizeFeishuBotEvent,
 } from "../src/sources/feishu";
@@ -19,6 +23,37 @@ class FakeFeishuUxcClient implements FeishuCallClient {
   async call(args: Record<string, unknown>) {
     this.calls.push(args);
     return { data: { ok: true } };
+  }
+}
+
+class ContextFeishuUxcClient implements FeishuCallClient {
+  public calls: Array<Record<string, unknown>> = [];
+
+  async call(args: Record<string, unknown>) {
+    this.calls.push(args);
+    if (args.operation === "get:/im/v1/messages/{message_id}") {
+      return {
+        data: {
+          code: 0,
+          data: {
+            items: [{
+              message_id: "om_anchor",
+              chat_id: "oc_chat",
+              chat_type: "group",
+              msg_type: "text",
+              body: { content: "{\"text\":\"@TupTup Assistant hi\"}" },
+              mentions: [{ key: "@_user_1", name: "TupTup Assistant", id: { open_id: "ou_bot" } }],
+              sender: { id: { open_id: "ou_sender" }, sender_type: "user" },
+              create_time: "1773491924409",
+            }],
+          },
+        },
+      };
+    }
+    if (args.operation === "get:/im/v1/messages") {
+      throw new Error("Feishu API error 230027: missing im:message.group_msg");
+    }
+    return { data: { code: 0 } };
   }
 }
 
@@ -67,6 +102,36 @@ test("normalizeFeishuBotEvent extracts metadata and delivery handle", () => {
   assert.equal(normalized.deliveryHandle?.provider, "feishu");
   assert.equal(normalized.deliveryHandle?.surface, "message_reply");
   assert.equal(normalized.deliveryHandle?.targetRef, "om_123");
+});
+
+test("normalizeFeishuBotEvent accepts flat lark-cli style events", () => {
+  const source: SourceStream = {
+    sourceId: "src_feishu",
+    sourceType: "feishu_bot",
+    sourceKey: "tenant-default",
+    configRef: null,
+    config: { uxcAuth: "feishu-default" },
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  const normalized = normalizeFeishuBotEvent(source, { uxcAuth: "feishu-default" }, {
+    type: "im.message.receive_v1",
+    event_id: "fevt_flat",
+    message_id: "om_flat",
+    chat_id: "oc_chat",
+    message_type: "text",
+    content: "{\"text\":\"flat hello\"}",
+    create_time: "1773491924409",
+    sender_id: { open_id: "ou_sender" },
+  });
+
+  assert.ok(normalized);
+  assert.equal(normalized.sourceNativeId, "feishu_event:fevt_flat");
+  assert.equal(normalized.metadata?.messageId, "om_flat");
+  assert.equal(normalized.metadata?.content, "flat hello");
 });
 
 test("feishu delivery adapter maps message replies and chat sends to uxc calls", async () => {
@@ -122,4 +187,72 @@ test("feishu delivery invoke maps send_text to the canonical outbound path", asy
     targetRef: "oc_chat",
   }, "send_text", { text: "team update" }, client);
   assert.equal(fake.calls[0]?.operation, "post:/im/v1/messages");
+});
+
+test("feishu follow templates expand chat and mention subscriptions over a shared uxc source", () => {
+  assert.deepEqual(feishuFollowTemplateSpec().map((template) => template.templateId), ["feishu.chat", "feishu.mention"]);
+
+  const source: SourceStream = {
+    sourceId: "preview",
+    sourceType: "feishu_bot",
+    sourceKey: "preview",
+    configRef: null,
+    config: { uxcAuth: "feishu-tuptup", chatId: "oc_chat", openId: "ou_bot" },
+    status: "active",
+    checkpoint: null,
+    createdAt: "",
+    updatedAt: "",
+  };
+  const plan = expandFeishuFollowTemplate({
+    template: "mention",
+    args: { chatId: "oc_chat", openId: "ou_bot" },
+    source,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.templateId, "feishu.mention");
+  assert.equal(plan.sources[0]?.sourceKey, "feishu:feishu-tuptup:messages");
+  assert.deepEqual(plan.sources[0]?.config, {
+    uxcAuth: "feishu-tuptup",
+    eventTypes: ["im.message.receive_v1"],
+  });
+  assert.deepEqual(plan.subscriptions[0]?.filter, {
+    metadata: { chatId: "oc_chat" },
+    expr: "contains(metadata.mentionOpenIds, \"ou_bot\")",
+  });
+});
+
+test("feishu source operation fetches anchor message context and keeps permission warnings non-fatal", async () => {
+  const fake = new ContextFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  const source: SourceStream = {
+    sourceId: "src_feishu",
+    sourceType: "feishu_bot",
+    sourceKey: "tenant-default",
+    configRef: null,
+    config: { uxcAuth: "feishu-tuptup" },
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  assert.equal(feishuSourceOperations()[0]?.name, "get_message_context");
+  const result = await invokeFeishuSourceOperation(source, "get_message_context", { messageId: "om_anchor" }, client);
+
+  assert.equal(fake.calls[0]?.operation, "get:/im/v1/messages/{message_id}");
+  assert.equal((fake.calls[0]?.options as Record<string, unknown>)?.auth, "feishu-tuptup");
+  assert.equal(fake.calls[1]?.operation, "get:/im/v1/messages");
+  assert.equal((result.anchorMessage as Record<string, unknown> | null)?.messageId, "om_anchor");
+  assert.equal((result.anchorMessage as Record<string, unknown> | null)?.content, "@TupTup Assistant hi");
+  assert.equal((result.anchorMessage as Record<string, unknown> | null)?.senderOpenId, "ou_sender");
+  assert.deepEqual(result.chatWindowMessages, []);
+  assert.equal((result.warnings as Array<Record<string, unknown>>)[0]?.code, "chat_window_unavailable");
+  assert.deepEqual(result.deliveryHandle, {
+    provider: "feishu",
+    surface: "message_reply",
+    targetRef: "om_anchor",
+    threadRef: null,
+    replyMode: "reply",
+  });
 });

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -57,6 +57,70 @@ class ContextFeishuUxcClient implements FeishuCallClient {
   }
 }
 
+class SuccessfulContextFeishuUxcClient implements FeishuCallClient {
+  public calls: Array<Record<string, unknown>> = [];
+
+  async call(args: Record<string, unknown>) {
+    this.calls.push(args);
+    if (args.operation === "get:/im/v1/messages/{message_id}") {
+      return {
+        data: {
+          data: {
+            code: 0,
+            data: {
+              items: [feishuMessage({
+                messageId: "om_anchor",
+                content: "{\"text\":\"anchor\"}",
+                createTime: "1773491924409",
+              })],
+            },
+          },
+        },
+      };
+    }
+    if (args.operation === "get:/im/v1/messages") {
+      const payload = args.payload as Record<string, unknown>;
+      if (payload.sort_type === "ByCreateTimeDesc") {
+        return {
+          data: {
+            code: 0,
+            data: {
+              items: [
+                feishuMessage({ messageId: "om_anchor", content: "{\"text\":\"anchor\"}", createTime: "1773491924409" }),
+                feishuMessage({ messageId: "om_before", content: "{\"text\":\"before\"}", createTime: "1773491922409" }),
+              ],
+            },
+          },
+        };
+      }
+      return {
+        data: {
+          code: 0,
+          data: {
+            items: [
+              feishuMessage({ messageId: "om_anchor", content: "{\"text\":\"anchor\"}", createTime: "1773491924409" }),
+              feishuMessage({ messageId: "om_after", content: "{\"text\":\"after\"}", createTime: "1773491926409" }),
+            ],
+          },
+        },
+      };
+    }
+    return { data: { code: 0 } };
+  }
+}
+
+function feishuMessage(input: { messageId: string; content: string; createTime: string }): Record<string, unknown> {
+  return {
+    message_id: input.messageId,
+    chat_id: "oc_chat",
+    chat_type: "group",
+    msg_type: "text",
+    body: { content: input.content },
+    sender: { id: { open_id: "ou_sender" }, sender_type: "user" },
+    create_time: input.createTime,
+  };
+}
+
 test("normalizeFeishuBotEvent extracts metadata and delivery handle", () => {
   const source: SourceStream = {
     sourceId: "src_feishu",
@@ -255,4 +319,42 @@ test("feishu source operation fetches anchor message context and keeps permissio
     threadRef: null,
     replyMode: "reply",
   });
+});
+
+test("feishu source operation unwraps nested UXC envelopes and anchors chat windows to message time", async () => {
+  const fake = new SuccessfulContextFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  const source: SourceStream = {
+    sourceId: "src_feishu",
+    sourceType: "feishu_bot",
+    sourceKey: "tenant-default",
+    configRef: null,
+    config: { uxcAuth: "feishu-tuptup" },
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  const result = await invokeFeishuSourceOperation(source, "get_message_context", {
+    messageId: "om_anchor",
+    windowBefore: 1,
+    windowAfter: 1,
+  }, client);
+
+  assert.equal((result.anchorMessage as Record<string, unknown> | null)?.messageId, "om_anchor");
+  assert.deepEqual((result.chatWindowMessages as Array<Record<string, unknown>>).map((message) => message.messageId), [
+    "om_before",
+    "om_anchor",
+    "om_after",
+  ]);
+  const beforePayload = fake.calls[1]?.payload as Record<string, unknown>;
+  assert.equal(beforePayload.sort_type, "ByCreateTimeDesc");
+  assert.equal(beforePayload.page_size, 2);
+  assert.equal(beforePayload.end_time, "1773491925");
+  const afterPayload = fake.calls[2]?.payload as Record<string, unknown>;
+  assert.equal(afterPayload.sort_type, "ByCreateTimeAsc");
+  assert.equal(afterPayload.page_size, 2);
+  assert.equal(afterPayload.start_time, "1773491924");
+  assert.deepEqual(result.warnings, []);
 });

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -814,6 +814,84 @@ export default {
   }
 });
 
+test("user-defined remote_source modules can expose source actions and invoke them", async () => {
+  const fake = new FakeRemoteSourceClient();
+  const { dir, store, service } = await makeService(fake);
+  try {
+    const moduleDir = path.join(dir, "source-modules");
+    fs.mkdirSync(moduleDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(moduleDir, "source-action-hook.mjs"),
+      `export default {
+  id: "demo.source-action-hook",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() {
+    return null;
+  },
+  listSourceOperations() {
+    return [{
+      name: "get_context",
+      title: "Get Context",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id"],
+        properties: { id: { type: "string" } }
+      }
+    }];
+  },
+  async invokeSourceOperation(input) {
+    return {
+      sourceId: input.source.sourceId,
+      operation: input.operation,
+      id: input.input.id
+    };
+  }
+};`,
+      "utf8",
+    );
+
+    const source = await service.registerSource({
+      sourceType: "remote_source",
+      sourceKey: "demo-source-action",
+      config: {
+        modulePath: "source-action-hook.mjs",
+        moduleConfig: {},
+      },
+    });
+
+    const listed = await service.listSourceOperations(source.sourceId);
+    assert.deepEqual(listed.operations.map((operation) => operation.name), ["get_context"]);
+
+    const invoked = await service.invokeSourceOperation({
+      sourceId: source.sourceId,
+      operation: "get_context",
+      input: { id: "evt-1" },
+    });
+    assert.equal(invoked.operation, "get_context");
+    assert.deepEqual(invoked.data, {
+      sourceId: source.sourceId,
+      operation: "get_context",
+      id: "evt-1",
+    });
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function checkpointKeyForPayload(
   payload: unknown,
   strategy: NonNullable<ManagedSourceSpec["poll_config"]>["checkpoint_strategy"],


### PR DESCRIPTION
## Summary

- add an IM Agent Interaction Model RFC covering IM reminders, context fetch, and feedback operations
- add source-level actions so agents can invoke provider context operations through AgentInbox
- implement Feishu/Lark follow templates and `get_message_context` over UXC auth, keeping app credentials outside AgentInbox
- extend Feishu normalization, delivery tests, and remote source action tests

## Validation

- `npm run build`
- `node --require ts-node/register --test --test-force-exit test/feishu.test.ts test/remote_source.test.ts`
- live Feishu smoke with `feishu-tuptup` in the `bottest` group:
  - read `get_message_context` through `agentinbox source invoke`
  - confirmed `chatWindowMessages` returned after `im:message.group_msg` was granted
  - sent a Feishu message reply through `agentinbox deliver invoke`

## Notes

Feishu app credentials are expected to be hosted in UXC and referenced from AgentInbox by `uxcAuth`.
