### PR TITLE
Add Feishu recent messages source operation

### DIFF
--- a/docs/site/guides/feishu.md
+++ b/docs/site/guides/feishu.md
@@ -89,6 +89,18 @@ agentinbox source invoke <sourceId> \
   --input-json '{"messageId":"<messageId>","chatId":"<chatId>","windowBefore":5,"windowAfter":5}'
 ```
 
+`get_message_context` is anchored to a specific inbox message. Keep passing the
+triggering `messageId` when an agent is adding context for a notification; this
+avoids racing against newer messages in the same group.
+
+For unanchored browsing, list the latest messages in a chat instead:
+
+```bash
+agentinbox source invoke <sourceId> \
+  --operation list_recent_messages \
+  --input-json '{"chatId":"<chatId>","limit":20}'
+```
+
 Reply with text:
 
 ```bash

--- a/src/sources/feishu.ts
+++ b/src/sources/feishu.ts
@@ -150,6 +150,7 @@ export class FeishuUxcClient {
     chatId: string;
     startTime?: string;
     endTime?: string;
+    pageToken?: string;
     pageSize?: number;
     sort?: "ByCreateTimeAsc" | "ByCreateTimeDesc";
   }): Promise<unknown> {
@@ -165,6 +166,9 @@ export class FeishuUxcClient {
     }
     if (input.endTime) {
       payload.end_time = input.endTime;
+    }
+    if (input.pageToken) {
+      payload.page_token = input.pageToken;
     }
     const response = await this.client.call({
       endpoint: input.endpoint ?? FEISHU_OPENAPI_ENDPOINT,
@@ -519,6 +523,26 @@ export function feishuSourceOperations(): SourceOperationDescriptor[] {
         required: ["anchorMessage", "chatWindowMessages", "threadMessages", "warnings", "deliveryHandle"],
       },
     },
+    {
+      name: "list_recent_messages",
+      title: "List Recent Messages",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["chatId"],
+        properties: {
+          chatId: { type: "string", minLength: 1 },
+          limit: { type: "number", minimum: 1, maximum: 50 },
+          before: { type: "string", minLength: 1 },
+          pageToken: { type: "string", minLength: 1 },
+        },
+      },
+      outputSchema: {
+        type: "object",
+        additionalProperties: true,
+        required: ["chatId", "messages", "warnings"],
+      },
+    },
   ];
 }
 
@@ -528,6 +552,9 @@ export async function invokeFeishuSourceOperation(
   input: Record<string, unknown>,
   client: FeishuUxcClient = new FeishuUxcClient(),
 ): Promise<Record<string, unknown>> {
+  if (operation === "list_recent_messages") {
+    return listRecentFeishuMessages(source, input, client);
+  }
   if (operation !== "get_message_context") {
     throw new Error(`unknown Feishu source operation: ${operation}`);
   }
@@ -579,6 +606,36 @@ export async function invokeFeishuSourceOperation(
       threadRef: anchorMessage?.threadId ?? anchorMessage?.parentId ?? null,
       replyMode: "reply",
     },
+  };
+}
+
+async function listRecentFeishuMessages(
+  source: SourceStream,
+  input: Record<string, unknown>,
+  client: FeishuUxcClient,
+): Promise<Record<string, unknown>> {
+  const chatId = asString(input.chatId);
+  if (!chatId) {
+    throw new Error("list_recent_messages requires input.chatId");
+  }
+  const config = parseFeishuSourceConfig(source);
+  const limit = boundedPositiveInteger(input.limit, 20, 50);
+  const raw = await client.listMessages({
+    endpoint: config.endpoint,
+    schemaUrl: config.schemaUrl,
+    auth: config.uxcAuth,
+    chatId,
+    endTime: asString(input.before) ?? undefined,
+    pageToken: asString(input.pageToken) ?? undefined,
+    pageSize: limit,
+    sort: "ByCreateTimeDesc",
+  });
+  return {
+    chatId,
+    messages: normalizeFeishuMessages(raw),
+    warnings: [],
+    ...(feishuResponsePageToken(raw) ? { pageToken: feishuResponsePageToken(raw) } : {}),
+    ...(feishuResponseHasMore(raw) != null ? { hasMore: feishuResponseHasMore(raw) } : {}),
   };
 }
 
@@ -1041,6 +1098,35 @@ function positiveInteger(value: unknown): number | null {
     return null;
   }
   return value;
