### PR TITLE
Clarify unsupported delivery command errors

### DIFF
--- a/docs/site/guides/feishu.md
+++ b/docs/site/guides/feishu.md
@@ -129,3 +129,27 @@ agentinbox deliver invoke \
 
 Rich text and files are available through delivery operations such as
 `send_post`, `send_file`, and `send_file_from_path`.
+
+Send a new message to a chat by using the `chat_message` surface and the chat
+ID as the target:
+
+```bash
+agentinbox deliver invoke \
+  --provider feishu \
+  --surface chat_message \
+  --target '<chatId>' \
+  --operation send_text \
+  --input-json '{"text":"Daily report","uxcAuth":"feishu-default"}'
+```
+
+Use `deliver actions` to inspect available operations and input schemas:
+
+```bash
+agentinbox deliver actions \
+  --provider feishu \
+  --surface chat_message \
+  --target '<chatId>'
+```
+
+The Feishu adapter currently supports `message_reply` and `chat_message`
+surfaces.

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -276,10 +276,10 @@ export class AdapterRegistry {
   async listDeliveryOperations(
     source: SourceStream | null,
     handle: DeliveryHandle,
-  ): Promise<DeliveryOperationDescriptor[]> {
+  ): Promise<DeliveryOperationDescriptor[] | null> {
     const module = await this.resolveDeliveryModule(source, handle);
     if (!module?.listDeliveryOperations) {
-      return [];
+      return null;
     }
     return module.listDeliveryOperations({ handle, source });
   }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1991,6 +1991,8 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("deliver send is not supported") ||
     message.startsWith("deliveryHandle requires") ||
     message.startsWith("delivery operations are not supported") ||
+    message.startsWith("unsupported delivery surface") ||
+    message.startsWith("unsupported delivery operation") ||
     message.startsWith("source operations are not supported") ||
     message.startsWith("unknown GitHub delivery operation") ||
     message.startsWith("unknown Feishu delivery operation") ||

--- a/src/service.ts
+++ b/src/service.ts
@@ -1948,6 +1948,12 @@ export class AgentInboxService {
     const handle = resolveDeliveryHandle(request);
     const source = resolveDeliverySource(this.store, request.sourceId, handle);
     const operations = await this.adapters.listDeliveryOperations(source, handle);
+    if (operations === null) {
+      throw new Error(`delivery operations are not supported for provider ${handle.provider}`);
+    }
+    if (operations.length === 0) {
+      throw new Error(noDeliveryOperationsMessage(handle));
+    }
     return {
       sourceId: source?.sourceId ?? null,
       handle,
@@ -1960,6 +1966,15 @@ export class AgentInboxService {
   ): Promise<DeliveryAttempt & { note: string; operation: string }> {
     const handle = resolveDeliveryHandle(request);
     const source = resolveDeliverySource(this.store, request.sourceId, handle);
+    const operations = await this.adapters.listDeliveryOperations(source, handle);
+    if (operations !== null) {
+      if (operations.length === 0) {
+        throw new Error(noDeliveryOperationsMessage(handle));
+      }
+      if (!operations.some((operation) => operation.name === request.operation)) {
+        throw new Error(unsupportedDeliveryOperationMessage(handle, request.operation, operations));
+      }
+    }
     const attempt: DeliveryAttempt = {
       deliveryId: generateCanonicalId("dlv"),
       provider: handle.provider,
@@ -1985,9 +2000,9 @@ export class AgentInboxService {
     attempt: DeliveryAttempt,
   ): Promise<{ status: DeliveryAttempt["status"]; note: string }> {
     const operations = await this.adapters.listDeliveryOperations(source, handle);
-    const canonicalOperation = operations.find((operation) => operation.canonicalTextAlias);
+    const canonicalOperation = operations?.find((operation) => operation.canonicalTextAlias);
     if (!canonicalOperation) {
-      throw new Error(`deliver send is not supported for ${handle.provider}/${handle.surface}; use deliver invoke`);
+      throw new Error(deliverSendUnsupportedMessage(handle, operations));
     }
     const input = payload.text != null ? { ...payload, body: String(payload.text) } : payload;
     return this.adapters.invokeDeliveryOperation(source, handle, canonicalOperation.name, input, attempt);
@@ -4486,6 +4501,54 @@ function listHostStreamKinds(hostType: SourceHost["hostType"]): string[] {
     case "remote_source":
       return ["default"];
   }
+}
+
+const KNOWN_DELIVERY_SURFACES: Record<string, string[]> = {
+  feishu: ["message_reply", "chat_message"],
+  github: ["issue_comment", "pull_request_comment", "review_comment"],
+};
+
+function unsupportedDeliverySurfaceMessage(handle: DeliveryHandle): string {
+  const supported = KNOWN_DELIVERY_SURFACES[handle.provider];
+  const supportedHint = supported?.length
+    ? ` Supported surfaces for ${handle.provider}: ${supported.join(", ")}.`
+    : "";
+  return `unsupported delivery surface for ${handle.provider}: ${handle.surface}.${supportedHint} ${deliveryActionsHelp(handle)}`;
+}
+
+function noDeliveryOperationsMessage(handle: DeliveryHandle): string {
+  if (!isKnownDeliverySurface(handle)) {
+    return unsupportedDeliverySurfaceMessage(handle);
+  }
+  return `delivery operations are not supported for ${handle.provider}/${handle.surface}. ${deliveryActionsHelp(handle)}`;
+}
+
+function unsupportedDeliveryOperationMessage(
+  handle: DeliveryHandle,
+  operation: string,
+  operations: DeliveryOperationDescriptor[],
+): string {
+  const names = operations.map((item) => item.name).join(", ");
+  return `unsupported delivery operation for ${handle.provider}/${handle.surface}: ${operation}. Available operations: ${names}. ${deliveryActionsHelp(handle)}`;
+}
+
+function deliverSendUnsupportedMessage(handle: DeliveryHandle, operations: DeliveryOperationDescriptor[] | null): string {
+  if (!operations || operations.length === 0) {
+    if (!isKnownDeliverySurface(handle)) {
+      return unsupportedDeliverySurfaceMessage(handle);
+    }
+    return `deliver send is not supported for ${handle.provider}/${handle.surface}. ${deliveryActionsHelp(handle)}`;
+  }
+  const names = operations.map((item) => item.name).join(", ");
+  return `deliver send is not supported for ${handle.provider}/${handle.surface}; use deliver invoke with one of: ${names}. ${deliveryActionsHelp(handle)}`;
+}
+
+function deliveryActionsHelp(handle: DeliveryHandle): string {
+  return `Run \`agentinbox deliver actions --provider ${handle.provider} --surface ${handle.surface} --target ${handle.targetRef}\` to inspect supported operations and input schemas.`;
+}
+
+function isKnownDeliverySurface(handle: DeliveryHandle): boolean {
+  return KNOWN_DELIVERY_SURFACES[handle.provider]?.includes(handle.surface) === true;
 }
 
 function getHostConfigFields(hostType: SourceHost["hostType"]): Array<{ name: string; type: string; description: string; required?: boolean }> {

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -664,6 +664,28 @@ test("control plane validates sources/events occurredAt and deliveries/send requ
       });
       assert.equal(mismatchedSend.statusCode, 400);
       assert.match(mismatchedSend.data.error, /deliver send is not supported/);
+
+      const unsupportedFeishuSurface = await client.request<{ error: string }>("/deliveries/actions", {
+        provider: "feishu",
+        surface: "group_message",
+        targetRef: "oc_chat",
+      });
+      assert.equal(unsupportedFeishuSurface.statusCode, 400);
+      assert.match(unsupportedFeishuSurface.data.error, /unsupported delivery surface for feishu: group_message/);
+      assert.match(unsupportedFeishuSurface.data.error, /Supported surfaces for feishu: message_reply, chat_message/);
+      assert.match(unsupportedFeishuSurface.data.error, /agentinbox deliver actions --provider feishu --surface group_message --target oc_chat/);
+
+      const unknownFeishuOperation = await client.request<{ error: string }>("/deliveries/invoke", {
+        provider: "feishu",
+        surface: "chat_message",
+        targetRef: "oc_chat",
+        operation: "send_group_message",
+        input: {},
+      });
+      assert.equal(unknownFeishuOperation.statusCode, 400);
+      assert.match(unknownFeishuOperation.data.error, /unsupported delivery operation for feishu\/chat_message: send_group_message/);
+      assert.match(unknownFeishuOperation.data.error, /Available operations: send_text, send_post, send_file, send_file_from_path/);
+      assert.match(unknownFeishuOperation.data.error, /agentinbox deliver actions --provider feishu --surface chat_message --target oc_chat/);
     } finally {
       await started.close();
     }
@@ -714,6 +736,31 @@ test("control plane exposes delivery actions and invoke for remote modules", asy
   },
   async invokeDeliveryOperation(input) {
     return { status: "sent", note: "invoked " + input.operation + " for " + input.handle.targetRef };
+  }
+};`,
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(moduleDir, "invoke-only-delivery-hook.mjs"),
+    `export default {
+  id: "demo.invoke-only-delivery-hook",
+  validateConfig() {},
+  buildManagedSourceSpec() {
+    return {
+      endpoint: "https://example.com",
+      mode: "poll",
+      poll_config: {
+        interval_secs: 30,
+        extract_items_pointer: "",
+        checkpoint_strategy: { type: "item_key", item_key_pointer: "/id", seen_window: 32 }
+      }
+    };
+  },
+  mapRawEvent() {
+    return null;
+  },
+  async invokeDeliveryOperation(input) {
+    return { status: "sent", note: "invoke-only " + input.operation + " for " + input.handle.targetRef };
   }
 };`,
     "utf8",
@@ -776,6 +823,45 @@ test("control plane exposes delivery actions and invoke for remote modules", asy
       assert.equal(invoke.data.status, "sent");
       assert.equal(invoke.data.operation, "ack_remote_event");
       assert.match(invoke.data.note, /invoked ack_remote_event/);
+
+      const invokeOnlyHost = await client.request<{ hostId: string }>("/hosts", {
+        hostType: "remote_source",
+        hostKey: "demo-invoke-only-delivery",
+        config: {},
+      });
+      assert.equal(invokeOnlyHost.statusCode, 200);
+      const invokeOnlySource = await client.request<{ sourceId: string }>("/sources", {
+        hostId: invokeOnlyHost.data.hostId,
+        streamKind: "default",
+        streamKey: "demo-invoke-only-delivery",
+        config: {
+          modulePath: "invoke-only-delivery-hook.mjs",
+          moduleConfig: {},
+        },
+      });
+      assert.equal(invokeOnlySource.statusCode, 200);
+
+      const invokeOnlyActions = await client.request<{ error: string }>("/deliveries/actions", {
+        sourceId: invokeOnlySource.data.sourceId,
+        provider: "demo",
+        surface: "ticket",
+        targetRef: "ticket:43",
+      });
+      assert.equal(invokeOnlyActions.statusCode, 400);
+      assert.match(invokeOnlyActions.data.error, /delivery operations are not supported/);
+
+      const invokeOnlyResult = await client.request<{ status: string; note: string; operation: string }>("/deliveries/invoke", {
+        sourceId: invokeOnlySource.data.sourceId,
+        provider: "demo",
+        surface: "ticket",
+        targetRef: "ticket:43",
+        operation: "custom_dynamic_operation",
+        input: { body: "acked" },
+      });
+      assert.equal(invokeOnlyResult.statusCode, 200);
+      assert.equal(invokeOnlyResult.data.status, "sent");
+      assert.equal(invokeOnlyResult.data.operation, "custom_dynamic_operation");
+      assert.match(invokeOnlyResult.data.note, /invoke-only custom_dynamic_operation/);
     } finally {
       await started.close();
     }
@@ -1972,6 +2058,40 @@ test("cli deliver invoke requires input-json", () => {
       result.stderr,
       /usage: agentinbox deliver invoke \(\-\-handle-json JSON \| \-\-provider PROVIDER \-\-surface SURFACE \-\-target TARGET\) \-\-operation NAME \-\-input-json JSON \[\-\-source-id SOURCE_ID\]/,
     );
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli deliver reports unsupported dynamic surfaces with actions help", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-deliver-help-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%9633",
+    CODEX_THREAD_ID: "thread-deliver-help",
+  };
+
+  try {
+    const result = runCli([
+      "deliver",
+      "actions",
+      "--provider",
+      "feishu",
+      "--surface",
+      "group_message",
+      "--target",
+      "oc_chat",
+    ], env);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /HTTP 400/);
+    assert.match(result.stderr, /unsupported delivery surface for feishu: group_message/);
+    assert.match(result.stderr, /Supported surfaces for feishu: message_reply, chat_message/);
+    assert.match(result.stderr, /agentinbox deliver actions --provider feishu --surface group_message --target oc_chat/);
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- return 400 with actionable help for unsupported delivery surfaces and operations
- make unsupported Feishu `group_message` point users to supported surfaces and `deliver actions`
- document `chat_message` as the supported Feishu new-chat-message surface

Fixes #204.

## Validation

- `npm run build`
- `node --require ts-node/register --test --test-force-exit --test-name-pattern 'control plane validates sources/events occurredAt and deliveries/send request shape|cli deliver reports unsupported dynamic surfaces with actions help|cli deliver actions exposes handle-scoped delivery operations|cli deliver invoke requires input-json' test/control_plane.test.ts`
