### PR TITLE
Fix Telegram poll and webhook activation dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ The format is intentionally simple during public beta:
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-21
+
+### Added
+
+- Added status diagnostics for daemon, database health, source/agent counts,
+  activation target reachability, activation dispatch backlog, and delivery
+  retry state.
+
+### Changed
+
+- Split store subscription query and SQLite migration/recovery coverage into
+  focused tests while keeping the end-to-end smoke path in the integration
+  suite.
+
 ## [1.3.3] - 2026-06-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/swagger": "^9.5.2",
-        "@holon-run/uxc-daemon-client": "^0.15.4",
+        "@holon-run/uxc-daemon-client": "^0.15.8",
         "better-sqlite3": "^12.10.0",
         "commander": "^14.0.3",
         "fastify": "^5.6.1",
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@holon-run/uxc-daemon-client": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.15.4.tgz",
-      "integrity": "sha512-Rz6qUCPEtgnwanghASX/YJ7kAo+EdaXgdf+m4hAhZl64TDDaoHtFQF+5PB7EutXCD0Yf1ahID2F/jLxhy4+Wxw==",
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@holon-run/uxc-daemon-client/-/uxc-daemon-client-0.15.8.tgz",
+      "integrity": "sha512-ZawBJoo/jTTm29hqCyhT5eaXXu6eUhTXDCWWwJEYNctJGdyeEtIEArKNl8a4lfyS3dnoPBnZfKcrIO+VYls0dA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holon-run/agentinbox",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@holon-run/agentinbox",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/swagger": "^9.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holon-run/agentinbox",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Local event subscription and delivery service for agents.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@fastify/swagger": "^9.5.2",
-    "@holon-run/uxc-daemon-client": "^0.15.4",
+    "@holon-run/uxc-daemon-client": "^0.15.8",
     "better-sqlite3": "^12.10.0",
     "commander": "^14.0.3",
     "fastify": "^5.6.1",

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -19,7 +19,7 @@ import { AgentInboxStore } from "./store";
 import { resolveAgentInboxHome } from "./paths";
 import { FeishuDeliveryAdapter } from "./sources/feishu";
 import { GithubCallClient, GithubDeliveryAdapter } from "./sources/github";
-import { TelegramDeliveryAdapter } from "./sources/telegram";
+import { TelegramBotApiClient, TelegramDeliveryAdapter } from "./sources/telegram";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
 import { ExpandedFollowPlan, ExpandedSubscriptionPlan, ExpandFollowTemplateInput, LifecycleSignal, RemoteSourceModule, RemoteSourceModuleRegistry, builtinRemoteSourceTypes } from "./sources/remote_modules";
 import { resolveSourceIdentity, resolveSourceSchema } from "./source_resolution";
