### PR TITLE
Omit null Feishu delivery uuid

### DIFF
--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -54,13 +54,13 @@ export class FeishuUxcClient {
     await this.client.call({
       endpoint: input.endpoint ?? FEISHU_OPENAPI_ENDPOINT,
       operation: "post:/im/v1/messages",
-      payload: {
+      payload: compactPayload({
         receive_id_type: "chat_id",
         receive_id: input.chatId,
         msg_type: input.msgType,
         content: input.content,
-        uuid: input.uuid ?? null,
-      },
+        uuid: input.uuid,
+      }),
       options: {
         auth: input.auth,
         schema_url: input.schemaUrl ?? FEISHU_IM_SCHEMA_URL,
@@ -81,13 +81,13 @@ export class FeishuUxcClient {
     await this.client.call({
       endpoint: input.endpoint ?? FEISHU_OPENAPI_ENDPOINT,
       operation: "post:/im/v1/messages/{message_id}/reply",
-      payload: {
+      payload: compactPayload({
         message_id: input.messageId,
         msg_type: input.msgType,
         content: input.content,
-        reply_in_thread: input.replyInThread ?? null,
-        uuid: input.uuid ?? null,
-      },
+        reply_in_thread: input.replyInThread,
+        uuid: input.uuid,
+      }),
       options: {
         auth: input.auth,
         schema_url: input.schemaUrl ?? FEISHU_IM_SCHEMA_URL,
@@ -1206,6 +1206,10 @@ function asRecord(value: unknown): Record<string, unknown> {
     return {};
   }
   return value as Record<string, unknown>;
+}
+
+function compactPayload(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined));
 }
 
 function asString(value: unknown): string | null {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -223,6 +223,8 @@ test("feishu delivery adapter maps message replies and chat sends to uxc calls",
   await adapter.send({ kind: "reply", payload: { text: "hello" } } as never, replyAttempt);
   assert.equal(fake.calls[0]?.operation, "post:/im/v1/messages/{message_id}/reply");
   assert.equal((fake.calls[0]?.options as Record<string, unknown>)?.schema_url, FEISHU_IM_SCHEMA_URL);
+  assert.equal(Object.hasOwn(fake.calls[0]?.payload as Record<string, unknown>, "uuid"), false);
+  assert.equal(Object.hasOwn(fake.calls[0]?.payload as Record<string, unknown>, "reply_in_thread"), false);
 
   const chatAttempt: DeliveryAttempt = {
     ...replyAttempt,
@@ -235,6 +237,7 @@ test("feishu delivery adapter maps message replies and chat sends to uxc calls",
   assert.equal(fake.calls[1]?.operation, "post:/im/v1/messages");
   assert.equal((fake.calls[1]?.payload as Record<string, unknown>)?.receive_id_type, "chat_id");
   assert.equal((fake.calls[1]?.options as Record<string, unknown>)?.schema_url, FEISHU_IM_SCHEMA_URL);
+  assert.equal(Object.hasOwn(fake.calls[1]?.payload as Record<string, unknown>, "uuid"), false);
 });
 
 test("feishu delivery operations expose canonical text, rich text, and file actions", () => {
@@ -260,6 +263,18 @@ test("feishu delivery invoke maps send_text to the canonical outbound path", asy
     targetRef: "oc_chat",
   }, "send_text", { text: "team update" }, client);
   assert.equal(fake.calls[0]?.operation, "post:/im/v1/messages");
+});
+
+test("feishu delivery includes optional uuid only when provided", async () => {
+  const fake = new FakeFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  await invokeFeishuDeliveryOperation({
+    provider: "feishu",
+    surface: "chat_message",
+    targetRef: "oc_chat",
+  }, "send_text", { text: "team update", uuid: "msg-1" }, client);
+
+  assert.equal((fake.calls[0]?.payload as Record<string, unknown>)?.uuid, "msg-1");
 });
 
 test("feishu delivery invoke maps send_post blocks to Feishu post payloads", async () => {


### PR DESCRIPTION
## Summary
- omit optional Feishu `uuid` and `reply_in_thread` fields when they are not provided
- keep explicit `uuid` support for callers that want idempotent delivery
- add Feishu delivery regression coverage for the default payload shape

## Why
Feishu treats `uuid: null` as an idempotency value. AgentInbox was reporting `sent`, but Feishu could return a previous message instead of creating a new chat message.

## Validation
- `npm run build`
- `node --require ts-node/register --test --test-force-exit test/feishu.test.ts`
- local daemon smoke: `agentinbox deliver send ...` to the `bottest` chat and verified the message appeared via `lark-cli im +chat-messages-list`
