### PR TITLE
Resolve Feishu bot open_id for mention follows

### DIFF
--- a/docs/site/guides/feishu.md
+++ b/docs/site/guides/feishu.md
@@ -24,14 +24,23 @@ For most agent bot workflows, use the global mention template:
 ```bash
 agentinbox follow feishu mentions \
   --agent-id <agentId> \
-  --arg openId=<botOpenId> \
   --config-json '{"uxcAuth":"feishu-default"}'
 ```
 
-This follows messages that mention `<botOpenId>` across chats visible to the
-configured Feishu/Lark app event stream. It does not mean every chat in the
-tenant. The app must be allowed to receive those events, and the bot normally
-needs to be in the chat.
+By default, `AgentInbox` resolves the configured app bot's `open_id` from the
+Feishu/Lark credential and follows messages that mention that bot across chats
+visible to the app event stream. It does not mean every chat in the tenant. The
+app must be allowed to receive those events, and the bot normally needs to be
+in the chat.
+
+To follow mentions for another user or bot explicitly, pass `openId`:
+
+```bash
+agentinbox follow feishu mentions \
+  --agent-id <agentId> \
+  --arg openId=<openId> \
+  --config-json '{"uxcAuth":"feishu-default"}'
+```
 
 ## Follow One Chat
 

--- a/docs/site/rfcs/im-agent-interaction-model.md
+++ b/docs/site/rfcs/im-agent-interaction-model.md
@@ -191,7 +191,7 @@ Illustrative examples:
 agentinbox follow im chat --arg chatId=oc_xxx
 agentinbox follow im mention --arg chatId=oc_xxx --arg openId=ou_agent
 agentinbox follow feishu mention --arg chatId=oc_xxx --arg openId=ou_agent
-agentinbox follow feishu mentions --arg openId=ou_agent
+agentinbox follow feishu mentions
 ```
 
 The compiled subscription should use normal filter semantics.
@@ -210,7 +210,9 @@ Example mention filter:
 For IM-native onboarding, a provider can also expose a broader mention intent
 that does not require the user or agent to know a group `chatId` up front.
 For Feishu/Lark, `feishu.mentions` follows all chats visible to the app event
-stream and filters only by `mentionOpenIds`:
+stream and filters only by `mentionOpenIds`. If the caller does not pass an
+explicit `openId`, the Feishu/Lark module should resolve the configured app
+bot's `open_id` through the provider credential before compiling the filter:
 
 ```json
 {

--- a/skills/agentinbox/SKILL.md
+++ b/skills/agentinbox/SKILL.md
@@ -168,11 +168,15 @@ the source has no follow template.
 
 Feishu/Lark follows require a UXC credential that can host the Feishu app
 connection. For bot mention workflows, prefer the global mention template so
-the user does not need to discover a group `chat_id` first:
+the user does not need to discover a group `chat_id` or bot `open_id` first:
 
 ```bash
-agentinbox follow feishu mentions --agent-id <agentId> --arg openId=<botOpenId> --config-json '{"uxcAuth":"feishu-default"}'
+agentinbox follow feishu mentions --agent-id <agentId> --config-json '{"uxcAuth":"feishu-default"}'
 ```
+
+When `openId` is omitted, `AgentInbox` resolves the configured app bot's
+`open_id` through UXC before creating the subscription. Pass `--arg
+openId=<openId>` only when following mentions for a different user or bot.
 
 Use the chat-scoped templates when the task is explicitly limited to one group:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1626,7 +1626,7 @@ Examples:
   agentinbox follow github repo --agent-id <agentId> --arg owner=holon-run --arg repo=agentinbox
   agentinbox follow github pr --agent-id <agentId> --arg owner=holon-run --arg repo=agentinbox --arg number=87 --arg withCi=true
   agentinbox follow github issue --agent-id <agentId> --arg owner=holon-run --arg repo=agentinbox --arg number=180
-  agentinbox follow feishu mentions --agent-id <agentId> --arg openId=ou_bot --config-json '{"uxcAuth":"feishu-default"}'
+  agentinbox follow feishu mentions --agent-id <agentId> --config-json '{"uxcAuth":"feishu-default"}'
 `,
     source: `agentinbox source
 

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -1,4 +1,7 @@
 import { UxcDaemonClient } from "@holon-run/uxc-daemon-client";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   AppendSourceEventInput,
   DeliveryAttempt,
@@ -15,6 +18,7 @@ import type { ExpandFollowTemplateInput, ExpandedFollowPlan } from "./remote_mod
 export const FEISHU_OPENAPI_ENDPOINT = "https://open.feishu.cn/open-apis";
 export const FEISHU_IM_SCHEMA_URL =
   "https://raw.githubusercontent.com/holon-run/uxc/main/skills/feishu-openapi-skill/references/feishu-im.openapi.json";
+const FEISHU_BOT_SCHEMA_FILE = join(tmpdir(), "agentinbox-feishu-bot.openapi.json");
 export const DEFAULT_FEISHU_EVENT_TYPES = ["im.message.receive_v1"];
 const DEFAULT_CONTEXT_BOUND_SECONDS = 7 * 24 * 60 * 60;
 
@@ -31,7 +35,7 @@ export interface FeishuCallClient {
     endpoint: string;
     operation: string;
     payload?: Record<string, unknown>;
-    options?: { auth?: string; schema_url?: string };
+    options?: { auth?: string; schema_url?: string; refresh_schema?: boolean; no_cache?: boolean };
   }): Promise<{ data: unknown }>;
 }
 
