### PR TITLE
feat: support Feishu rich text and file delivery

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1997,7 +1997,7 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("unknown Feishu source operation") ||
     message.startsWith("invalid GitHub targetRef") ||
     message.startsWith("get_message_context requires") ||
-    message.includes("requires input.text") ||
+    message.includes("requires input.") ||
     message.includes("requires input.body") ||
     message.startsWith("subscriptions/reset requires") ||
     message.startsWith("agents requires") ||

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -213,6 +213,11 @@ export function feishuDeliveryOperationsForHandle(handle: DeliveryHandle): Deliv
       inputSchema: {
         type: "object",
         additionalProperties: false,
+        anyOf: [
+          { required: ["blocks"] },
+          { required: ["paragraphs"] },
+          { required: ["content"] },
+        ],
         properties: {
           title: { type: "string" },
           locale: { type: "string", minLength: 1 },

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -91,6 +91,34 @@ export class FeishuUxcClient {
     });
   }
 
+  async uploadFile(input: {
+    endpoint?: string;
+    schemaUrl?: string;
+    auth?: string;
+    filePath: string;
+    fileName: string;
+    fileType?: string;
+  }): Promise<string> {
+    const response = await this.client.call({
+      endpoint: input.endpoint ?? FEISHU_OPENAPI_ENDPOINT,
+      operation: "post:/im/v1/files",
+      payload: {
+        file_type: input.fileType ?? "stream",
+        file_name: input.fileName,
+        file: input.filePath,
+      },
+      options: {
+        auth: input.auth,
+        schema_url: input.schemaUrl ?? FEISHU_IM_SCHEMA_URL,
+      },
+    });
+    const fileKey = findStringField(response.data, "file_key");
+    if (!fileKey) {
+      throw new Error("Feishu file upload response did not include file_key");
+    }
+    return fileKey;
+  }
+
   async getMessage(input: {
     endpoint?: string;
     schemaUrl?: string;
@@ -163,27 +191,91 @@ export function feishuDeliveryOperationsForHandle(handle: DeliveryHandle): Deliv
   if (handle.surface !== "message_reply" && handle.surface !== "chat_message") {
     return [];
   }
-  return [{
-    name: "send_text",
-    title: handle.surface === "message_reply" ? "Reply With Text" : "Send Text Message",
-    inputSchema: {
-      type: "object",
-      additionalProperties: false,
-      required: ["text"],
-      properties: {
-        text: { type: "string", minLength: 1 },
-        endpoint: { type: "string", minLength: 1 },
-        schemaUrl: { type: "string", minLength: 1 },
-        schema_url: { type: "string", minLength: 1 },
-        uxcAuth: { type: "string", minLength: 1 },
-        auth: { type: "string", minLength: 1 },
-        replyInThread: { type: "boolean" },
-        reply_in_thread: { type: "boolean" },
-        uuid: { type: "string", minLength: 1 },
+  const commonProperties = commonDeliveryInputSchemaProperties();
+  return [
+    {
+      name: "send_text",
+      title: handle.surface === "message_reply" ? "Reply With Text" : "Send Text Message",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["text"],
+        properties: {
+          text: { type: "string", minLength: 1 },
+          ...commonProperties,
+        },
+      },
+      canonicalTextAlias: true,
+    },
+    {
+      name: "send_post",
+      title: handle.surface === "message_reply" ? "Reply With Rich Text" : "Send Rich Text Message",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          title: { type: "string" },
+          locale: { type: "string", minLength: 1 },
+          blocks: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+          },
+          paragraphs: {
+            type: "array",
+            items: {
+              type: "array",
+              items: { type: "object", additionalProperties: true },
+            },
+          },
+          content: {
+            anyOf: [
+              { type: "string", minLength: 1 },
+              { type: "object", additionalProperties: true },
+            ],
+          },
+          ...commonProperties,
+        },
       },
     },
-    canonicalTextAlias: true,
-  }];
+    {
+      name: "send_file",
+      title: handle.surface === "message_reply" ? "Reply With File" : "Send File Message",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        anyOf: [
+          { required: ["fileKey"] },
+          { required: ["file_key"] },
+        ],
+        properties: {
+          fileKey: { type: "string", minLength: 1 },
+          file_key: { type: "string", minLength: 1 },
+          ...commonProperties,
+        },
+      },
+    },
+    {
+      name: "send_file_from_path",
+      title: handle.surface === "message_reply" ? "Upload And Reply With File" : "Upload And Send File",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        anyOf: [
+          { required: ["filePath"] },
+          { required: ["file_path"] },
+        ],
+        properties: {
+          filePath: { type: "string", minLength: 1 },
+          file_path: { type: "string", minLength: 1 },
+          fileName: { type: "string", minLength: 1 },
+          file_name: { type: "string", minLength: 1 },
+          fileType: { type: "string", minLength: 1 },
+          file_type: { type: "string", minLength: 1 },
+          ...commonProperties,
+        },
+      },
+    },
+  ];
 }
 
 export async function invokeFeishuDeliveryOperation(
@@ -192,16 +284,58 @@ export async function invokeFeishuDeliveryOperation(
   input: Record<string, unknown>,
   client: FeishuUxcClient = new FeishuUxcClient(),
 ): Promise<{ status: "sent"; note: string }> {
-  if (operation !== "send_text") {
-    throw new Error(`unknown Feishu delivery operation: ${operation}`);
-  }
-  const text = asString(input.text);
-  if (!text || text.trim().length === 0) {
-    throw new Error("send_text requires input.text");
-  }
   const config = parseDeliveryConfig(input);
-  const message = normalizeDeliveryMessage({ text });
+  if (operation === "send_text") {
+    const text = asString(input.text);
+    if (!text || text.trim().length === 0) {
+      throw new Error("send_text requires input.text");
+    }
+    await sendFeishuMessage(handle, normalizeDeliveryMessage({ text }), config, client);
+    return { status: "sent", note: sentNote(handle, "text") };
+  }
 
+  if (operation === "send_post") {
+    const message = normalizeFeishuPostMessage(input);
+    await sendFeishuMessage(handle, message, config, client);
+    return { status: "sent", note: sentNote(handle, "rich text") };
+  }
+
+  if (operation === "send_file") {
+    const fileKey = asString(input.fileKey) ?? asString(input.file_key);
+    if (!fileKey) {
+      throw new Error("send_file requires input.fileKey");
+    }
+    await sendFeishuMessage(handle, normalizeFeishuFileMessage(fileKey), config, client);
+    return { status: "sent", note: sentNote(handle, "file") };
+  }
+
+  if (operation === "send_file_from_path") {
+    const filePath = asString(input.filePath) ?? asString(input.file_path);
+    if (!filePath) {
+      throw new Error("send_file_from_path requires input.filePath");
+    }
+    const fileName = asString(input.fileName) ?? asString(input.file_name) ?? basename(filePath);
+    const fileKey = await client.uploadFile({
+      endpoint: config.endpoint,
+      schemaUrl: config.schemaUrl,
+      auth: config.auth,
+      filePath,
+      fileName,
+      fileType: asString(input.fileType) ?? asString(input.file_type) ?? "stream",
+    });
+    await sendFeishuMessage(handle, normalizeFeishuFileMessage(fileKey), config, client);
+    return { status: "sent", note: `${sentNote(handle, "file")} after upload` };
+  }
+
+  throw new Error(`unknown Feishu delivery operation: ${operation}`);
+}
+
+async function sendFeishuMessage(
+  handle: DeliveryHandle,
+  message: { msgType: string; content: string },
+  config: ReturnType<typeof parseDeliveryConfig>,
+  client: FeishuUxcClient,
+): Promise<void> {
   if (handle.surface === "message_reply") {
     await client.replyToMessage({
       endpoint: config.endpoint,
@@ -213,7 +347,7 @@ export async function invokeFeishuDeliveryOperation(
       replyInThread: config.replyInThread,
       uuid: config.uuid,
     });
-    return { status: "sent", note: "sent Feishu message reply" };
+    return;
   }
 
   if (handle.surface === "chat_message") {
@@ -226,10 +360,15 @@ export async function invokeFeishuDeliveryOperation(
       content: message.content,
       uuid: config.uuid,
     });
-    return { status: "sent", note: "sent Feishu chat message" };
+    return;
   }
-
   throw new Error(`deliver send only supports canonical Feishu text surfaces; use deliver invoke for ${handle.surface}`);
+}
+
+function sentNote(handle: DeliveryHandle, kind: string): string {
+  return handle.surface === "message_reply"
+    ? `sent Feishu ${kind} message reply`
+    : `sent Feishu ${kind} chat message`;
 }
 
 export function feishuFollowTemplateSpec(): FollowTemplateSpec[] {
@@ -536,6 +675,123 @@ function normalizeDeliveryMessage(payload: Record<string, unknown>): { msgType: 
     msgType: "text",
     content: JSON.stringify({ text: JSON.stringify(payload) }),
   };
+}
+
+function commonDeliveryInputSchemaProperties(): Record<string, unknown> {
+  return {
+    endpoint: { type: "string", minLength: 1 },
+    schemaUrl: { type: "string", minLength: 1 },
+    schema_url: { type: "string", minLength: 1 },
+    uxcAuth: { type: "string", minLength: 1 },
+    auth: { type: "string", minLength: 1 },
+    replyInThread: { type: "boolean" },
+    reply_in_thread: { type: "boolean" },
+    uuid: { type: "string", minLength: 1 },
+  };
+}
+
+function normalizeFeishuFileMessage(fileKey: string): { msgType: string; content: string } {
+  return {
+    msgType: "file",
+    content: JSON.stringify({ file_key: fileKey }),
+  };
+}
+
+function normalizeFeishuPostMessage(input: Record<string, unknown>): { msgType: string; content: string } {
+  const rawContent = input.content;
+  if (typeof rawContent === "string" && rawContent.trim().length > 0) {
+    return { msgType: "post", content: rawContent };
+  }
+  if (rawContent && typeof rawContent === "object" && !Array.isArray(rawContent)) {
+    return { msgType: "post", content: JSON.stringify(rawContent) };
+  }
+
+  const paragraphs = normalizePostParagraphs(input);
+  if (paragraphs.length === 0) {
+    throw new Error("send_post requires input.blocks, input.paragraphs, or input.content");
+  }
+  const locale = asString(input.locale) ?? "zh_cn";
+  return {
+    msgType: "post",
+    content: JSON.stringify({
+      [locale]: {
+        title: asString(input.title) ?? "",
+        content: paragraphs,
+      },
+    }),
+  };
+}
+
+function normalizePostParagraphs(input: Record<string, unknown>): Array<Array<Record<string, unknown>>> {
+  if (Array.isArray(input.paragraphs)) {
+    return input.paragraphs
+      .map((paragraph) => Array.isArray(paragraph) ? normalizePostBlocks(paragraph) : [])
+      .filter((paragraph) => paragraph.length > 0);
+  }
+  if (Array.isArray(input.blocks)) {
+    const paragraph = normalizePostBlocks(input.blocks);
+    return paragraph.length > 0 ? [paragraph] : [];
+  }
+  return [];
+}
+
+function normalizePostBlocks(blocks: unknown[]): Array<Record<string, unknown>> {
+  return blocks.map((block) => normalizePostBlock(asRecord(block))).filter((block): block is Record<string, unknown> => block !== null);
+}
+
+function normalizePostBlock(block: Record<string, unknown>): Record<string, unknown> | null {
+  const type = asString(block.type) ?? "text";
+  if (type === "text") {
+    const text = asString(block.text);
+    if (!text) {
+      return null;
+    }
+    return { tag: "text", text };
+  }
+  if (type === "link") {
+    const text = asString(block.text);
+    const url = asString(block.url) ?? asString(block.href);
+    if (!text || !url) {
+      return null;
+    }
+    return { tag: "a", text, href: url };
+  }
+  if (type === "mention") {
+    const openId = asString(block.openId) ?? asString(block.open_id) ?? asString(block.userId) ?? asString(block.user_id);
+    if (!openId) {
+      return null;
+    }
+    return {
+      tag: "at",
+      user_id: openId,
+      ...(asString(block.name) ? { user_name: asString(block.name) } : {}),
+    };
+  }
+  return null;
+}
+
+function basename(filePath: string): string {
+  const trimmed = filePath.replace(/\/+$/, "");
+  const parts = trimmed.split("/");
+  return parts[parts.length - 1] || "upload.bin";
+}
+
+function findStringField(value: unknown, field: string): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const direct = asString(record[field]);
+  if (direct) {
+    return direct;
+  }
+  for (const child of Object.values(record)) {
+    const found = findStringField(child, field);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
 }
 
 interface NormalizedFeishuMessage {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -235,14 +235,17 @@ test("feishu delivery adapter maps message replies and chat sends to uxc calls",
 });
 
 test("feishu delivery operations expose canonical text, rich text, and file actions", () => {
-  assert.deepEqual(
-    feishuDeliveryOperationsForHandle({
-      provider: "feishu",
-      surface: "message_reply",
-      targetRef: "om_reply",
-    }).map((operation) => operation.name),
-    ["send_text", "send_post", "send_file", "send_file_from_path"],
-  );
+  const operations = feishuDeliveryOperationsForHandle({
+    provider: "feishu",
+    surface: "message_reply",
+    targetRef: "om_reply",
+  });
+  assert.deepEqual(operations.map((operation) => operation.name), ["send_text", "send_post", "send_file", "send_file_from_path"]);
+  assert.deepEqual((operations.find((operation) => operation.name === "send_post")?.inputSchema as Record<string, unknown>).anyOf, [
+    { required: ["blocks"] },
+    { required: ["paragraphs"] },
+    { required: ["content"] },
+  ]);
 });
 
 test("feishu delivery invoke maps send_text to the canonical outbound path", async () => {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -22,6 +22,9 @@ class FakeFeishuUxcClient implements FeishuCallClient {
 
   async call(args: Record<string, unknown>) {
     this.calls.push(args);
+    if (args.operation === "post:/im/v1/files") {
+      return { data: { code: 0, data: { file_key: "file_uploaded" } } };
+    }
     return { data: { ok: true } };
   }
 }
@@ -231,14 +234,14 @@ test("feishu delivery adapter maps message replies and chat sends to uxc calls",
   assert.equal((fake.calls[1]?.options as Record<string, unknown>)?.schema_url, FEISHU_IM_SCHEMA_URL);
 });
 
-test("feishu delivery operations expose a canonical send_text action", () => {
+test("feishu delivery operations expose canonical text, rich text, and file actions", () => {
   assert.deepEqual(
     feishuDeliveryOperationsForHandle({
       provider: "feishu",
       surface: "message_reply",
       targetRef: "om_reply",
     }).map((operation) => operation.name),
-    ["send_text"],
+    ["send_text", "send_post", "send_file", "send_file_from_path"],
   );
 });
 
@@ -251,6 +254,78 @@ test("feishu delivery invoke maps send_text to the canonical outbound path", asy
     targetRef: "oc_chat",
   }, "send_text", { text: "team update" }, client);
   assert.equal(fake.calls[0]?.operation, "post:/im/v1/messages");
+});
+
+test("feishu delivery invoke maps send_post blocks to Feishu post payloads", async () => {
+  const fake = new FakeFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  await invokeFeishuDeliveryOperation({
+    provider: "feishu",
+    surface: "message_reply",
+    targetRef: "om_reply",
+  }, "send_post", {
+    title: "Update",
+    blocks: [
+      { type: "text", text: "See " },
+      { type: "link", text: "PR", url: "https://example.com/pr/1" },
+      { type: "mention", openId: "ou_user", name: "Alice" },
+    ],
+  }, client);
+
+  assert.equal(fake.calls[0]?.operation, "post:/im/v1/messages/{message_id}/reply");
+  const payload = fake.calls[0]?.payload as Record<string, unknown>;
+  assert.equal(payload.msg_type, "post");
+  assert.deepEqual(JSON.parse(String(payload.content)), {
+    zh_cn: {
+      title: "Update",
+      content: [[
+        { tag: "text", text: "See " },
+        { tag: "a", text: "PR", href: "https://example.com/pr/1" },
+        { tag: "at", user_id: "ou_user", user_name: "Alice" },
+      ]],
+    },
+  });
+});
+
+test("feishu delivery invoke sends files by existing file key", async () => {
+  const fake = new FakeFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  await invokeFeishuDeliveryOperation({
+    provider: "feishu",
+    surface: "chat_message",
+    targetRef: "oc_chat",
+  }, "send_file", { fileKey: "file_123" }, client);
+
+  assert.equal(fake.calls[0]?.operation, "post:/im/v1/messages");
+  const payload = fake.calls[0]?.payload as Record<string, unknown>;
+  assert.equal(payload.msg_type, "file");
+  assert.equal(payload.receive_id, "oc_chat");
+  assert.deepEqual(JSON.parse(String(payload.content)), { file_key: "file_123" });
+});
+
+test("feishu delivery invoke uploads local paths before sending file messages", async () => {
+  const fake = new FakeFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  await invokeFeishuDeliveryOperation({
+    provider: "feishu",
+    surface: "message_reply",
+    targetRef: "om_reply",
+  }, "send_file_from_path", {
+    filePath: "/tmp/report.txt",
+    uxcAuth: "feishu-tuptup",
+  }, client);
+
+  assert.equal(fake.calls[0]?.operation, "post:/im/v1/files");
+  assert.deepEqual(fake.calls[0]?.payload, {
+    file_type: "stream",
+    file_name: "report.txt",
+    file: "/tmp/report.txt",
+  });
+  assert.equal((fake.calls[0]?.options as Record<string, unknown>)?.auth, "feishu-tuptup");
+  assert.equal(fake.calls[1]?.operation, "post:/im/v1/messages/{message_id}/reply");
+  const replyPayload = fake.calls[1]?.payload as Record<string, unknown>;
+  assert.equal(replyPayload.msg_type, "file");
+  assert.deepEqual(JSON.parse(String(replyPayload.content)), { file_key: "file_uploaded" });
 });
 
 test("feishu follow templates expand chat and mention subscriptions over a shared uxc source", () => {


### PR DESCRIPTION
## Summary

- add Feishu `send_post`, `send_file`, and `send_file_from_path` delivery operations
- keep reply vs chat send selected by the existing `DeliveryHandle.surface`
- upload local file paths through UXC daemon before sending Feishu file messages
- broaden Feishu delivery validation and tests for rich text/file payloads

## Validation

- `npm run build`
- `node --require ts-node/register --test --test-force-exit test/feishu.test.ts test/remote_source.test.ts`
- live smoke in the `bottest` Feishu group through `agentinbox deliver invoke`:
  - `send_post` replied with rich text
  - `send_file_from_path` uploaded an absolute local path and replied with a file
