### PR TITLE
feat: add agent target update command for webhook targets (#190)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -608,6 +608,24 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "agent" && normalized[1] === "target" && normalized[2] === "update") {
+    const [agentId, targetId] = normalized.slice(3, 5);
+    if (!agentId || !targetId) {
+      throw new Error("usage: agentinbox agent target update <agentId> <targetId> [--url URL] [--activation-mode MODE] [--notify-lease-ms N] [--min-unacked-items N]");
+    }
+    const body: Record<string, unknown> = {};
+    const url = takeFlagValue(normalized, "--url");
+    if (url) body.url = url;
+    const activationMode = takeFlagValue(normalized, "--activation-mode");
+    if (activationMode) body.activationMode = activationMode;
+    const notifyLeaseMs = takeFlagValue(normalized, "--notify-lease-ms");
+    if (notifyLeaseMs) body.notifyLeaseMs = parseOptionalNumber(notifyLeaseMs);
+    const minUnackedItems = takeFlagValue(normalized, "--min-unacked-items");
+    if (minUnackedItems) body.minUnackedItems = parseOptionalNumber(minUnackedItems);
+    await printRemote(client, `/agents/${encodeURIComponent(agentId)}/targets/${encodeURIComponent(targetId)}`, body, "PATCH");
+    return;
+  }
+
   if (command === "subscription" && normalized[1] === "add") {
     const args = normalized.slice(2);
     const positionals = positionalArgs(args, [
@@ -1328,11 +1346,18 @@ function clientArgsForCommand(args: string[]): string[] {
   if (isAgentTargetAddWebhookCommand(args)) {
     return withoutFlagValues(args, "--url");
   }
+  if (isAgentTargetUpdateCommand(args)) {
+    return withoutFlagValues(args, "--url");
+  }
   return args;
 }
 
 function isAgentTargetAddWebhookCommand(args: string[]): boolean {
   return args[0] === "agent" && args[1] === "target" && args[2] === "add" && args[3] === "webhook";
+}
+
+function isAgentTargetUpdateCommand(args: string[]): boolean {
+  return args[0] === "agent" && args[1] === "target" && args[2] === "update";
 }
 
 function withoutFlagValues(args: string[], flag: string): string[] {
@@ -1717,6 +1742,7 @@ Usage:
   agentinbox agent target list <agentId> [--limit N]
   agentinbox agent target remove <agentId> <targetId>
   agentinbox agent target resume <agentId> <targetId>
+  agentinbox agent target update <agentId> <targetId> [--url URL] [--activation-mode MODE] [--notify-lease-ms N] [--min-unacked-items N]
 `,
     timer: `agentinbox timer
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -1130,6 +1130,55 @@ function buildFastifyServer(service: AgentInboxService) {
     });
   });
 
+  app.patch("/agents/:agentId/targets/:targetId", {
+    schema: {
+      tags: ["agents"],
+      params: {
+        type: "object",
+        required: ["agentId", "targetId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+          targetId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          url: { type: "string" },
+          activationMode: { type: "string" },
+          notifyLeaseMs: { type: "integer", minimum: 1 },
+          minUnackedItems: { type: "integer", minimum: 1 },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string; targetId: string };
+    const body = request.body as {
+      url?: string;
+      activationMode?: ActivationMode;
+      notifyLeaseMs?: number;
+      minUnackedItems?: number;
+    };
+    if (!body.url && body.activationMode === undefined && body.notifyLeaseMs === undefined && body.minUnackedItems === undefined) {
+      throw new Error("at least one of --url, --activation-mode, --notify-lease-ms, --min-unacked-items must be provided");
+    }
+    return service.updateWebhookActivationTarget(
+      decodeURIComponent(params.agentId),
+      decodeURIComponent(params.targetId),
+      {
+        url: body.url,
+        activationMode: body.activationMode,
+        notifyLeaseMs: body.notifyLeaseMs ?? null,
+        minUnackedItems: body.minUnackedItems ?? null,
+      },
+    );
+  });
+
   app.delete("/agents/:agentId/targets/:targetId", {
     schema: {
       tags: ["agents"],

--- a/src/model.ts
+++ b/src/model.ts
@@ -375,6 +375,13 @@ export interface AddWebhookActivationTargetInput {
   minUnackedItems?: number | null;
 }
 
+export interface UpdateWebhookActivationTargetInput {
+  url?: string;
+  activationMode?: ActivationMode;
+  notifyLeaseMs?: number | null;
+  minUnackedItems?: number | null;
+}
+
 export interface DirectInboxTextMessageInput {
   message: string;
   sender?: string | null;

--- a/src/service.ts
+++ b/src/service.ts
@@ -5,6 +5,7 @@ import {
   ActivationTarget,
   AddWebhookActivationTargetInput,
   Agent,
+  UpdateWebhookActivationTargetInput,
   AgentTimer,
   DirectInboxTextMessageInput,
   DirectInboxTextMessageResult,
@@ -968,6 +969,34 @@ export class AgentInboxService {
     };
     this.store.insertActivationTarget(target);
     this.markAgentActive(agentId);
+    return target;
+  }
+
+  updateWebhookActivationTarget(
+    agentId: string,
+    targetId: string,
+    input: UpdateWebhookActivationTargetInput,
+  ): WebhookActivationTarget {
+    this.getAgent(agentId);
+    const existing = this.getActivationTarget(targetId);
+    if (existing.agentId !== agentId) {
+      throw new Error(`activation target ${targetId} does not belong to agent ${agentId}`);
+    }
+    if (existing.kind !== "webhook") {
+      throw new Error(`activation target ${targetId} is not a webhook target`);
+    }
+    validateNotifyLeaseMs(input.notifyLeaseMs);
+    validateMinUnackedItems(input.minUnackedItems);
+    const mode = normalizeWebhookActivationMode(input.activationMode ?? existing.mode);
+    const now = nowIso();
+    const target = this.store.updateWebhookActivationTarget(targetId, {
+      url: input.url ?? existing.url,
+      mode,
+      notifyLeaseMs: input.notifyLeaseMs ?? existing.notifyLeaseMs,
+      minUnackedItems: input.minUnackedItems !== undefined ? input.minUnackedItems : existing.minUnackedItems ?? null,
+      updatedAt: now,
+      lastSeenAt: now,
+    });
     return target;
   }
 

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 import initSqlJs from "sql.js";
 import { AdapterRegistry } from "../src/adapters";
 import { EventBusBackend, SqliteEventBusBackend } from "../src/backend";
-import { Activation, ActivationTarget, AppendSourceEventInput, Subscription, TerminalActivationTarget } from "../src/model";
+import { Activation, ActivationTarget, AppendSourceEventInput, Subscription, TerminalActivationTarget, WebhookActivationTarget } from "../src/model";
 import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { ActivationGate } from "../src/runtime_gate";
 import { UxcRemoteSourceClient } from "../src/sources/remote";
@@ -858,6 +858,104 @@ test("terminal registration is rejected while an active webhook target exists fo
     const targets = service.listActivationTargets("agent-webhook-sticky");
     assert.equal(targets.length, 1);
     assert.equal(targets[0]?.kind, "webhook");
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("update webhook activation target via service", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    service.registerAgent({
+      agentId: "update-webhook-test",
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "update-webhook-test",
+      tmuxPaneId: "%999",
+    });
+    const target = service.addWebhookActivationTarget("update-webhook-test", {
+      url: "http://127.0.0.1:9999/original",
+      activationMode: "activation_with_items",
+      notifyLeaseMs: 100,
+      minUnackedItems: 5,
+    });
+    assert.equal(target.url, "http://127.0.0.1:9999/original");
+    assert.equal(target.mode, "activation_with_items");
+    assert.equal(target.notifyLeaseMs, 100);
+    assert.equal(target.minUnackedItems, 5);
+
+    // Update URL only
+    const updated = service.updateWebhookActivationTarget("update-webhook-test", target.targetId, {
+      url: "http://127.0.0.1:8888/updated",
+    });
+    assert.equal(updated.url, "http://127.0.0.1:8888/updated");
+    assert.equal(updated.mode, "activation_with_items"); // unchanged
+    assert.equal(updated.notifyLeaseMs, 100); // unchanged
+    assert.equal(updated.minUnackedItems, 5); // unchanged
+    assert.equal(updated.status, "active"); // reset to active
+
+    // Update mode only
+    const updated2 = service.updateWebhookActivationTarget("update-webhook-test", target.targetId, {
+      activationMode: "activation_only",
+    });
+    assert.equal(updated2.url, "http://127.0.0.1:8888/updated"); // unchanged
+    assert.equal(updated2.mode, "activation_only");
+    assert.equal(updated2.notifyLeaseMs, 100);
+    assert.equal(updated2.minUnackedItems, 5);
+
+    // Update notifyLeaseMs and minUnackedItems
+    const updated3 = service.updateWebhookActivationTarget("update-webhook-test", target.targetId, {
+      notifyLeaseMs: 200,
+      minUnackedItems: 3,
+    });
+    assert.equal(updated3.notifyLeaseMs, 200);
+    assert.equal(updated3.minUnackedItems, 3);
+
+    // Verify store reflects updates
+    const stored = service.getActivationTarget(target.targetId);
+    assert.equal(stored.kind, "webhook");
+    const webhookStored = stored as WebhookActivationTarget;
+    assert.equal(webhookStored.url, "http://127.0.0.1:8888/updated");
+    assert.equal(webhookStored.mode, "activation_only");
+    assert.equal(webhookStored.notifyLeaseMs, 200);
+    assert.equal(webhookStored.minUnackedItems, 3);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("update webhook activation target rejects non-webhook targets", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    service.registerAgent({
+      agentId: "update-non-webhook",
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "update-non-webhook",
+      tmuxPaneId: "%998",
+    });
+    const terminalTargets = service.listActivationTargets("update-non-webhook");
+    assert.equal(terminalTargets.length, 1);
+    const terminalTarget = terminalTargets[0]!;
+    assert.equal(terminalTarget.kind, "terminal");
+
+    assert.throws(
+      () => service.updateWebhookActivationTarget("update-non-webhook", terminalTarget.targetId, {
+        url: "http://127.0.0.1:9999/updated",
+      }),
+      /not a webhook target/,
+    );
+
+    assert.throws(
+      () => service.updateWebhookActivationTarget("update-non-webhook", "nonexistent-id", {
+        url: "http://127.0.0.1:9999/updated",
+      }),
+      /unknown activation target/,
+    );
   } finally {
     await service.stop();
     store.close();

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1698,6 +1698,90 @@ test("cli agent register requires --agent-id when --webhook-url is used", async 
   }
 });
 
+test("cli agent target update webhook", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "aix-cli-webhook-target-update-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%905",
+    CODEX_THREAD_ID: "thread-cli-webhook-target-update",
+  };
+
+  try {
+    const register = runCli(["agent", "register", "--agent-id", "agent-cli-webhook-update"], env);
+    assert.equal(register.status, 0, register.stderr);
+
+    const addTarget = runCli([
+      "agent",
+      "target",
+      "add",
+      "webhook",
+      "agent-cli-webhook-update",
+      "--url",
+      "http://127.0.0.1:9999/activate",
+      "--activation-mode",
+      "activation_with_items",
+      "--notify-lease-ms",
+      "100",
+    ], env);
+    assert.equal(addTarget.status, 0, addTarget.stderr);
+    const target = JSON.parse(addTarget.stdout) as { targetId: string; url: string; mode: string };
+    assert.equal(target.url, "http://127.0.0.1:9999/activate");
+
+    // Update URL
+    const update = runCli([
+      "agent",
+      "target",
+      "update",
+      "agent-cli-webhook-update",
+      target.targetId,
+      "--url",
+      "http://127.0.0.1:8888/updated",
+    ], env);
+    assert.equal(update.status, 0, update.stderr);
+    const updated = JSON.parse(update.stdout) as { url: string; mode: string; notifyLeaseMs: number };
+    assert.equal(updated.url, "http://127.0.0.1:8888/updated");
+    assert.equal(updated.mode, "activation_with_items"); // unchanged
+    assert.equal(updated.notifyLeaseMs, 100); // unchanged
+
+    // Update mode
+    const update2 = runCli([
+      "agent",
+      "target",
+      "update",
+      "agent-cli-webhook-update",
+      target.targetId,
+      "--activation-mode",
+      "activation_only",
+    ], env);
+    assert.equal(update2.status, 0, update2.stderr);
+    const updated2 = JSON.parse(update2.stdout) as { mode: string; url: string };
+    assert.equal(updated2.mode, "activation_only");
+    assert.equal(updated2.url, "http://127.0.0.1:8888/updated"); // unchanged
+
+    // Verify list reflects update
+    const list = runCli(["agent", "target", "list", "agent-cli-webhook-update"], env);
+    assert.equal(list.status, 0, list.stderr);
+    assert.match(list.stdout, /8888\/updated/);
+
+    // Usage error when no params
+    const noArgs = runCli(["agent", "target", "update"], env);
+    assert.notEqual(noArgs.status, 0);
+    assert.match(noArgs.stderr, /usage: agentinbox agent target update/);
+
+    // Error for non-existent target
+    const badTarget = runCli(["agent", "target", "update", "agent-cli-webhook-update", "nonexistent", "--url", "http://127.0.0.1:9999/nope"], env);
+    assert.notEqual(badTarget.status, 0);
+    assert.match(badTarget.stderr, /unknown activation target/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("cli source schema resolves source ids to instance schema", () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-source-schema-"));
   const env = {


### PR DESCRIPTION
## Summary

Adds `agentinbox agent target update <agentId> <targetId>` CLI command for updating webhook target properties.

## Changes

- **model**: Add `UpdateWebhookActivationTargetInput` interface with all fields optional
- **service**: Add `updateWebhookActivationTarget` method — validates ownership, ensures webhook kind, supports partial updates, resets status to active
- **http**: Add `PATCH /agents/:agentId/targets/:targetId` route with schema validation
- **cli**: Add `agent target update` subcommand with `--url`, `--activation-mode`, `--notify-lease-ms`, `--min-unacked-items` flags; add `isAgentTargetUpdateCommand` to `clientArgsForCommand` to prevent `--url` from being consumed as daemon base URL override
- **tests**: Service-level tests (update individual fields, rejects non-webhook targets) + CLI integration test

Closes #190