@@ -172,6 +176,28 @@ export class FeishuUxcClient {
       },
     });
     return response.data;
+  }
+
+  async getBotOpenId(input: {
+    endpoint?: string;
+    auth?: string;
+  }): Promise<string> {
+    const response = await this.client.call({
+      endpoint: input.endpoint ?? FEISHU_OPENAPI_ENDPOINT,
+      operation: "get:/bot/v3/info",
+      payload: {},
+      options: {
+        auth: input.auth,
+        schema_url: ensureFeishuBotSchemaFile(),
+        refresh_schema: true,
+        no_cache: true,
+      },
+    });
+    const openId = findStringField(response.data, "open_id");
+    if (!openId) {
+      throw new Error("Feishu bot info response did not include bot.open_id");
+    }
+    return openId;
   }
 }
 
@@ -403,13 +429,16 @@ export function feishuFollowTemplateSpec(): FollowTemplateSpec[] {
       label: "Feishu Mentions",
       description: "Follow messages across visible Feishu/Lark chats that mention a user or bot.",
       argsSchema: [
-        { name: "openId", type: "string", required: true, description: "Mentioned user or bot open_id." },
+        { name: "openId", type: "string", required: false, description: "Mentioned user or bot open_id. Defaults to the configured app bot open_id." },
       ],
     },
   ];
 }
 
-export function expandFeishuFollowTemplate(input: ExpandFollowTemplateInput): ExpandedFollowPlan | null {
+export async function expandFeishuFollowTemplate(
+  input: ExpandFollowTemplateInput,
+  client: FeishuUxcClient = new FeishuUxcClient(),
+): Promise<ExpandedFollowPlan | null> {
   if (input.template !== "chat" && input.template !== "mention" && input.template !== "mentions") {
     return null;
   }
@@ -424,7 +453,7 @@ export function expandFeishuFollowTemplate(input: ExpandFollowTemplateInput): Ex
 
   let trackedResourceRef = chatId ? `chat:${chatId}` : "mentions";
   if (input.template === "mention" || input.template === "mentions") {
-    const openId = asString(args.openId);
+    const openId = asString(args.openId) ?? await resolveFeishuMentionOpenId(input, config, client);
     if (!openId) {
       throw new Error(`follow template feishu.${input.template} requires argument openId`);
     }
@@ -452,6 +481,20 @@ export function expandFeishuFollowTemplate(input: ExpandFollowTemplateInput): Ex
       },
     ],
   };
