### PR TITLE
Add Feishu global mention follow

### DIFF
--- a/docs/site/guides/README.md
+++ b/docs/site/guides/README.md
@@ -3,8 +3,13 @@
 - [Onboarding With The AgentInbox Skill](./onboarding-with-agent-skill.md)
 - [Getting Started](./getting-started.md)
 - [Review Workflows](./review-workflows.md)
+- [Feishu And Lark](./feishu.md)
 
 <!-- INDEX:START -->
+
+- [Feishu And Lark](./feishu.md)
+  This guide shows how to use `AgentInbox` with a Feishu/Lark bot through UXC.
+  <!-- mdorigin:index kind=article -->
 
 - [Getting Started](./getting-started.md)
   This guide shows the shortest path from install to a working local agent session.

--- a/docs/site/guides/feishu.md
+++ b/docs/site/guides/feishu.md
@@ -1,0 +1,93 @@
+# Feishu And Lark
+
+This guide shows how to use `AgentInbox` with a Feishu/Lark bot through UXC.
+
+## Prerequisites
+
+- `agentinbox` installed and running
+- `uxc` installed
+- a UXC Feishu/Lark credential, for example `feishu-default`
+- a Feishu/Lark app with message event permissions such as
+  `im:message.group_msg`
+- the bot added to the chats where it should receive message events
+
+Register the current runtime first:
+
+```bash
+agentinbox agent register
+```
+
+## Follow Bot Mentions
+
+For most agent bot workflows, use the global mention template:
+
+```bash
+agentinbox follow feishu mentions \
+  --agent-id <agentId> \
+  --arg openId=<botOpenId> \
+  --config-json '{"uxcAuth":"feishu-default"}'
+```
+
+This follows messages that mention `<botOpenId>` across chats visible to the
+configured Feishu/Lark app event stream. It does not mean every chat in the
+tenant. The app must be allowed to receive those events, and the bot normally
+needs to be in the chat.
+
+## Follow One Chat
+
+If the workflow is intentionally limited to one group, use the chat-scoped
+templates:
+
+```bash
+agentinbox follow feishu chat \
+  --agent-id <agentId> \
+  --arg chatId=<chatId> \
+  --config-json '{"uxcAuth":"feishu-default"}'
+```
+
+```bash
+agentinbox follow feishu mention \
+  --agent-id <agentId> \
+  --arg chatId=<chatId> \
+  --arg openId=<botOpenId> \
+  --config-json '{"uxcAuth":"feishu-default"}'
+```
+
+Feishu/Lark `chat_id` values are API identifiers. Users normally see group
+names in the app UI, not `oc_xxx` ids. Resolve them with Feishu/Lark IM tools
+before using a chat-scoped follow, or prefer `feishu.mentions`.
+
+## Read, Add Context, And Reply
+
+Read the agent inbox:
+
+```bash
+agentinbox inbox read --agent-id <agentId>
+```
+
+Feishu/Lark inbox items include:
+
+- `metadata.chatId`
+- `metadata.messageId`
+- `metadata.mentionOpenIds`
+- `deliveryHandle`
+
+Fetch surrounding message context when needed:
+
+```bash
+agentinbox source invoke <sourceId> \
+  --operation get_message_context \
+  --input-json '{"messageId":"<messageId>","chatId":"<chatId>","windowBefore":5,"windowAfter":5}'
+```
+
+Reply with text:
+
+```bash
+agentinbox deliver invoke \
+  --handle-json '<deliveryHandle-json>' \
+  --operation send_text \
+  --input-json '{"text":"Acknowledged","uxcAuth":"feishu-default"}'
+```
+
+Rich text and files are available through delivery operations such as
+`send_post`, `send_file`, and `send_file_from_path`.

--- a/docs/site/rfcs/im-agent-interaction-model.md
+++ b/docs/site/rfcs/im-agent-interaction-model.md
@@ -191,6 +191,7 @@ Illustrative examples:
 agentinbox follow im chat --arg chatId=oc_xxx
 agentinbox follow im mention --arg chatId=oc_xxx --arg openId=ou_agent
 agentinbox follow feishu mention --arg chatId=oc_xxx --arg openId=ou_agent
+agentinbox follow feishu mentions --arg openId=ou_agent
 ```
 
 The compiled subscription should use normal filter semantics.
@@ -205,6 +206,20 @@ Example mention filter:
   "expr": "contains(metadata.mentionOpenIds, \"ou_agent\")"
 }
 ```
