### PR TITLE
Refactor Telegram source to use uxc polling

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -76,7 +76,7 @@ export class AdapterRegistry {
   private readonly defaultDelivery = new NoopDeliveryAdapter();
   private readonly feishuDelivery = new FeishuDeliveryAdapter();
   private readonly githubDelivery = new GithubDeliveryAdapter();
-  private readonly telegramDelivery = new TelegramDeliveryAdapter();
+  private readonly telegramDelivery: TelegramDeliveryAdapter;
   private readonly homeDir: string;
   private readonly remoteModuleRegistry: RemoteSourceModuleRegistry;
 
@@ -95,11 +95,11 @@ export class AdapterRegistry {
     this.remoteModuleRegistry = options?.remoteModuleRegistry ?? new RemoteSourceModuleRegistry({
       githubCallClient: options?.githubCallClient,
     });
+    this.telegramDelivery = new TelegramDeliveryAdapter(options?.telegramClient);
     this.remoteSource = new RemoteSourceRuntime(store, appendSourceEvent, {
       homeDir: this.homeDir,
       client: options?.remoteSourceClient,
       moduleRegistry: this.remoteModuleRegistry,
-      telegramClient: options?.telegramClient,
     });
   }
 

--- a/src/sources/remote.ts
+++ b/src/sources/remote.ts
@@ -28,7 +28,6 @@ import {
   RemoteSourceModuleRegistry,
 } from "./remote_modules";
 import {
-  TelegramBotApiClient,
   normalizeTelegramBotUpdate,
   parseTelegramSourceConfig,
 } from "./telegram";
@@ -147,7 +146,6 @@ export class RemoteSourceRuntime {
   private readonly errorCounts = new Map<string, number>();
   private readonly nextRetryAt = new Map<string, number>();
   private readonly homeDir: string;
-  private readonly telegramClient: TelegramBotApiClient;
 
   constructor(
     private readonly store: AgentInboxStore,
@@ -156,13 +154,11 @@ export class RemoteSourceRuntime {
       moduleRegistry?: RemoteSourceModuleRegistry;
       client?: UxcRemoteSourceClient;
       homeDir?: string;
-      telegramClient?: TelegramBotApiClient;
     },
   ) {
     this.moduleRegistry = options?.moduleRegistry ?? new RemoteSourceModuleRegistry();
     this.client = options?.client ?? new RpcUxcRemoteSourceClient();
     this.homeDir = options?.homeDir ?? resolveAgentInboxHome(process.env);
-    this.telegramClient = options?.telegramClient ?? new TelegramBotApiClient();
   }
 
   async ensureSource(source: SourceStream): Promise<void> {
@@ -507,10 +503,6 @@ export class RemoteSourceRuntime {
           };
         }
       }
-      if (source.sourceType === "telegram_bot") {
-        return await this.syncTelegramSource(source);
-      }
-
       const module = await this.moduleRegistry.resolve(source, this.homeDir);
       const moduleSource = moduleInputSource(source);
       module.validateConfig(moduleSource);
@@ -616,73 +608,6 @@ export class RemoteSourceRuntime {
     }
   }
 