+}
+
+async function resolveFeishuMentionOpenId(
+  input: ExpandFollowTemplateInput,
+  config: FeishuBotSourceConfig,
+  client: FeishuUxcClient,
+): Promise<string | null> {
+  if (input.template !== "mentions") {
+    return null;
+  }
+  return client.getBotOpenId({
+    endpoint: config.endpoint,
+    auth: config.uxcAuth ?? input.source.configRef ?? undefined,
+  });
 }
 
 export function feishuSourceOperations(): SourceOperationDescriptor[] {
@@ -1177,3 +1220,52 @@ function asStringArray(value: unknown): string[] | null {
     .map((item) => asString(item))
     .filter((item): item is string => Boolean(item));
 }
+
+function ensureFeishuBotSchemaFile(): string {
+  const body = JSON.stringify(FEISHU_BOT_OPENAPI_SCHEMA);
+  writeFileSync(FEISHU_BOT_SCHEMA_FILE, body, "utf8");
+  return FEISHU_BOT_SCHEMA_FILE;
+}
+
+const FEISHU_BOT_OPENAPI_SCHEMA = {
+  openapi: "3.0.3",
+  info: {
+    title: "Feishu Bot Info",
+    version: "1.0.0",
+  },
+  servers: [
+    {
+      url: FEISHU_OPENAPI_ENDPOINT,
+    },
+  ],
+  // Feishu's docs site does not currently expose this as a stable
+  // machine-readable OpenAPI document to UXC, so keep the tiny operation
+  // schema needed for bot self-identification close to the adapter.
+  paths: {
+    "/bot/v3/info": {
+      get: {
+        operationId: "get:/bot/v3/info",
+        summary: "Get bot information for the current app",
+        responses: {
+          "200": {
+            description: "OK",
+          },
+        },
+        security: [
+          {
+            bearerAuth: [],
+          },
+        ],
+      },
+    },
+  },
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "tenant_access_token",
+      },
+    },
+  },
+} as const;

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -709,7 +709,7 @@ const FEISHU_BOT_MODULE: RemoteSourceModule = {
   listFollowTemplates(): FollowTemplateSpec[] {
     return feishuFollowTemplateSpec();
   },
-  expandFollowTemplate(input: ExpandFollowTemplateInput): ExpandedFollowPlan | null {
+  async expandFollowTemplate(input: ExpandFollowTemplateInput): Promise<ExpandedFollowPlan | null> {
     return expandFeishuFollowTemplate(input);
   },
   buildManagedSourceSpec(source: SourceStream): ManagedSourceSpec {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -22,6 +22,9 @@ class FakeFeishuUxcClient implements FeishuCallClient {
 
   async call(args: Record<string, unknown>) {
     this.calls.push(args);
+    if (args.operation === "get:/bot/v3/info") {
+      return { data: { code: 0, bot: { open_id: "ou_resolved_bot" } } };
+    }
     if (args.operation === "post:/im/v1/files") {
       return { data: { code: 0, data: { file_key: "file_uploaded" } } };
     }
@@ -331,7 +334,7 @@ test("feishu delivery invoke uploads local paths before sending file messages", 
   assert.deepEqual(JSON.parse(String(replyPayload.content)), { file_key: "file_uploaded" });
 });
 
-test("feishu follow templates expand chat and mention subscriptions over a shared uxc source", () => {
+test("feishu follow templates expand chat and mention subscriptions over a shared uxc source", async () => {
   assert.deepEqual(feishuFollowTemplateSpec().map((template) => template.templateId), [
     "feishu.chat",
     "feishu.mention",
@@ -349,7 +352,7 @@ test("feishu follow templates expand chat and mention subscriptions over a share
     createdAt: "",
     updatedAt: "",
   };
-  const plan = expandFeishuFollowTemplate({
+  const plan = await expandFeishuFollowTemplate({
     template: "mention",
     args: { chatId: "oc_chat", openId: "ou_bot" },
     source,
@@ -368,7 +371,7 @@ test("feishu follow templates expand chat and mention subscriptions over a share
   });
 });
 
-test("feishu mentions follow template does not require a chat id", () => {
+test("feishu mentions follow template does not require a chat id", async () => {
   const source: SourceStream = {
     sourceId: "preview",
     sourceType: "feishu_bot",
@@ -380,7 +383,7 @@ test("feishu mentions follow template does not require a chat id", () => {
     createdAt: "",
     updatedAt: "",
   };
-  const plan = expandFeishuFollowTemplate({
+  const plan = await expandFeishuFollowTemplate({
     template: "mentions",
     args: { openId: "ou_bot" },
     source,
@@ -397,6 +400,37 @@ test("feishu mentions follow template does not require a chat id", () => {
     expr: "contains(metadata.mentionOpenIds, \"ou_bot\")",
   });
   assert.equal(plan.subscriptions[0]?.trackedResourceRef, "mention:ou_bot");
+});
+
+test("feishu mentions follow template resolves the configured bot open id by default", async () => {
+  const fake = new FakeFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  const source: SourceStream = {
+    sourceId: "preview",
+    sourceType: "feishu_bot",
+    sourceKey: "preview",
+    configRef: null,
+    config: { uxcAuth: "feishu-tuptup" },
+    status: "active",
+    checkpoint: null,
+    createdAt: "",
+    updatedAt: "",
+  };
+  const plan = await expandFeishuFollowTemplate({
+    template: "mentions",
+    args: {},
+    source,
+  }, client);
+
+  assert.ok(plan);
+  assert.deepEqual(plan.subscriptions[0]?.filter, {
+    expr: "contains(metadata.mentionOpenIds, \"ou_resolved_bot\")",
+  });
+  assert.equal(plan.subscriptions[0]?.trackedResourceRef, "mention:ou_resolved_bot");
+  assert.equal(fake.calls[0]?.operation, "get:/bot/v3/info");
+  assert.equal((fake.calls[0]?.options as Record<string, unknown>)?.auth, "feishu-tuptup");
+  assert.equal((fake.calls[0]?.options as Record<string, unknown>)?.refresh_schema, true);
+  assert.equal((fake.calls[0]?.options as Record<string, unknown>)?.no_cache, true);
 });
 
 test("feishu source operation fetches anchor message context and keeps permission warnings non-fatal", async () => {


### PR DESCRIPTION
## Summary
- make `feishu.mentions` resolve the configured app bot `open_id` when `openId` is omitted
- add a minimal Feishu bot-info OpenAPI schema for UXC calls to `/bot/v3/info`
- update CLI help, guide, RFC, and bundled skill to show the no-openId onboarding path

## Testing
- `npm run build`
- `node --require ts-node/register --test --test-force-exit test/feishu.test.ts`
- live UXC smoke: `FeishuUxcClient.getBotOpenId({auth: "feishu-tuptup"})` returned the TupTup Assistant bot open_id