+}
+
+function boundedPositiveInteger(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    return fallback;
+  }
+  return Math.min(value, max);
+}
+
+function feishuResponsePageToken(raw: unknown): string | null {
+  const record = asRecord(raw);
+  const data = asRecord(record.data);
+  const nestedData = asRecord(data.data);
+  return asString(nestedData.page_token)
+    ?? asString(data.page_token)
+    ?? asString(record.page_token);
+}
+
+function feishuResponseHasMore(raw: unknown): boolean | null {
+  const record = asRecord(raw);
+  const data = asRecord(record.data);
+  const nestedData = asRecord(data.data);
+  if (typeof nestedData.has_more === "boolean") {
+    return nestedData.has_more;
+  }
+  if (typeof data.has_more === "boolean") {
+    return data.has_more;
+  }
+  return typeof record.has_more === "boolean" ? record.has_more : null;
 }
 
 function extractMentionNames(raw: unknown): string[] {

--- a/test/feishu.test.ts
+++ b/test/feishu.test.ts
@@ -115,6 +115,30 @@ class SuccessfulContextFeishuUxcClient implements FeishuCallClient {
   }
 }
 
+class RecentMessagesFeishuUxcClient implements FeishuCallClient {
+  public calls: Array<Record<string, unknown>> = [];
+
+  async call(args: Record<string, unknown>) {
+    this.calls.push(args);
+    if (args.operation === "get:/im/v1/messages") {
+      return {
+        data: {
+          code: 0,
+          data: {
+            items: [
+              feishuMessage({ messageId: "om_latest", content: "{\"text\":\"latest\"}", createTime: "1773491928409" }),
+              feishuMessage({ messageId: "om_previous", content: "{\"text\":\"previous\"}", createTime: "1773491926409" }),
+            ],
+            page_token: "next_page",
+            has_more: true,
+          },
+        },
+      };
+    }
+    return { data: { code: 0 } };
+  }
+}
+
 function feishuMessage(input: { messageId: string; content: string; createTime: string }): Record<string, unknown> {
   return {
     message_id: input.messageId,
@@ -519,4 +543,67 @@ test("feishu source operation unwraps nested UXC envelopes and anchors chat wind
   assert.equal(afterPayload.page_size, 2);
   assert.equal(afterPayload.start_time, "1773491924");
   assert.deepEqual(result.warnings, []);
+});
+
+test("feishu source operation lists recent chat messages with default limit", async () => {
+  const fake = new RecentMessagesFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  const source: SourceStream = {
+    sourceId: "src_feishu",
+    sourceType: "feishu_bot",
+    sourceKey: "tenant-default",
+    configRef: null,
+    config: { uxcAuth: "feishu-tuptup" },
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  assert.ok(feishuSourceOperations().some((operation) => operation.name === "list_recent_messages"));
+  const result = await invokeFeishuSourceOperation(source, "list_recent_messages", { chatId: "oc_chat" }, client);
+
+  assert.equal(fake.calls[0]?.operation, "get:/im/v1/messages");
+  assert.equal((fake.calls[0]?.options as Record<string, unknown>)?.auth, "feishu-tuptup");
+  const payload = fake.calls[0]?.payload as Record<string, unknown>;
+  assert.equal(payload.container_id, "oc_chat");
+  assert.equal(payload.page_size, 20);
+  assert.equal(payload.sort_type, "ByCreateTimeDesc");
+  assert.equal(Object.hasOwn(payload, "start_time"), false);
+  assert.equal(Object.hasOwn(payload, "end_time"), false);
+  assert.deepEqual((result.messages as Array<Record<string, unknown>>).map((message) => message.messageId), [
+    "om_latest",
+    "om_previous",
+  ]);
+  assert.equal(result.pageToken, "next_page");
+  assert.equal(result.hasMore, true);
+  assert.deepEqual(result.warnings, []);
+});
+
+test("feishu source operation lists recent chat messages with explicit limit and before cursor", async () => {
+  const fake = new RecentMessagesFeishuUxcClient();
+  const client = new FeishuUxcClient(fake);
+  const source: SourceStream = {
+    sourceId: "src_feishu",
+    sourceType: "feishu_bot",
+    sourceKey: "tenant-default",
+    configRef: null,
+    config: { uxcAuth: "feishu-tuptup" },
+    status: "active",
+    checkpoint: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  await invokeFeishuSourceOperation(source, "list_recent_messages", {
+    chatId: "oc_chat",
+    limit: 3,
+    before: "1773491930",
+    pageToken: "page_1",
+  }, client);
+
+  const payload = fake.calls[0]?.payload as Record<string, unknown>;
+  assert.equal(payload.page_size, 3);
+  assert.equal(payload.end_time, "1773491930");
+  assert.equal(payload.page_token, "page_1");
 });


### PR DESCRIPTION
## Summary
- add Feishu `list_recent_messages` source operation for unanchored chat browsing
- reuse existing Feishu message normalization and include pagination hints when returned by UXC
- document when to use anchored `get_message_context` versus recent-message browsing

## Validation
- `npm run build`
- `node --require ts-node/register --test --test-force-exit test/feishu.test.ts`

Closes #197.