-  private async syncTelegramSource(source: SourceStream): Promise<SourcePollResult> {
-    const config = parseTelegramSourceConfig(source);
-    const botToken = config.botToken ?? tokenFromEnv(config.tokenEnv);
-    if (!botToken) {
-      throw new Error("Telegram source requires config.botToken or tokenEnv");
-    }
-    const checkpoint = parseRemoteCheckpoint(source.checkpoint);
-    const updates = await this.telegramClient.getUpdates({
-      endpoint: config.endpoint,
-      botToken,
-      offset: checkpoint.telegramCursor?.nextOffset,
-      timeout: 0,
-      allowedUpdates: config.allowedUpdates,
-    });
-
-    let appended = 0;
-    let deduped = 0;
-    let nextOffset = checkpoint.telegramCursor?.nextOffset ?? 0;
-    for (const update of updates) {
-      const normalized = normalizeTelegramBotUpdate(source, config, update);
-      const updateId = numberFromUnknown(update.update_id);
-      if (updateId !== undefined) {
-        nextOffset = Math.max(nextOffset, updateId + 1);
-      }
-      if (!normalized) {
-        continue;
-      }
-      const result = await this.appendSourceEvent(normalized);
-      appended += result.appended;
-      deduped += result.deduped;
-    }
-
-    const latestSource = this.store.getSource(source.sourceId);
-    if (!latestSource) {
-      throw new Error(`unknown source: ${source.sourceId}`);
-    }
-    const observedAt = nowIso();
-    this.store.updateSourceRuntime(source.sourceId, {
-      status: latestSource.status === "paused" ? "paused" : "active",
-      checkpoint: JSON.stringify({
-        ...checkpoint,
-        telegramCursor: { nextOffset },
-        managedRuntime: {
-          status: "running",
-          runId: null,
-          streamId: null,
-          lastError: null,
-          updatedAt: observedAt,
-          startedAt: checkpoint.managedRuntime?.startedAt ?? observedAt,
-          stoppedAt: null,
-        },
-        lastEventAt: observedAt,
-        lastError: null,
-      } satisfies RemoteSourceCheckpoint),
-    });
-    this.errorCounts.delete(source.sourceId);
-    this.nextRetryAt.delete(source.sourceId);
-
-    return {
-      sourceId: source.sourceId,
-      sourceType: source.sourceType,
-      appended,
-      deduped,
-      eventsRead: updates.length,
-      note: "telegram getUpdates poll completed",
-    };
-  }
 }
 
 function normalizeExpandedSubscriptionPlan(
@@ -746,27 +671,6 @@ function managedBindingForSource(source: SourceStream): { namespace: string; sou
 
 function managedSourceBindingKey(namespace: string, sourceKey: string): string {
   return `${namespace}:${sourceKey}`;
-}
-
-function tokenFromEnv(name: string | undefined): string | null {
-  if (!name) {
-    return null;
-  }
-  const value = process.env[name];
-  return typeof value === "string" && value.length > 0 ? value : null;
-}
-
-function numberFromUnknown(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  if (typeof value === "string" && value.trim().length > 0) {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) {
-      return parsed;
-    }
-  }
-  return undefined;
 }
 
 function parseRemoteCheckpoint(checkpoint: string | null | undefined): RemoteSourceCheckpoint {

--- a/src/sources/remote_modules.ts
+++ b/src/sources/remote_modules.ts
@@ -770,6 +770,7 @@ const TELEGRAM_BOT_MODULE: RemoteSourceModule = {
       configSchema: [
         { name: "botToken", type: "string", required: false, description: "Telegram bot token. Prefer tokenEnv for shared/local configuration." },
         { name: "tokenEnv", type: "string", required: false, description: "Environment variable name containing the Telegram bot token." },
+        { name: "uxcAuth", type: "string", required: false, description: "Optional UXC Telegram auth profile." },
         { name: "botUsername", type: "string", required: false, description: "Optional bot username used for source host identity." },
         { name: "chatIds", type: "string[]", required: false, description: "Optional Telegram chat ID allowlist." },
         { name: "allowedUpdates", type: "string[]", required: false, description: "Optional Telegram Bot API allowed_updates value." },
@@ -796,13 +797,10 @@ const TELEGRAM_BOT_MODULE: RemoteSourceModule = {
     const config = parseTelegramSourceConfig(source);
     return {
       endpoint: config.endpoint ?? TELEGRAM_BOT_API_ENDPOINT,
-      operation_id: "getUpdates",
+      operation_id: "post:/getUpdates",
       mode: "poll",
       args: {
         timeout: 5,
-        ...(config.botToken ? { botToken: config.botToken } : {}),
-        ...(config.tokenEnv ? { tokenEnv: config.tokenEnv } : {}),
-        ...(config.chatIds && config.chatIds.length > 0 ? { chatIds: config.chatIds } : {}),
         ...(config.allowedUpdates && config.allowedUpdates.length > 0 ? { allowed_updates: config.allowedUpdates } : {}),
       },
       poll_config: {
@@ -815,6 +813,10 @@ const TELEGRAM_BOT_MODULE: RemoteSourceModule = {
           type: "item_key",
           item_key_pointer: "/update_id",
         },
+      },
+      options: {
+        auth: config.uxcAuth,
+        artifact_compaction: false,
       },
     };
   },

--- a/src/sources/telegram.ts
+++ b/src/sources/telegram.ts
@@ -11,6 +11,7 @@ export const TELEGRAM_BOT_API_ENDPOINT = "https://api.telegram.org";
 
 export interface TelegramBotSourceConfig {
   endpoint?: string;
+  uxcAuth?: string;
   botToken?: string;
   tokenEnv?: string;
   botUsername?: string;
@@ -254,6 +255,7 @@ export function parseTelegramSourceConfig(source: SourceStream): TelegramBotSour
   const config = source.config ?? {};
   return {
     endpoint: asString(config.endpoint) ?? asString(config.apiBaseUrl) ?? TELEGRAM_BOT_API_ENDPOINT,
+    uxcAuth: asString(config.uxcAuth) ?? asString(config.credentialRef) ?? undefined,
     botToken: asString(config.botToken) ?? undefined,
     tokenEnv: asString(config.tokenEnv) ?? undefined,
     botUsername: asString(config.botUsername) ?? undefined,

--- a/test/remote_source.test.ts
+++ b/test/remote_source.test.ts
@@ -12,7 +12,6 @@ import { ManagedSourceSpec, RemoteSourceModuleRegistry, builtInModuleIdForSource
 import { AgentInboxStore } from "../src/store";
 import { TerminalDispatcher } from "../src/terminal";
 import { nowIso } from "../src/util";
-import { TelegramBotApiClient } from "../src/sources/telegram";
 
 class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   private readonly streams = new Map<string, Array<{ offset: number; raw_payload: unknown }>>();
@@ -193,30 +192,7 @@ class FakeRemoteSourceClient implements UxcRemoteSourceClient {
   }
 }
 
-class FakeTelegramFetchClient {
-  public readonly calls: Array<{ url: string; init?: RequestInit }> = [];
-  private updates: Record<string, unknown>[] = [];
-
-  push(update: Record<string, unknown>): void {
-    this.updates.push(update);
-  }
-
-  async fetch(url: string, init?: RequestInit): Promise<{ ok: boolean; status: number; text(): Promise<string> }> {
-    this.calls.push({ url, init });
-    const parsed = new URL(url);
-    const offset = Number(parsed.searchParams.get("offset") ?? "0");
-    const result = this.updates.filter((update) => Number(update.update_id) >= offset);
-    return {
-      ok: true,
-      status: 200,
-      async text() {
-        return JSON.stringify({ ok: true, result });
-      },
-    };
-  }
-}
-
-async function makeService(fake: FakeRemoteSourceClient, options?: { telegramFetchClient?: FakeTelegramFetchClient }): Promise<{
+async function makeService(fake: FakeRemoteSourceClient): Promise<{
   dir: string;
   store: AgentInboxStore;
   service: AgentInboxService;
@@ -228,7 +204,6 @@ async function makeService(fake: FakeRemoteSourceClient, options?: { telegramFet
   const adapters = new AdapterRegistry(store, async (input: AppendSourceEventInput) => service.appendSourceEvent(input), {
     homeDir: dir,
     remoteSourceClient: fake,
-    telegramClient: options?.telegramFetchClient ? new TelegramBotApiClient(options.telegramFetchClient) : undefined,
   });
   service = new AgentInboxService(store, adapters, undefined, undefined, undefined, new TerminalDispatcher(async () => ({
     stdout: "",
@@ -609,13 +584,12 @@ test("github_repo_ci builtin module emits status transitions for one workflow ru
 
 test("telegram_bot builtin module ingests getUpdates messages", async () => {
   const fake = new FakeRemoteSourceClient();
-  const telegram = new FakeTelegramFetchClient();
-  const { dir, store, service } = await makeService(fake, { telegramFetchClient: telegram });
+  const { dir, store, service } = await makeService(fake);
   try {
     const source = await service.registerSource({
       sourceType: "telegram_bot",
       sourceKey: "operator-bot",
-      config: { botToken: "TOKEN", chatIds: ["456"], allowedUpdates: ["message"], endpoint: "https://telegram.test" },
+      config: { uxcAuth: "telegram-local", chatIds: ["456"], allowedUpdates: ["message"], endpoint: "https://telegram.test" },
     });
     const agent = service.registerAgent({
       backend: "tmux",
@@ -630,7 +604,7 @@ test("telegram_bot builtin module ingests getUpdates messages", async () => {
       startPolicy: "earliest",
     });
 
-    telegram.push({
+    fake.push("stream:telegram_bot:operator-bot", {
       update_id: 123,
       message: {
         message_id: 7,
@@ -659,9 +633,15 @@ test("telegram_bot builtin module ingests getUpdates messages", async () => {
       threadRef: "7",
       replyMode: "reply",
     });
-    assert.equal(fake.ensuredSources.length, 0);
-    assert.match(telegram.calls[0]?.url ?? "", /^https:\/\/telegram\.test\/botTOKEN\/getUpdates\?/);
-    assert.equal(new URL(telegram.calls[0]!.url).searchParams.get("allowed_updates"), '["message"]');
+    assert.ok(fake.ensuredSources.length >= 1);
+    assert.deepEqual(fake.ensuredSources.at(-1), { namespace: "agentinbox", sourceKey: "telegram_bot:operator-bot" });
+    const spec = (fake as unknown as { streamSpecs: Map<string, ManagedSourceSpec> }).streamSpecs.get("stream:telegram_bot:operator-bot");
+    assert.equal(spec?.endpoint, "https://telegram.test");
+    assert.equal(spec?.operation_id, "post:/getUpdates");
+    assert.equal(spec?.mode, "poll");
+    assert.deepEqual(spec?.args, { timeout: 5, allowed_updates: ["message"] });
+    assert.deepEqual(spec?.options, { auth: "telegram-local", artifact_compaction: false });
+    assert.equal(spec?.poll_config?.request_cursor_arg, "offset");
   } finally {
     await service.stop();
     store.close();


### PR DESCRIPTION
## Summary
- route telegram_bot polling through the remote managed source/uxc subscription path
- add optional uxcAuth/credentialRef config projection for Telegram managed sources
- keep Telegram delivery handled by the existing Telegram Bot API adapter

Closes #212

## Verification
- npm test
- npm run build