@@ -88,6 +88,7 @@ export class AdapterRegistry {
       remoteSourceClient?: UxcRemoteSourceClient;
       remoteModuleRegistry?: RemoteSourceModuleRegistry;
       githubCallClient?: GithubCallClient;
+      telegramClient?: TelegramBotApiClient;
     },
   ) {
     this.homeDir = options?.homeDir ?? resolveAgentInboxHome(process.env);
@@ -98,6 +99,7 @@ export class AdapterRegistry {
       homeDir: this.homeDir,
       client: options?.remoteSourceClient,
       moduleRegistry: this.remoteModuleRegistry,
+      telegramClient: options?.telegramClient,
     });
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -114,6 +114,7 @@ interface ActivationPolicy {
 interface BufferedNotification {
   agentId: string;
   targetId: string;
+  targetKind: ActivationTarget["kind"];
   pending: Array<{
     subscriptionId: string | null;
     sourceId: string;
@@ -2417,6 +2418,7 @@ export class AgentInboxService {
       buffer = {
         agentId: target.agentId,
         targetId: target.targetId,
+        targetKind: target.kind,
         pending: [],
         timer: null,
         inFlight: false,
@@ -2514,21 +2516,24 @@ export class AgentInboxService {
         return;
       }
       const state = this.store.getActivationDispatchState(buffer.agentId, buffer.targetId);
-      const shouldAttemptDispatch = !state || (state.status === "dirty" && state.leaseExpiresAt == null);
+      const shouldAttemptDispatch = !state
+        || (state.status === "dirty" && state.leaseExpiresAt == null)
+        || (state.status === "notified" && buffer.targetKind === "webhook");
       if (shouldAttemptDispatch) {
+        const pendingState = state?.status === "dirty" ? state : null;
         const inbox = this.ensureInboxForAgent(buffer.agentId);
         const unackedItems = this.store.listInboxEntries(inbox.inboxId, { includeAcked: false });
         const dispatched = await this.dispatchActivationTarget({
           agentId: buffer.agentId,
           targetId: buffer.targetId,
-          newItemCount: state ? state.pendingNewItemCount + entries.length : entries.length,
+          newItemCount: pendingState ? pendingState.pendingNewItemCount + entries.length : entries.length,
           totalUnackedCount: unackedItems.length,
-          summary: state ? latestSummary(entries) ?? state.pendingSummary : latestSummary(entries),
-          subscriptionIds: state
-            ? uniqueSortedNullable([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)])
+          summary: pendingState ? latestSummary(entries) ?? pendingState.pendingSummary : latestSummary(entries),
+          subscriptionIds: pendingState
+            ? uniqueSortedNullable([...pendingState.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)])
             : uniqueSortedNullable(entries.map((entry) => entry.subscriptionId)),
-          sourceIds: state
-            ? uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)])
+          sourceIds: pendingState
+            ? uniqueSorted([...pendingState.pendingSourceIds, ...entries.map((entry) => entry.sourceId)])
             : uniqueSorted(entries.map((entry) => entry.sourceId)),
           entries: unackedItems,
         });
@@ -2537,22 +2542,22 @@ export class AgentInboxService {
           this.store.deleteActivationDispatchState(buffer.agentId, buffer.targetId);
         }
         if (dispatched === "retryable_failure") {
-          if (state && state.status === "dirty" && state.leaseExpiresAt == null) {
+          if (pendingState && pendingState.leaseExpiresAt == null) {
             this.store.upsertActivationDispatchState({
               agentId: buffer.agentId,
               targetId: buffer.targetId,
               status: "dirty",
               leaseExpiresAt: new Date(Date.now() + DEFAULT_NOTIFY_RETRY_MS).toISOString(),
-              lastNotifiedFingerprint: state.lastNotifiedFingerprint,
+              lastNotifiedFingerprint: pendingState.lastNotifiedFingerprint,
               deferReason: null,
               deferAttempts: 0,
               firstDeferredAt: null,
               lastDeferredAt: null,
               pendingFingerprint: null,
-              pendingNewItemCount: state.pendingNewItemCount + entries.length,
-              pendingSummary: latestSummary(entries) ?? state.pendingSummary,
-              pendingSubscriptionIds: uniqueSortedNullable([...state.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)]),
-              pendingSourceIds: uniqueSorted([...state.pendingSourceIds, ...entries.map((entry) => entry.sourceId)]),
+              pendingNewItemCount: pendingState.pendingNewItemCount + entries.length,
+              pendingSummary: latestSummary(entries) ?? pendingState.pendingSummary,
+              pendingSubscriptionIds: uniqueSortedNullable([...pendingState.pendingSubscriptionIds, ...entries.map((entry) => entry.subscriptionId)]),
+              pendingSourceIds: uniqueSorted([...pendingState.pendingSourceIds, ...entries.map((entry) => entry.sourceId)]),
               updatedAt: nowIso(),
             });
           } else {

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -27,6 +27,11 @@ import {
   ManagedSourceSpec,
   RemoteSourceModuleRegistry,
 } from "./remote_modules";
+import {
+  TelegramBotApiClient,
+  normalizeTelegramBotUpdate,
+  parseTelegramSourceConfig,
+} from "./telegram";
 
 type UxcSourceEnsureArgs = Parameters<UxcDaemonClient["sourceEnsure"]>[0];
 type UxcSourceEnsureSpec = UxcSourceEnsureArgs["spec"];
@@ -61,6 +66,9 @@ interface RemoteSourceCheckpoint {
   };
   streamCursor?: {
     afterOffset: number;
+  };
+  telegramCursor?: {
+    nextOffset: number;
   };
   lastEventAt?: string;
   lastError?: string | null;
@@ -139,6 +147,7 @@ export class RemoteSourceRuntime {
   private readonly errorCounts = new Map<string, number>();
   private readonly nextRetryAt = new Map<string, number>();
   private readonly homeDir: string;
+  private readonly telegramClient: TelegramBotApiClient;
 
   constructor(
     private readonly store: AgentInboxStore,
@@ -147,11 +156,13 @@ export class RemoteSourceRuntime {
       moduleRegistry?: RemoteSourceModuleRegistry;
       client?: UxcRemoteSourceClient;
       homeDir?: string;
+      telegramClient?: TelegramBotApiClient;
     },
   ) {
     this.moduleRegistry = options?.moduleRegistry ?? new RemoteSourceModuleRegistry();
     this.client = options?.client ?? new RpcUxcRemoteSourceClient();
     this.homeDir = options?.homeDir ?? resolveAgentInboxHome(process.env);
+    this.telegramClient = options?.telegramClient ?? new TelegramBotApiClient();
   }
 
   async ensureSource(source: SourceStream): Promise<void> {
@@ -496,6 +507,9 @@ export class RemoteSourceRuntime {
           };
         }
       }
+      if (source.sourceType === "telegram_bot") {
+        return await this.syncTelegramSource(source);
+      }
 
       const module = await this.moduleRegistry.resolve(source, this.homeDir);
       const moduleSource = moduleInputSource(source);
@@ -601,6 +615,74 @@ export class RemoteSourceRuntime {
       this.inFlight.delete(sourceId);
     }
   }
+
+  private async syncTelegramSource(source: SourceStream): Promise<SourcePollResult> {
+    const config = parseTelegramSourceConfig(source);
+    const botToken = config.botToken ?? tokenFromEnv(config.tokenEnv);
+    if (!botToken) {
+      throw new Error("Telegram source requires config.botToken or tokenEnv");
+    }
+    const checkpoint = parseRemoteCheckpoint(source.checkpoint);
+    const updates = await this.telegramClient.getUpdates({
+      endpoint: config.endpoint,
+      botToken,
+      offset: checkpoint.telegramCursor?.nextOffset,
+      timeout: 0,
+      allowedUpdates: config.allowedUpdates,
+    });
+
+    let appended = 0;
+    let deduped = 0;
+    let nextOffset = checkpoint.telegramCursor?.nextOffset ?? 0;
+    for (const update of updates) {
+      const normalized = normalizeTelegramBotUpdate(source, config, update);
+      const updateId = numberFromUnknown(update.update_id);
+      if (updateId !== undefined) {
+        nextOffset = Math.max(nextOffset, updateId + 1);
+      }
+      if (!normalized) {
+        continue;
+      }
+      const result = await this.appendSourceEvent(normalized);
+      appended += result.appended;
+      deduped += result.deduped;
+    }
+
+    const latestSource = this.store.getSource(source.sourceId);
+    if (!latestSource) {
+      throw new Error(`unknown source: ${source.sourceId}`);
+    }
+    const observedAt = nowIso();
+    this.store.updateSourceRuntime(source.sourceId, {
+      status: latestSource.status === "paused" ? "paused" : "active",
+      checkpoint: JSON.stringify({
+        ...checkpoint,
+        telegramCursor: { nextOffset },
+        managedRuntime: {
+          status: "running",
+          runId: null,
+          streamId: null,
+          lastError: null,
+          updatedAt: observedAt,
+          startedAt: checkpoint.managedRuntime?.startedAt ?? observedAt,
+          stoppedAt: null,
+        },
+        lastEventAt: observedAt,
+        lastError: null,
+      } satisfies RemoteSourceCheckpoint),
+    });
+    this.errorCounts.delete(source.sourceId);
+    this.nextRetryAt.delete(source.sourceId);
+
+    return {
+      sourceId: source.sourceId,
+      sourceType: source.sourceType,
+      appended,
+      deduped,
+      eventsRead: updates.length,
+      note: "telegram getUpdates poll completed",
+    };
+  }
 }
 
 function normalizeExpandedSubscriptionPlan(
@@ -664,6 +746,27 @@ function managedBindingForSource(source: SourceStream): { namespace: string; sou
 
 function managedSourceBindingKey(namespace: string, sourceKey: string): string {
   return `${namespace}:${sourceKey}`;
+}
+
+function tokenFromEnv(name: string | undefined): string | null {
+  if (!name) {
+    return null;
+  }
+  const value = process.env[name];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberFromUnknown(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
 }
 
 function parseRemoteCheckpoint(checkpoint: string | null | undefined): RemoteSourceCheckpoint {

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -66,7 +66,7 @@ export interface ManagedSourceSpec {
   args?: Record<string, unknown> | null;
   resource_uri?: string | null;
   read_resource?: boolean;
-  transport_hint?: "websocket" | "discord_gateway" | "slack_socket_mode" | "feishu_long_connection" | "telegram_get_updates" | null;
+  transport_hint?: "websocket" | "discord_gateway" | "slack_socket_mode" | "feishu_long_connection" | null;
   subprotocols?: string[];
   initial_text_frames?: string[];
   mode: "stream" | "poll";
@@ -798,12 +798,23 @@ const TELEGRAM_BOT_MODULE: RemoteSourceModule = {
       endpoint: config.endpoint ?? TELEGRAM_BOT_API_ENDPOINT,
       operation_id: "getUpdates",
       mode: "poll",
-      transport_hint: "telegram_get_updates",
       args: {
+        timeout: 5,
         ...(config.botToken ? { botToken: config.botToken } : {}),
         ...(config.tokenEnv ? { tokenEnv: config.tokenEnv } : {}),
         ...(config.chatIds && config.chatIds.length > 0 ? { chatIds: config.chatIds } : {}),
-        ...(config.allowedUpdates && config.allowedUpdates.length > 0 ? { allowedUpdates: config.allowedUpdates } : {}),
+        ...(config.allowedUpdates && config.allowedUpdates.length > 0 ? { allowed_updates: config.allowedUpdates } : {}),
+      },
+      poll_config: {
+        interval_secs: 2,
+        extract_items_pointer: "/result",
+        request_cursor_arg: "offset",
+        cursor_from_item_pointer: "/update_id",
+        cursor_transform: "increment",
+        checkpoint_strategy: {
+          type: "item_key",
+          item_key_pointer: "/update_id",
+        },
       },
     };
   },

--- a/src/sources/telegram.ts
+++ b/src/sources/telegram.ts
@@ -31,6 +31,47 @@ export interface TelegramFetchClient {
 export class TelegramBotApiClient {
   constructor(private readonly client: TelegramFetchClient = { fetch: (url, init) => fetch(url, init) }) {}
 
+  async getUpdates(input: {
+    endpoint?: string;
+    botToken: string;
+    offset?: number;
+    timeout?: number;
+    allowedUpdates?: string[];
+  }): Promise<Record<string, unknown>[]> {
+    const endpoint = stripTrailingSlash(input.endpoint ?? TELEGRAM_BOT_API_ENDPOINT);
+    const params = new URLSearchParams();
+    if (input.offset !== undefined) {
+      params.set("offset", String(input.offset));
+    }
+    if (input.timeout !== undefined) {
+      params.set("timeout", String(input.timeout));
+    }
+    if (input.allowedUpdates && input.allowedUpdates.length > 0) {
+      params.set("allowed_updates", JSON.stringify(input.allowedUpdates));
+    }
+    const query = params.toString();
+    const response = await this.client.fetch(`${endpoint}/bot${input.botToken}/getUpdates${query ? `?${query}` : ""}`);
+    const body = await response.text();
+    if (!response.ok) {
+      throw new Error(`Telegram getUpdates failed with status ${response.status}: ${body}`);
+    }
+    const parsed = JSON.parse(body) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Telegram getUpdates returned a non-object response");
+    }
+    const envelope = parsed as Record<string, unknown>;
+    if (envelope.ok !== true) {
+      throw new Error(`Telegram getUpdates returned ok=false: ${body}`);
+    }
+    const result = envelope.result;
+    if (!Array.isArray(result)) {
+      throw new Error("Telegram getUpdates response missing result array");
+    }
+    return result
+      .map((item) => asRecord(item))
+      .filter((item) => Object.keys(item).length > 0);
+  }
+
   async sendMessage(input: {
     endpoint?: string;
     botToken: string;

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -3150,6 +3150,51 @@ test("direct inbox text messages create inbox items and trigger activation", asy
   }
 });
 
+test("webhook targets dispatch new items immediately during an active notify lease", async () => {
+  const dispatcher = new RecordingActivationDispatcher();
+  const { store, service, dir } = await makeService({
+    dispatcher,
+    activationWindowMs: 10,
+    activationMaxItems: 20,
+  });
+  try {
+    const registered = service.registerAgent({
+      agentId: "webhook-new-item-lease-test",
+      webhook: {
+        url: "http://127.0.0.1:9999/webhook",
+        notifyLeaseMs: 60_000,
+      },
+    });
+    const targetId = registered.webhookTarget!.targetId;
+
+    await service.addDirectInboxTextMessage("webhook-new-item-lease-test", { message: "first" });
+    await sleep(40);
+
+    assert.equal(dispatcher.calls.length, 1);
+    const firstState = store.getActivationDispatchState("webhook-new-item-lease-test", targetId);
+    assert.equal(firstState?.status, "notified");
+    assert.ok(firstState.leaseExpiresAt);
+    assert.ok(Date.parse(firstState.leaseExpiresAt) > Date.now());
+
+    await service.addDirectInboxTextMessage("webhook-new-item-lease-test", { message: "second" });
+    await sleep(40);
+
+    assert.equal(dispatcher.calls.length, 2);
+    assert.equal(dispatcher.calls[1]!.activation.newItemCount, 1);
+    assert.notEqual(
+      dispatcher.calls[1]!.activation.latestEntryId,
+      dispatcher.calls[0]!.activation.latestEntryId,
+    );
+    const secondState = store.getActivationDispatchState("webhook-new-item-lease-test", targetId);
+    assert.equal(secondState?.status, "notified");
+    assert.equal(secondState?.pendingNewItemCount, 0);
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("direct inbox text messages fail cleanly if the inbox item cannot be persisted", async () => {
   const dispatcher = new RecordingActivationDispatcher();
   const { store, service, dir } = await makeService({
@@ -3638,7 +3683,8 @@ test("active webhook targets suppress terminal activation dispatch for the same 
     await service.pollSubscription(subscription.subscriptionId);
     await sleep(40);
 
-    assert.equal(dispatcher.calls.length, 1);
+    assert.equal(dispatcher.calls.length, 2);
+    assert.equal(dispatcher.calls[1]!.activation.newItemCount, 1);
     assert.equal(terminalDispatcher.calls.length, 0);
 
     const ack = await service.ackAllInboxItems(registered.agent.agentId);
@@ -3653,7 +3699,7 @@ test("active webhook targets suppress terminal activation dispatch for the same 
     await service.pollSubscription(subscription.subscriptionId);
     await sleep(40);
 
-    assert.equal(dispatcher.calls.length, 2);
+    assert.equal(dispatcher.calls.length, 3);
     assert.equal(terminalDispatcher.calls.length, 0);
     assert.equal(store.listActivationDispatchStatesForAgent(registered.agent.agentId).length, 1);
   } finally {

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -12,6 +12,7 @@ import { ManagedSourceSpec, RemoteSourceModuleRegistry, builtInModuleIdForSource
 import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
 import { nowIso } from "../src/util";
+import { TelegramBotApiClient } from "../src/sources/telegram";
 
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   private readonly streams = new Map<string, Array<{ offset: number; raw_payload: unknown }>>();
@@ -192,7 +193,30 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   }
 }
 
-async function makeService(fake: FakeRemoteSourceClient): Promise<{
+class FakeTelegramFetchClient {
+  public readonly calls: Array<{ url: string; init?: RequestInit }> = [];
+  private updates: Record<string, unknown>[] = [];
+
+  push(update: Record<string, unknown>): void {
+    this.updates.push(update);
+  }
+
+  async fetch(url: string, init?: RequestInit): Promise<{ ok: boolean; status: number; text(): Promise<string> }> {
+    this.calls.push({ url, init });
+    const parsed = new URL(url);
+    const offset = Number(parsed.searchParams.get("offset") ?? "0");
+    const result = this.updates.filter((update) => Number(update.update_id) >= offset);
+    return {
+      ok: true,
+      status: 200,
+      async text() {
+        return JSON.stringify({ ok: true, result });
+      },
+    };
+  }
+}
+
+async function makeService(fake: FakeRemoteSourceClient, options?: { telegramFetchClient?: FakeTelegramFetchClient }): Promise<{
   dir: string;
   store: AgentInboxStore;
   service: AgentInboxService;
@@ -204,6 +228,7 @@ async function makeService(fake: FakeRemoteSourceClient): Promise<{
   const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input), {
     homeDir: dir,
     remoteSourceClient: fake,
+    telegramClient: options?.telegramFetchClient ? new TelegramBotApiClient(options.telegramFetchClient) : undefined,
   });
   service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
     stdout: "",
@@ -584,12 +609,13 @@ test("github_repo_ci builtin module emits status transitions for one workflow ru
 
 test("telegram_bot builtin module ingests getUpdates messages", async () => {
   const fake = new FakeRemoteSourceClient();
-  const { dir, store, service } = await makeService(fake);
+  const telegram = new FakeTelegramFetchClient();
+  const { dir, store, service } = await makeService(fake, { telegramFetchClient: telegram });
   try {
     const source = await service.registerSource({
       sourceType: "telegram_bot",
       sourceKey: "operator-bot",
-      config: { tokenEnv: "TELEGRAM_BOT_TOKEN", chatIds: ["456"], allowedUpdates: ["message"] },
+      config: { botToken: "TOKEN", chatIds: ["456"], allowedUpdates: ["message"], endpoint: "https://telegram.test" },
     });
     const agent = service.registerAgent({
       backend: "tmux",
@@ -604,7 +630,7 @@ test("telegram_bot builtin module ingests getUpdates messages", async () => {
       startPolicy: "earliest",
     });
 
-    fake.push("stream:telegram_bot:operator-bot", {
+    telegram.push({
       update_id: 123,
       message: {
         message_id: 7,
@@ -618,8 +644,6 @@ test("telegram_bot builtin module ingests getUpdates messages", async () => {
     const sourcePoll = await service.pollSource(source.sourceId);
     const subscriptionPoll = await service.pollSubscription(subscription.subscriptionId);
     const items = service.listInboxItems(agent.agent.agentId);
-    const spec = (fake as unknown as { streamSpecs: Map<string, ManagedSourceSpec> })
-      .streamSpecs.get("stream:telegram_bot:operator-bot");
 
     assert.equal(sourcePoll.appended, 1);
     assert.equal(subscriptionPoll.inboxItemsCreated, 1);
@@ -635,14 +659,9 @@ test("telegram_bot builtin module ingests getUpdates messages", async () => {
       threadRef: "7",
       replyMode: "reply",
     });
-    assert.equal(spec?.endpoint, "https://api.telegram.org");
-    assert.equal(spec?.operation_id, "getUpdates");
-    assert.equal(spec?.transport_hint, "telegram_get_updates");
-    assert.deepEqual(spec?.args, {
-      tokenEnv: "TELEGRAM_BOT_TOKEN",
-      chatIds: ["456"],
-      allowedUpdates: ["message"],
-    });
+    assert.equal(fake.ensuredSources.length, 0);
+    assert.match(telegram.calls[0]?.url ?? "", /^https:\/\/telegram\.test\/botTOKEN\/getUpdates\?/);
+    assert.equal(new URL(telegram.calls[0]!.url).searchParams.get("allowed_updates"), '["message"]');
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
## Summary
- poll Telegram Bot API updates directly instead of relying on generic REST probing
- dispatch webhook activations immediately for new items during an active notify lease
- keep terminal activation lease suppression behavior intact

## Verification
- npm run build
- npm test -- 322 passed / 0 failed