+
+For IM-native onboarding, a provider can also expose a broader mention intent
+that does not require the user or agent to know a group `chatId` up front.
+For Feishu/Lark, `feishu.mentions` follows all chats visible to the app event
+stream and filters only by `mentionOpenIds`:
+
+```json
+{
+  "expr": "contains(metadata.mentionOpenIds, \"ou_agent\")"
+}
+```
+
+This does not mean every tenant chat. It means every chat whose message events
+are delivered to the configured Feishu/Lark app and UXC managed source.
 
 The exact metadata fields are source-specific, but IM source modules should
 prefer a common vocabulary where provider data allows it:

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -166,6 +166,29 @@ Use `follow` as the default path for GitHub repo, PR, and issue tracking. Drop
 to `source schema` plus `subscription add` only when you need a custom filter or
 the source has no follow template.
 
+Feishu/Lark follows require a UXC credential that can host the Feishu app
+connection. For bot mention workflows, prefer the global mention template so
+the user does not need to discover a group `chat_id` first:
+
+```bash
+agentinbox follow feishu mentions --agent-id <agentId> --arg openId=<botOpenId> --config-json '{"uxcAuth":"feishu-default"}'
+```
+
+Use the chat-scoped templates when the task is explicitly limited to one group:
+
+```bash
+agentinbox follow feishu chat --agent-id <agentId> --arg chatId=<chatId> --config-json '{"uxcAuth":"feishu-default"}'
+agentinbox follow feishu mention --agent-id <agentId> --arg chatId=<chatId> --arg openId=<botOpenId> --config-json '{"uxcAuth":"feishu-default"}'
+```
+
+Feishu inbox items include `metadata.chatId`, `metadata.messageId`, and a
+`deliveryHandle`. Use `source invoke` for local context before replying:
+
+```bash
+agentinbox source invoke <sourceId> --operation get_message_context --input-json '{"messageId":"<messageId>","chatId":"<chatId>","windowBefore":5,"windowAfter":5}'
+agentinbox deliver invoke --handle-json '<deliveryHandle-json>' --operation send_text --input-json '{"text":"Acknowledged","uxcAuth":"feishu-default"}'
+```
+
 Advanced source/subscription commands:
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1626,6 +1626,7 @@ Examples:
   agentinbox follow github repo --agent-id <agentId> --arg owner=holon-run --arg repo=agentinbox
   agentinbox follow github pr --agent-id <agentId> --arg owner=holon-run --arg repo=agentinbox --arg number=87 --arg withCi=true
   agentinbox follow github issue --agent-id <agentId> --arg owner=holon-run --arg repo=agentinbox --arg number=180
+  agentinbox follow feishu mentions --agent-id <agentId> --arg openId=ou_bot --config-json '{"uxcAuth":"feishu-default"}'
 `,
     source: `agentinbox source
 

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -397,32 +397,39 @@ export function feishuFollowTemplateSpec(): FollowTemplateSpec[] {
         { name: "openId", type: "string", required: true, description: "Mentioned user or bot open_id." },
       ],
     },
+    {
+      templateId: "feishu.mentions",
+      providerOrKind: "feishu",
+      label: "Feishu Mentions",
+      description: "Follow messages across visible Feishu/Lark chats that mention a user or bot.",
+      argsSchema: [
+        { name: "openId", type: "string", required: true, description: "Mentioned user or bot open_id." },
+      ],
+    },
   ];
 }
 
 export function expandFeishuFollowTemplate(input: ExpandFollowTemplateInput): ExpandedFollowPlan | null {
-  if (input.template !== "chat" && input.template !== "mention") {
+  if (input.template !== "chat" && input.template !== "mention" && input.template !== "mentions") {
     return null;
   }
   const args = input.args ?? {};
   const chatId = asString(args.chatId);
-  if (!chatId) {
+  if (input.template !== "mentions" && !chatId) {
     throw new Error(`follow template feishu.${input.template} requires argument chatId`);
   }
   const config = parseFeishuSourceConfig(input.source);
   const sourceKey = `feishu:${config.uxcAuth ?? input.source.configRef ?? "default"}:messages`;
-  const filter: SubscriptionFilter = {
-    metadata: { chatId },
-  };
+  const filter: SubscriptionFilter = chatId ? { metadata: { chatId } } : {};
 
-  let trackedResourceRef = `chat:${chatId}`;
-  if (input.template === "mention") {
+  let trackedResourceRef = chatId ? `chat:${chatId}` : "mentions";
+  if (input.template === "mention" || input.template === "mentions") {
     const openId = asString(args.openId);
     if (!openId) {
-      throw new Error("follow template feishu.mention requires argument openId");
+      throw new Error(`follow template feishu.${input.template} requires argument openId`);
     }
     filter.expr = `contains(metadata.mentionOpenIds, ${JSON.stringify(openId)})`;
-    trackedResourceRef = `chat:${chatId}:mention:${openId}`;
+    trackedResourceRef = chatId ? `chat:${chatId}:mention:${openId}` : `mentions:${openId}`;
   }
 
   return {

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -429,7 +429,7 @@ export function expandFeishuFollowTemplate(input: ExpandFollowTemplateInput): Ex
       throw new Error(`follow template feishu.${input.template} requires argument openId`);
     }
     filter.expr = `contains(metadata.mentionOpenIds, ${JSON.stringify(openId)})`;
-    trackedResourceRef = chatId ? `chat:${chatId}:mention:${openId}` : `mentions:${openId}`;
+    trackedResourceRef = chatId ? `chat:${chatId}:mention:${openId}` : `mention:${openId}`;
   }
 
   return {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -332,7 +332,11 @@ test("feishu delivery invoke uploads local paths before sending file messages", 
 });
 
 test("feishu follow templates expand chat and mention subscriptions over a shared uxc source", () => {
-  assert.deepEqual(feishuFollowTemplateSpec().map((template) => template.templateId), ["feishu.chat", "feishu.mention"]);
+  assert.deepEqual(feishuFollowTemplateSpec().map((template) => template.templateId), [
+    "feishu.chat",
+    "feishu.mention",
+    "feishu.mentions",
+  ]);
 
   const source: SourceStream = {
     sourceId: "preview",
@@ -362,6 +366,37 @@ test("feishu follow templates expand chat and mention subscriptions over a share
     metadata: { chatId: "oc_chat" },
     expr: "contains(metadata.mentionOpenIds, \"ou_bot\")",
   });
+});
+
+test("feishu mentions follow template does not require a chat id", () => {
+  const source: SourceStream = {
+    sourceId: "preview",
+    sourceType: "feishu_bot",
+    sourceKey: "preview",
+    configRef: null,
+    config: { uxcAuth: "feishu-tuptup" },
+    status: "active",
+    checkpoint: null,
+    createdAt: "",
+    updatedAt: "",
+  };
+  const plan = expandFeishuFollowTemplate({
+    template: "mentions",
+    args: { openId: "ou_bot" },
+    source,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.templateId, "feishu.mentions");
+  assert.equal(plan.sources[0]?.sourceKey, "feishu:feishu-tuptup:messages");
+  assert.deepEqual(plan.sources[0]?.config, {
+    uxcAuth: "feishu-tuptup",
+    eventTypes: ["im.message.receive_v1"],
+  });
+  assert.deepEqual(plan.subscriptions[0]?.filter, {
+    expr: "contains(metadata.mentionOpenIds, \"ou_bot\")",
+  });
+  assert.equal(plan.subscriptions[0]?.trackedResourceRef, "mentions:ou_bot");
 });
 
 test("feishu source operation fetches anchor message context and keeps permission warnings non-fatal", async () => {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -396,7 +396,7 @@ test("feishu mentions follow template does not require a chat id", () => {
   assert.deepEqual(plan.subscriptions[0]?.filter, {
     expr: "contains(metadata.mentionOpenIds, \"ou_bot\")",
   });
-  assert.equal(plan.subscriptions[0]?.trackedResourceRef, "mentions:ou_bot");
+  assert.equal(plan.subscriptions[0]?.trackedResourceRef, "mention:ou_bot");
 });
 
 test("feishu source operation fetches anchor message context and keeps permission warnings non-fatal", async () => {


### PR DESCRIPTION
## Summary
- add a Feishu `mentions` follow template that filters by mentioned open_id without requiring chat_id
- document Feishu/Lark onboarding and global mention behavior in the guide, RFC, and bundled skill
- add Feishu follow-template coverage and a CLI help example

## Testing
- `npm run build`
- `node --require ts-node/register --test --test-force-exit test/feishu.test.ts`

Note: I accidentally started the full npm test suite with the pattern argument in the wrong script position; it was stopped after unrelated control-plane tests ran for several minutes. The targeted Feishu suite and TypeScript build both pass.