### PR TITLE
feat: add operator ingress reply routes

### DIFF
--- a/docs/site/rfcs/README.md
+++ b/docs/site/rfcs/README.md
@@ -5,8 +5,13 @@
 - [Subscription Lifecycle And Terminal Auto-Retire](./subscription-lifecycle-and-terminal-retire.md)
 - [Inbox Digests And Threaded Notification Entries](./inbox-digests-and-threaded-notification-entries.md)
 - [Public And Internal Identifier Strategy](./public-and-internal-identifier-strategy.md)
+- [Operator Ingress And Reply Routes](./operator-ingress-and-reply-routes.md)
 
 <!-- INDEX:START -->
+
+- [Operator Ingress And Reply Routes](./operator-ingress-and-reply-routes.md)
+  2026-06-22 · Define how AgentInbox bridges provider messages into Holon operator ingress and routes Holon replies back through provider delivery, starting with Feishu.
+  <!-- mdorigin:index kind=article -->
 
 - [IM Agent Interaction Model](./im-agent-interaction-model.md)
   2026-05-18 · Define how AgentInbox should model IM reminders, on-demand context fetching, and feedback operations, with Feishu/Lark as the first implementation case.

--- a/docs/site/rfcs/operator-ingress-and-reply-routes.md
+++ b/docs/site/rfcs/operator-ingress-and-reply-routes.md
@@ -1,0 +1,168 @@
+---
+title: Operator Ingress And Reply Routes
+date: 2026-06-22
+type: page
+summary: Define how AgentInbox bridges provider messages into Holon operator ingress and routes Holon replies back through provider delivery, starting with Feishu.
+---
+
+# Operator Ingress And Reply Routes
+
+## Summary
+
+`AgentInbox` should be the transport/control-plane bridge between external
+operator channels and Holon agents.
+
+For the first implementation, AgentInbox uses the current Holon contract:
+
+- register an operator transport binding on a Holon agent
+- forward inbound operator text to Holon `operator-ingress`
+- pass a `reply_route_id` per inbound message
+- receive Holon output on an AgentInbox delivery route callback
+- send the reply through the provider delivery adapter
+
+Feishu is the first provider integration because AgentInbox already has
+Feishu source and delivery support.
+
+## Problem
+
+External IM systems can deliver human operator messages to an agent, but the
+agent runtime may not reply synchronously. A single incoming Feishu message can
+start a long agent turn, tool calls, waits, or later completion briefs.
+
+Therefore AgentInbox should not model this as one provider webhook request that
+expects an immediate response.
+
+It also should not embed Holon runtime semantics into its core data model.
+AgentInbox owns provider identity, routing, persistence, and outbound delivery;
+Holon owns agent execution.
+
+## Current Holon Contract
+
+Holon currently exposes two relevant control endpoints:
+
+- `POST /control/agents/{agent_id}/operator-bindings`
+  - registers a binding with transport, operator actor, callback URL, auth, and
+    provider metadata
+- `POST /control/agents/{agent_id}/operator-ingress`
+  - injects an operator prompt with `text`, `actor_id`, `binding_id`,
+    `reply_route_id`, provider refs, correlation fields, and metadata
+
+The reply callback capability is binding-level. Each ingress can select a
+specific route using `reply_route_id`.
+
+This RFC intentionally does not require a richer ingress-level `reply_target`
+object yet.
+
+## Goals
+
+- route Feishu operator messages into Holon without provider details leaking to
+  Holon runtime state
+- let Holon replies return through AgentInbox delivery routes
+- keep AgentInbox within the product boundary:
+  `SourceStream → Interest → InboxItem → Activation → DeliveryHandle`
+- preserve provider-neutral core records while allowing provider adapters to
+  execute concrete delivery operations
+- support asynchronous replies rather than synchronous request/response chat
+
+## Non-Goals
+
+- do not implement agent runtime, task scheduling, or prompt orchestration in
+  AgentInbox
+- do not require Holon to know Feishu chat IDs or Feishu API details
+- do not build a general SaaS automation/workflow platform
+- do not require every provider to support operator ingress immediately
+- do not replace existing source subscriptions or delivery handles
+
+## Data Model
+
+### OperatorTransportBinding
+
+An `OperatorTransportBinding` connects one AgentInbox-managed transport to one
+Holon agent.
+
+It stores:
+
+- `bindingId`
+- `agentId`
+- `transport` such as `feishu`
+- `operatorActorId`
+- Holon base URL and optional Holon auth
+- optional AgentInbox delivery callback URL and delivery auth
+- optional default route id
+- capabilities such as `prompt`
+- provider and metadata
+
+When requested, AgentInbox syncs the binding to Holon through
+`operator-bindings`.
+
+### OperatorReplyRoute
+
+An `OperatorReplyRoute` maps a Holon `reply_route_id` back to an AgentInbox
+`DeliveryHandle`.
+
+It stores:
+
+- `routeId`
+- `bindingId`
+- `agentId`
+- `deliveryHandle`
+- optional source id and metadata
+
+Holon only needs to preserve the route id. AgentInbox uses that id to recover
+the provider target and call the correct delivery adapter.
+
+## Request Flow
+
+### 1. Register binding
+
+An operator or integration creates a binding for an agent:
+
+```text
+AgentInbox -> Holon /control/agents/{agent_id}/operator-bindings
+```
+
+AgentInbox includes the callback URL template that Holon can call when output
+is ready.
+
+### 2. Forward inbound Feishu message
+
+When a Feishu message should act as an operator prompt, AgentInbox:
+
+1. normalizes the operator actor id
+2. creates or updates an `OperatorReplyRoute`
+3. forwards the text to Holon `operator-ingress`
+4. includes `reply_route_id`, `provider_message_ref`, and metadata
+
+Holon accepts the prompt asynchronously and later emits output.
+
+### 3. Deliver Holon reply
+
+Holon calls AgentInbox:
+
+```text
+POST /delivery-routes/{route_id}/messages
+```
+
+AgentInbox resolves the route to a `DeliveryHandle` and sends the text through
+the provider delivery adapter. For Feishu, this currently maps to the canonical
+chat message or message reply delivery operation.
+
+## Feishu First Implementation
+
+The first implementation targets Feishu because AgentInbox already supports:
+
+- `feishu_bot` source streams
+- Feishu `DeliveryHandle` surfaces
+- canonical Feishu text send/reply delivery
+
+The operator route layer should only store provider routing data in the
+`DeliveryHandle`; it should not introduce Feishu-specific core tables.
+
+## Open Questions
+
+- Whether Holon should later accept an ingress-level `reply_target` object for
+  per-message callback capabilities.
+- How callback authentication should be rotated when AgentInbox is deployed as
+  a long-running local service.
+- Whether route lifecycle cleanup should be tied to source item retention,
+  conversation TTL, or explicit operator binding removal.

--- a/drizzle/migrations/0005_operator_transport_bindings.sql
+++ b/drizzle/migrations/0005_operator_transport_bindings.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `operator_transport_bindings` (
+  `binding_id` text PRIMARY KEY NOT NULL,
+  `agent_id` text NOT NULL,
+  `transport` text NOT NULL,
+  `operator_actor_id` text NOT NULL,
+  `holon_base_url` text NOT NULL,
+  `delivery_callback_url` text,
+  `delivery_auth_json` text,
+  `holon_auth_json` text,
+  `default_route_id` text,
+  `capabilities_json` text NOT NULL,
+  `provider` text,
+  `metadata_json` text NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+CREATE INDEX `idx_operator_bindings_agent_transport` ON `operator_transport_bindings` (`agent_id`,`transport`);
+
+CREATE TABLE `operator_reply_routes` (
+  `route_id` text PRIMARY KEY NOT NULL,
+  `binding_id` text NOT NULL,
+  `agent_id` text NOT NULL,
+  `source_id` text,
+  `delivery_handle_json` text NOT NULL,
+  `metadata_json` text NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+CREATE INDEX `idx_operator_reply_routes_binding` ON `operator_reply_routes` (`binding_id`);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -282,6 +282,38 @@ export const deliveries = sqliteTable("deliveries", {
   createdAt: text("created_at").notNull(),
 });
 
+export const operatorTransportBindings = sqliteTable("operator_transport_bindings", {
+  bindingId: text("binding_id").primaryKey(),
+  agentId: text("agent_id").notNull(),
+  transport: text("transport").notNull(),
+  operatorActorId: text("operator_actor_id").notNull(),
+  holonBaseUrl: text("holon_base_url").notNull(),
+  deliveryCallbackUrl: text("delivery_callback_url"),
+  deliveryAuthJson: text("delivery_auth_json"),
+  holonAuthJson: text("holon_auth_json"),
+  defaultRouteId: text("default_route_id"),
+  capabilitiesJson: text("capabilities_json").notNull(),
+  provider: text("provider"),
+  metadataJson: text("metadata_json").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+}, (table) => ({
+  agentTransportIdx: index("idx_operator_bindings_agent_transport").on(table.agentId, table.transport),
+}));
+
+export const operatorReplyRoutes = sqliteTable("operator_reply_routes", {
+  routeId: text("route_id").primaryKey(),
+  bindingId: text("binding_id").notNull(),
+  agentId: text("agent_id").notNull(),
+  sourceId: text("source_id"),
+  deliveryHandleJson: text("delivery_handle_json").notNull(),
+  metadataJson: text("metadata_json").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+}, (table) => ({
+  bindingIdx: index("idx_operator_reply_routes_binding").on(table.bindingId),
+}));
+
 export const streams = sqliteTable("streams", {
   streamId: text("stream_id").primaryKey(),
   sourceId: text("source_id").notNull(),

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -17,7 +17,7 @@ import {
 } from "./model";
 import { AgentInboxStore } from "./store";
 import { resolveAgentInboxHome } from "./paths";
-import { FeishuDeliveryAdapter } from "./sources/feishu";
+import { FeishuDeliveryAdapter, FeishuUxcClient } from "./sources/feishu";
 import { GithubCallClient, GithubDeliveryAdapter } from "./sources/github";
 import { TelegramBotApiClient, TelegramDeliveryAdapter } from "./sources/telegram";
 import { RemoteSourceRuntime, UxcRemoteSourceClient } from "./sources/remote";
@@ -74,7 +74,7 @@ export class AdapterRegistry {
   private readonly localEventSource = new NoopSourceAdapter("local_event");
   private readonly remoteSource: RemoteSourceRuntime;
   private readonly defaultDelivery = new NoopDeliveryAdapter();
-  private readonly feishuDelivery = new FeishuDeliveryAdapter();
+  private readonly feishuDelivery: FeishuDeliveryAdapter;
   private readonly githubDelivery = new GithubDeliveryAdapter();
   private readonly telegramDelivery: TelegramDeliveryAdapter;
   private readonly homeDir: string;
@@ -88,6 +88,7 @@ export class AdapterRegistry {
       remoteSourceClient?: UxcRemoteSourceClient;
       remoteModuleRegistry?: RemoteSourceModuleRegistry;
       githubCallClient?: GithubCallClient;
+      feishuClient?: FeishuUxcClient;
       telegramClient?: TelegramBotApiClient;
     },
   ) {
@@ -95,6 +96,7 @@ export class AdapterRegistry {
     this.remoteModuleRegistry = options?.remoteModuleRegistry ?? new RemoteSourceModuleRegistry({
       githubCallClient: options?.githubCallClient,
     });
+    this.feishuDelivery = new FeishuDeliveryAdapter(options?.feishuClient);
     this.telegramDelivery = new TelegramDeliveryAdapter(options?.telegramClient);
     this.remoteSource = new RemoteSourceRuntime(store, appendSourceEvent, {
       homeDir: this.homeDir,

--- a/src/http.ts
+++ b/src/http.ts
@@ -3,7 +3,16 @@ import Fastify from "fastify";
 import swagger from "@fastify/swagger";
 import { summarizeActivationTarget } from "./current_agent";
 import { AgentInboxService } from "./service";
-import { ActivationMode, DeliveryHandle, FollowInput, PreviewSourceSchemaInput, SourceInvokeRequest, WatchInboxOptions } from "./model";
+import {
+  ActivationMode,
+  AuthDescriptor,
+  DeliveryHandle,
+  FollowInput,
+  OperatorIngressInput,
+  PreviewSourceSchemaInput,
+  SourceInvokeRequest,
+  WatchInboxOptions,
+} from "./model";
 import { jsonResponse } from "./util";
 
 function sendSse(res: http.ServerResponse, event: string, data: unknown): void {
@@ -77,6 +86,18 @@ const deliveryTargetByFieldsSchema = {
     targetRef: { type: "string", minLength: 1 },
     threadRef: { type: "string" },
     replyMode: { type: "string" },
+  },
+} as const;
+
+const authDescriptorSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["type"],
+  properties: {
+    type: { type: "string", enum: ["bearer", "header"] },
+    token: { type: "string" },
+    headerName: { type: "string" },
+    headerValue: { type: "string" },
   },
 } as const;
 
@@ -1054,6 +1075,137 @@ function buildFastifyServer(service: AgentInboxService) {
     return service.resumeAgent(decodeURIComponent(params.agentId));
   });
 
+  app.get("/agents/:agentId/operator-bindings", {
+    schema: {
+      tags: ["operators"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      response: {
+        200: {
+          type: "object",
+          required: ["bindings"],
+          properties: {
+            bindings: { type: "array", items: jsonObjectSchema },
+          },
+        },
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    return { bindings: service.listOperatorTransportBindings(decodeURIComponent(params.agentId)) };
+  });
+
+  app.post("/agents/:agentId/operator-bindings", {
+    schema: {
+      tags: ["operators"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["transport", "operatorActorId", "holonBaseUrl"],
+        properties: {
+          bindingId: { type: "string" },
+          transport: { type: "string", minLength: 1 },
+          operatorActorId: { type: "string", minLength: 1 },
+          holonBaseUrl: { type: "string", minLength: 1 },
+          deliveryCallbackUrl: { type: "string" },
+          deliveryAuth: authDescriptorSchema,
+          holonAuth: authDescriptorSchema,
+          defaultRouteId: { type: "string" },
+          capabilities: { type: "array", items: { type: "string" } },
+          provider: { type: "string" },
+          metadata: jsonObjectSchema,
+          syncWithHolon: { type: "boolean" },
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    const body = request.body as Record<string, unknown>;
+    return service.registerOperatorTransportBinding(decodeURIComponent(params.agentId), {
+      bindingId: optionalString(body.bindingId) ?? null,
+      transport: String(body.transport),
+      operatorActorId: String(body.operatorActorId),
+      holonBaseUrl: String(body.holonBaseUrl),
+      deliveryCallbackUrl: optionalString(body.deliveryCallbackUrl) ?? null,
+      deliveryAuth: body.deliveryAuth ? body.deliveryAuth as AuthDescriptor : null,
+      holonAuth: body.holonAuth ? body.holonAuth as AuthDescriptor : null,
+      defaultRouteId: optionalString(body.defaultRouteId) ?? null,
+      capabilities: Array.isArray(body.capabilities) ? body.capabilities.map(String) : undefined,
+      provider: optionalString(body.provider) ?? null,
+      metadata: body.metadata && typeof body.metadata === "object" ? body.metadata as Record<string, unknown> : undefined,
+      syncWithHolon: typeof body.syncWithHolon === "boolean" ? body.syncWithHolon : undefined,
+    });
+  });
+
+  app.post("/agents/:agentId/operator-ingress", {
+    schema: {
+      tags: ["operators"],
+      params: {
+        type: "object",
+        required: ["agentId"],
+        properties: {
+          agentId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["text", "bindingId"],
+        properties: {
+          text: { type: "string", minLength: 1 },
+          bindingId: { type: "string", minLength: 1 },
+          actorId: { type: "string" },
+          replyRouteId: { type: "string" },
+          provider: { type: "string" },
+          upstreamProvider: { type: "string" },
+          providerMessageRef: { type: "string" },
+          correlationId: { type: "string" },
+          causationId: { type: "string" },
+          metadata: jsonObjectSchema,
+          sourceItemId: { type: "string" },
+          deliveryHandle: deliveryHandleSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { agentId: string };
+    const body = request.body as Record<string, unknown>;
+    return service.forwardOperatorIngress(decodeURIComponent(params.agentId), {
+      text: String(body.text),
+      bindingId: String(body.bindingId),
+      actorId: optionalString(body.actorId) ?? null,
+      replyRouteId: optionalString(body.replyRouteId) ?? null,
+      provider: optionalString(body.provider) ?? null,
+      upstreamProvider: optionalString(body.upstreamProvider) ?? null,
+      providerMessageRef: optionalString(body.providerMessageRef) ?? null,
+      correlationId: optionalString(body.correlationId) ?? null,
+      causationId: optionalString(body.causationId) ?? null,
+      metadata: body.metadata && typeof body.metadata === "object" ? body.metadata as Record<string, unknown> : undefined,
+      sourceItemId: optionalString(body.sourceItemId) ?? null,
+      deliveryHandle: body.deliveryHandle ? body.deliveryHandle as DeliveryHandle : null,
+    } satisfies OperatorIngressInput);
+  });
+
   app.get("/agents/:agentId/targets", {
     schema: {
       tags: ["agents"],
@@ -1933,6 +2085,44 @@ function buildFastifyServer(service: AgentInboxService) {
     },
   }, async (request) => service.invokeDelivery(request.body as never));
 
+  app.post("/delivery-routes/:routeId/messages", {
+    schema: {
+      tags: ["deliveries"],
+      params: {
+        type: "object",
+        required: ["routeId"],
+        properties: {
+          routeId: { type: "string", minLength: 1 },
+        },
+      },
+      body: {
+        type: "object",
+        additionalProperties: false,
+        required: ["text"],
+        properties: {
+          text: { type: "string", minLength: 1 },
+          kind: { type: "string" },
+          targetAgentId: { type: "string" },
+          metadata: jsonObjectSchema,
+        },
+      },
+      response: {
+        200: jsonObjectSchema,
+        400: errorResponseSchema,
+        404: errorResponseSchema,
+      },
+    },
+  }, async (request) => {
+    const params = request.params as { routeId: string };
+    const body = request.body as Record<string, unknown>;
+    return service.deliverOperatorReply(decodeURIComponent(params.routeId), {
+      text: String(body.text),
+      kind: optionalString(body.kind) ?? null,
+      targetAgentId: optionalString(body.targetAgentId) ?? null,
+      metadata: body.metadata && typeof body.metadata === "object" ? body.metadata as Record<string, unknown> : undefined,
+    });
+  });
+
   app.setNotFoundHandler((_request, reply) => {
     void reply.code(404).send({ error: "not found" });
   });
@@ -2040,6 +2230,9 @@ function isBadRequestError(message: string): boolean {
     message.startsWith("deliver send is not supported") ||
     message.startsWith("deliveryHandle requires") ||
     message.startsWith("delivery operations are not supported") ||
+    message.startsWith("operator binding requires") ||
+    message.startsWith("operator ingress requires") ||
+    message.startsWith("operator reply route requires") ||
     message.startsWith("unsupported delivery surface") ||
     message.startsWith("unsupported delivery operation") ||
     message.startsWith("source operations are not supported") ||

--- a/src/model.ts
+++ b/src/model.ts
@@ -19,6 +19,85 @@ export interface DeliveryHandle {
   replyMode?: string | null;
 }
 
+export interface RegisterOperatorBindingInput {
+  bindingId?: string | null;
+  transport: string;
+  operatorActorId: string;
+  holonBaseUrl: string;
+  deliveryCallbackUrl?: string | null;
+  deliveryAuth?: AuthDescriptor | null;
+  holonAuth?: AuthDescriptor | null;
+  defaultRouteId?: string | null;
+  capabilities?: string[];
+  provider?: string | null;
+  metadata?: Record<string, unknown>;
+  syncWithHolon?: boolean;
+}
+
+export interface OperatorIngressInput {
+  text: string;
+  bindingId: string;
+  actorId?: string | null;
+  replyRouteId?: string | null;
+  provider?: string | null;
+  upstreamProvider?: string | null;
+  providerMessageRef?: string | null;
+  correlationId?: string | null;
+  causationId?: string | null;
+  metadata?: Record<string, unknown>;
+  sourceItemId?: string | null;
+  deliveryHandle?: DeliveryHandle | null;
+}
+
+export interface OperatorIngressResult {
+  accepted: boolean;
+  bindingId: string;
+  replyRouteId: string | null;
+  holon: unknown;
+}
+
+export interface OperatorReplyRoute {
+  routeId: string;
+  bindingId: string;
+  agentId: string;
+  deliveryHandle: DeliveryHandle;
+  sourceId?: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OperatorReplyMessageInput {
+  text: string;
+  kind?: string | null;
+  targetAgentId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuthDescriptor {
+  type: "bearer" | "header";
+  token?: string | null;
+  headerName?: string | null;
+  headerValue?: string | null;
+}
+
+export interface OperatorTransportBinding {
+  bindingId: string;
+  agentId: string;
+  transport: string;
+  operatorActorId: string;
+  holonBaseUrl: string;
+  deliveryCallbackUrl?: string | null;
+  deliveryAuth?: AuthDescriptor | null;
+  holonAuth?: AuthDescriptor | null;
+  defaultRouteId?: string | null;
+  capabilities: string[];
+  provider?: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface SourceHost {
   hostId: string;
   hostType: HostType;

--- a/src/service.ts
+++ b/src/service.ts
@@ -26,8 +26,12 @@ import {
   InboxWatchEvent,
   NotificationGrouping,
   NotificationPolicy,
+  OperatorIngressInput,
+  OperatorIngressResult,
+  OperatorReplyMessageInput,
   PreviewSourceSchemaInput,
   RegisterAgentInput,
+  RegisterOperatorBindingInput,
   RegisterAgentResult,
   RegisterHostInput,
   RegisterSourceInput,
@@ -50,6 +54,7 @@ import {
   SubscriptionLifecycleRetirement,
   SubscriptionPollResult,
   TerminalActivationTarget,
+  OperatorTransportBinding,
   UpdateTimerStatusResult,
   UpdateSourceInput,
   WatchInboxOptions,
@@ -2025,6 +2030,155 @@ export class AgentInboxService {
     return { ...storedAttempt, note: result.note, operation: request.operation };
   }
 
+  async registerOperatorTransportBinding(
+    agentId: string,
+    input: RegisterOperatorBindingInput,
+  ): Promise<OperatorTransportBinding & { holon?: unknown }> {
+    if (!input.transport) {
+      throw new Error("operator binding requires transport");
+    }
+    if (!input.operatorActorId) {
+      throw new Error("operator binding requires operatorActorId");
+    }
+    if (!input.holonBaseUrl) {
+      throw new Error("operator binding requires holonBaseUrl");
+    }
+    const now = nowIso();
+    const current = input.bindingId ? this.store.getOperatorTransportBinding(input.bindingId) : null;
+    const binding: OperatorTransportBinding = {
+      bindingId: input.bindingId ?? generateCanonicalId("opb"),
+      agentId,
+      transport: input.transport,
+      operatorActorId: input.operatorActorId,
+      holonBaseUrl: input.holonBaseUrl.replace(/\/+$/, ""),
+      deliveryCallbackUrl: input.deliveryCallbackUrl ?? null,
+      deliveryAuth: input.deliveryAuth ?? null,
+      holonAuth: input.holonAuth ?? null,
+      defaultRouteId: input.defaultRouteId ?? null,
+      capabilities: input.capabilities ?? ["prompt"],
+      provider: input.provider ?? null,
+      metadata: input.metadata ?? {},
+      createdAt: current?.createdAt ?? now,
+      updatedAt: now,
+    };
+    const stored = this.store.upsertOperatorTransportBinding(binding);
+    const holon = input.syncWithHolon === false ? undefined : await this.syncOperatorBindingToHolon(stored);
+    return holon === undefined ? stored : { ...stored, holon };
+  }
+
+  listOperatorTransportBindings(agentId: string): OperatorTransportBinding[] {
+    return this.store.listOperatorTransportBindings(agentId);
+  }
+
+  async forwardOperatorIngress(agentId: string, input: OperatorIngressInput): Promise<OperatorIngressResult> {
+    if (!input.text) {
+      throw new Error("operator ingress requires text");
+    }
+    const binding = this.store.getOperatorTransportBinding(input.bindingId);
+    if (!binding || binding.agentId !== agentId) {
+      throw new Error(`unknown operator binding for agent ${agentId}: ${input.bindingId}`);
+    }
+    const replyRouteId = input.replyRouteId ?? binding.defaultRouteId ?? null;
+    if (replyRouteId && input.deliveryHandle) {
+      const now = nowIso();
+      this.store.upsertOperatorReplyRoute({
+        routeId: replyRouteId,
+        bindingId: binding.bindingId,
+        agentId,
+        deliveryHandle: input.deliveryHandle,
+        sourceId: typeof input.metadata?.sourceId === "string" ? input.metadata.sourceId : null,
+        metadata: input.metadata ?? {},
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    const holon = await this.postHolonJson(
+      binding,
+      `/control/agents/${encodeURIComponent(agentId)}/operator-ingress`,
+      {
+        text: input.text,
+        actor_id: input.actorId ?? binding.operatorActorId,
+        binding_id: binding.bindingId,
+        reply_route_id: replyRouteId,
+        provider: input.provider ?? binding.provider ?? binding.transport,
+        upstream_provider: input.upstreamProvider ?? binding.provider ?? binding.transport,
+        provider_message_ref: input.providerMessageRef ?? null,
+        correlation_id: input.correlationId ?? null,
+        causation_id: input.causationId ?? null,
+        metadata: {
+          ...(input.metadata ?? {}),
+          source_item_id: input.sourceItemId ?? undefined,
+        },
+      },
+    );
+    return {
+      accepted: true,
+      bindingId: binding.bindingId,
+      replyRouteId,
+      holon,
+    };
+  }
+
+  async deliverOperatorReply(routeId: string, input: OperatorReplyMessageInput): Promise<DeliveryAttempt & { note: string }> {
+    if (!input.text) {
+      throw new Error("operator reply route requires text");
+    }
+    const route = this.store.getOperatorReplyRoute(routeId);
+    if (!route) {
+      throw new Error(`unknown operator reply route: ${routeId}`);
+    }
+    return this.sendDelivery({
+      sourceId: route.sourceId ?? undefined,
+      deliveryHandle: route.deliveryHandle,
+      kind: input.kind ?? "reply",
+      payload: {
+        text: input.text,
+        targetAgentId: input.targetAgentId ?? route.agentId,
+        routeId,
+        metadata: input.metadata ?? {},
+      },
+    });
+  }
+
+  private async syncOperatorBindingToHolon(binding: OperatorTransportBinding): Promise<unknown> {
+    return this.postHolonJson(
+      binding,
+      `/control/agents/${encodeURIComponent(binding.agentId)}/operator-bindings`,
+      {
+        binding_id: binding.bindingId,
+        transport: binding.transport,
+        operator_actor_id: binding.operatorActorId,
+        default_route_id: binding.defaultRouteId,
+        delivery_callback_url: binding.deliveryCallbackUrl,
+        delivery_auth: binding.deliveryAuth,
+        capabilities: binding.capabilities,
+        provider: binding.provider,
+        metadata: binding.metadata,
+      },
+    );
+  }
+
+  private async postHolonJson(
+    binding: OperatorTransportBinding,
+    path: string,
+    payload: Record<string, unknown>,
+  ): Promise<unknown> {
+    const response = await fetch(`${binding.holonBaseUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...authHeaders(binding.holonAuth),
+      },
+      body: JSON.stringify(payload),
+    });
+    const text = await response.text();
+    const body = text ? parseJsonResponse(text) : {};
+    if (!response.ok) {
+      throw new Error(`Holon operator route call failed: ${response.status} ${text}`);
+    }
+    return body;
+  }
+
   private async sendCanonicalDeliveryViaModule(
     source: SourceStream,
     handle: DeliveryHandle,
@@ -3962,6 +4116,27 @@ function providerForSourceType(sourceType: SourceStream["sourceType"]): string |
     return "telegram";
   }
   return null;
+}
+
+function authHeaders(auth: OperatorTransportBinding["holonAuth"]): Record<string, string> {
+  if (!auth) {
+    return {};
+  }
+  if (auth.type === "bearer" && auth.token) {
+    return { authorization: `Bearer ${auth.token}` };
+  }
+  if (auth.type === "header" && auth.headerName && auth.headerValue) {
+    return { [auth.headerName]: auth.headerValue };
+  }
+  return {};
+}
+
+function parseJsonResponse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { text };
+  }
 }
 
 export class ActivationDispatcher {

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,6 +24,8 @@ import {
   InboxItem,
   ListInboxItemsOptions,
   NotificationGrouping,
+  OperatorReplyRoute,
+  OperatorTransportBinding,
   AgentTimer,
   RegisterAgentInput,
   SourceHost,
@@ -2018,6 +2020,96 @@ export class AgentInboxStore {
     return rows.map((row) => this.mapDelivery(row));
   }
 
+  upsertOperatorTransportBinding(binding: OperatorTransportBinding): OperatorTransportBinding {
+    this.run(
+      `
+      insert into operator_transport_bindings (
+        binding_id, agent_id, transport, operator_actor_id, holon_base_url,
+        delivery_callback_url, delivery_auth_json, holon_auth_json, default_route_id,
+        capabilities_json, provider, metadata_json, created_at, updated_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      on conflict(binding_id) do update set
+        agent_id = excluded.agent_id,
+        transport = excluded.transport,
+        operator_actor_id = excluded.operator_actor_id,
+        holon_base_url = excluded.holon_base_url,
+        delivery_callback_url = excluded.delivery_callback_url,
+        delivery_auth_json = excluded.delivery_auth_json,
+        holon_auth_json = excluded.holon_auth_json,
+        default_route_id = excluded.default_route_id,
+        capabilities_json = excluded.capabilities_json,
+        provider = excluded.provider,
+        metadata_json = excluded.metadata_json,
+        updated_at = excluded.updated_at
+    `,
+      [
+        binding.bindingId,
+        binding.agentId,
+        binding.transport,
+        binding.operatorActorId,
+        binding.holonBaseUrl,
+        binding.deliveryCallbackUrl ?? null,
+        binding.deliveryAuth ? JSON.stringify(binding.deliveryAuth) : null,
+        binding.holonAuth ? JSON.stringify(binding.holonAuth) : null,
+        binding.defaultRouteId ?? null,
+        JSON.stringify(binding.capabilities),
+        binding.provider ?? null,
+        JSON.stringify(binding.metadata),
+        binding.createdAt,
+        binding.updatedAt,
+      ],
+    );
+    this.persist();
+    return this.getOperatorTransportBinding(binding.bindingId)!;
+  }
+
+  getOperatorTransportBinding(bindingId: string): OperatorTransportBinding | null {
+    const row = this.getOne("select * from operator_transport_bindings where binding_id = ?", [bindingId]);
+    return row ? this.mapOperatorTransportBinding(row) : null;
+  }
+
+  listOperatorTransportBindings(agentId?: string): OperatorTransportBinding[] {
+    const rows = agentId
+      ? this.getAll("select * from operator_transport_bindings where agent_id = ? order by created_at asc", [agentId])
+      : this.getAll("select * from operator_transport_bindings order by created_at asc");
+    return rows.map((row) => this.mapOperatorTransportBinding(row));
+  }
+
+  upsertOperatorReplyRoute(route: OperatorReplyRoute): OperatorReplyRoute {
+    this.run(
+      `
+      insert into operator_reply_routes (
+        route_id, binding_id, agent_id, source_id, delivery_handle_json,
+        metadata_json, created_at, updated_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?)
+      on conflict(route_id) do update set
+        binding_id = excluded.binding_id,
+        agent_id = excluded.agent_id,
+        source_id = excluded.source_id,
+        delivery_handle_json = excluded.delivery_handle_json,
+        metadata_json = excluded.metadata_json,
+        updated_at = excluded.updated_at
+    `,
+      [
+        route.routeId,
+        route.bindingId,
+        route.agentId,
+        route.sourceId ?? null,
+        JSON.stringify(route.deliveryHandle),
+        JSON.stringify(route.metadata),
+        route.createdAt,
+        route.updatedAt,
+      ],
+    );
+    this.persist();
+    return this.getOperatorReplyRoute(route.routeId)!;
+  }
+
+  getOperatorReplyRoute(routeId: string): OperatorReplyRoute | null {
+    const row = this.getOne("select * from operator_reply_routes where route_id = ?", [routeId]);
+    return row ? this.mapOperatorReplyRoute(row) : null;
+  }
+
   insertStream(stream: StreamRecord): void {
     this.run(
       "insert into streams (stream_id, source_id, stream_key, backend, created_at) values (?, ?, ?, ?, ?)",
@@ -2612,6 +2704,38 @@ export class AgentInboxStore {
       payload: parseJson<Record<string, unknown>>(row.payload_json as string),
       status: row.status as DeliveryAttempt["status"],
       createdAt: String(row.created_at),
+    };
+  }
+
+  private mapOperatorTransportBinding(row: Record<string, unknown>): OperatorTransportBinding {
+    return {
+      bindingId: String(row.binding_id),
+      agentId: String(row.agent_id),
+      transport: String(row.transport),
+      operatorActorId: String(row.operator_actor_id),
+      holonBaseUrl: String(row.holon_base_url),
+      deliveryCallbackUrl: row.delivery_callback_url ? String(row.delivery_callback_url) : null,
+      deliveryAuth: row.delivery_auth_json ? parseJson<OperatorTransportBinding["deliveryAuth"]>(row.delivery_auth_json as string) : null,
+      holonAuth: row.holon_auth_json ? parseJson<OperatorTransportBinding["holonAuth"]>(row.holon_auth_json as string) : null,
+      defaultRouteId: row.default_route_id ? String(row.default_route_id) : null,
+      capabilities: parseJson<string[]>(row.capabilities_json as string),
+      provider: row.provider ? String(row.provider) : null,
+      metadata: parseJson<Record<string, unknown>>(row.metadata_json as string),
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
+    };
+  }
+
+  private mapOperatorReplyRoute(row: Record<string, unknown>): OperatorReplyRoute {
+    return {
+      routeId: String(row.route_id),
+      bindingId: String(row.binding_id),
+      agentId: String(row.agent_id),
+      sourceId: row.source_id ? String(row.source_id) : null,
+      deliveryHandle: parseJson<OperatorReplyRoute["deliveryHandle"]>(row.delivery_handle_json as string),
+      metadata: parseJson<Record<string, unknown>>(row.metadata_json as string),
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
     };
   }
 

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -10,6 +11,7 @@ import { Activation, ActivationTarget, AppendSourceEventInput, Subscription, Ter
 import { ActivationDispatcher, AgentInboxService } from "../src/service";
 import { ActivationGate } from "../src/runtime_gate";
 import { UxcRemoteSourceClient } from "../src/sources/remote";
+import { FeishuCallClient, FeishuUxcClient } from "../src/sources/feishu";
 import { GithubCallClient } from "../src/sources/github";
 import { AgentInboxStore } from "../src/store";
 import { assignedAgentIdFromContext, TerminalDispatcher, TerminalProbeStatus } from "../src/terminal";
@@ -110,6 +112,25 @@ class FakeGithubCallClient implements GithubCallClient {
         },
       },
     };
+  }
+}
+
+class FakeFeishuCallClient implements FeishuCallClient {
+  public calls: Array<{
+    endpoint: string;
+    operation: string;
+    payload?: Record<string, unknown>;
+    options?: { auth?: string; schema_url?: string; refresh_schema?: boolean; no_cache?: boolean };
+  }> = [];
+
+  async call(args: {
+    endpoint: string;
+    operation: string;
+    payload?: Record<string, unknown>;
+    options?: { auth?: string; schema_url?: string; refresh_schema?: boolean; no_cache?: boolean };
+  }): Promise<{ data: unknown }> {
+    this.calls.push(args);
+    return { data: { ok: true, file_key: "file-test" } };
   }
 }
 
@@ -283,6 +304,7 @@ async function makeService(options?: {
   activationWindowMs?: number;
   activationMaxItems?: number;
   backend?: EventBusBackend;
+  feishuCallClient?: FeishuCallClient;
 }): Promise<{ store: AgentInboxStore; service: AgentInboxService; dir: string }> {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-test-"));
   const store = await AgentInboxStore.open(path.join(dir, "agentinbox.sqlite"));
@@ -291,6 +313,7 @@ async function makeService(options?: {
     homeDir: dir,
     remoteSourceClient: new FakeRemoteSourceClient(),
     githubCallClient: new FakeGithubCallClient(),
+    feishuClient: options?.feishuCallClient ? new FeishuUxcClient(options.feishuCallClient) : undefined,
   });
   service = new AgentInboxService(
     store,
@@ -367,6 +390,38 @@ function requireTerminalTarget(result: { terminalTarget: TerminalActivationTarge
   return result.terminalTarget;
 }
 
+async function startHolonStub(): Promise<{
+  baseUrl: string;
+  calls: Array<{ method: string; url: string; body: unknown; authorization?: string }>;
+  close: () => Promise<void>;
+}> {
+  const calls: Array<{ method: string; url: string; body: unknown; authorization?: string }> = [];
+  const server = http.createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      const rawBody = Buffer.concat(chunks).toString("utf8");
+      const body = rawBody ? JSON.parse(rawBody) : {};
+      calls.push({
+        method: request.method ?? "GET",
+        url: request.url ?? "/",
+        body,
+        authorization: request.headers.authorization,
+      });
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, message_id: `msg_${calls.length}` }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    calls,
+    close: () => new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve())),
+  };
+}
+
 test("agent register creates a stable agent, inbox, and terminal activation target", async () => {
   const { store, service, dir } = await makeService();
   try {
@@ -403,6 +458,85 @@ test("agent register creates a stable agent, inbox, and terminal activation targ
     const details = service.getInboxDetailsByAgent(first.agent.agentId) as { inbox: { ownerAgentId: string } };
     assert.equal(details.inbox.ownerAgentId, first.agent.agentId);
   } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("operator ingress forwards Feishu route to Holon and callback sends Feishu reply", async () => {
+  const holon = await startHolonStub();
+  const feishu = new FakeFeishuCallClient();
+  const { store, service, dir } = await makeService({ feishuCallClient: feishu });
+  try {
+    const agent = await registerTmuxAgent(service, "operator-feishu");
+    const binding = await service.registerOperatorTransportBinding(agent.agentId, {
+      bindingId: "opb_feishu_test",
+      transport: "feishu",
+      provider: "feishu",
+      operatorActorId: "feishu:ou_test",
+      holonBaseUrl: holon.baseUrl,
+      deliveryCallbackUrl: "http://agentinbox.test/delivery-routes/{route_id}/messages",
+      holonAuth: { type: "bearer", token: "holon-secret" },
+      capabilities: ["prompt"],
+      syncWithHolon: true,
+    });
+
+    assert.equal(binding.bindingId, "opb_feishu_test");
+    assert.equal(holon.calls.length, 1);
+    assert.equal(holon.calls[0].url, `/control/agents/${encodeURIComponent(agent.agentId)}/operator-bindings`);
+    assert.equal(holon.calls[0].authorization, "Bearer holon-secret");
+
+    const ingress = await service.forwardOperatorIngress(agent.agentId, {
+      bindingId: binding.bindingId,
+      text: "hello from Feishu",
+      actorId: "feishu:ou_test",
+      replyRouteId: "route_feishu_chat",
+      providerMessageRef: "om_test",
+      sourceItemId: "item_test",
+      deliveryHandle: {
+        provider: "feishu",
+        surface: "chat_message",
+        targetRef: "oc_test_chat",
+      },
+      metadata: {
+        chatId: "oc_test_chat",
+      },
+    });
+
+    assert.equal(ingress.accepted, true);
+    assert.equal(ingress.replyRouteId, "route_feishu_chat");
+    assert.equal(holon.calls.length, 2);
+    assert.equal(holon.calls[1].url, `/control/agents/${encodeURIComponent(agent.agentId)}/operator-ingress`);
+    assert.deepEqual(holon.calls[1].body, {
+      text: "hello from Feishu",
+      actor_id: "feishu:ou_test",
+      binding_id: "opb_feishu_test",
+      reply_route_id: "route_feishu_chat",
+      provider: "feishu",
+      upstream_provider: "feishu",
+      provider_message_ref: "om_test",
+      correlation_id: null,
+      causation_id: null,
+      metadata: {
+        chatId: "oc_test_chat",
+        source_item_id: "item_test",
+      },
+    });
+
+    const delivery = await service.deliverOperatorReply("route_feishu_chat", {
+      text: "reply from Holon",
+      targetAgentId: agent.agentId,
+    });
+
+    assert.equal(delivery.status, "sent");
+    assert.equal(feishu.calls.length, 1);
+    assert.equal(feishu.calls[0].operation, "post:/im/v1/messages");
+    assert.equal(feishu.calls[0].payload?.receive_id, "oc_test_chat");
+    assert.equal(feishu.calls[0].payload?.msg_type, "text");
+    assert.equal(feishu.calls[0].payload?.content, JSON.stringify({ text: "reply from Holon" }));
+  } finally {
+    await holon.close();
     await service.stop();
     store.close();
     fs.rmSync(dir, { recursive: true, force: true });

--- a/test/store_migration.test.ts
+++ b/test/store_migration.test.ts
@@ -6,6 +6,15 @@ import assert from "node:assert/strict";
 import BetterSqlite3 from "better-sqlite3";
 import { AgentInboxStore } from "../src/store";
 
+const EXPECTED_MIGRATION_TAGS = [
+  "0000_v1_initial",
+  "0001_activation_entry_boundary",
+  "0002_host_scoped_lifecycle_retirements",
+  "0003_subscription_tracked_resource_indexes",
+  "0004_provider_raw_payload",
+  "0005_operator_transport_bindings",
+];
+
 async function createLegacyDb(dbPath: string): Promise<void> {
   fs.rmSync(dbPath, { force: true });
   const db = new BetterSqlite3(dbPath);
@@ -141,13 +150,7 @@ test("store migrates a new database using drizzle SQL migrations", async () => {
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, [
-      "0000_v1_initial",
-      "0001_activation_entry_boundary",
-      "0002_host_scoped_lifecycle_retirements",
-      "0003_subscription_tracked_resource_indexes",
-      "0004_provider_raw_payload",
-    ]);
+    assert.deepEqual(state.appliedTags, EXPECTED_MIGRATION_TAGS);
     assert.equal(state.hasNewIndex, true);
     assert.deepEqual(state.retirementColumns.includes("host_id"), true);
     assert.equal(state.hasTrackedResourceIndex, true);
@@ -188,13 +191,7 @@ test("store reopens an existing v1 database without archiving it", async () => {
   const reopened = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, [
-      "0000_v1_initial",
-      "0001_activation_entry_boundary",
-      "0002_host_scoped_lifecycle_retirements",
-      "0003_subscription_tracked_resource_indexes",
-      "0004_provider_raw_payload",
-    ]);
+    assert.deepEqual(state.appliedTags, EXPECTED_MIGRATION_TAGS);
     assert.equal(warnings.length, 0);
     assert.equal(state.hasTrackedResourceIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.includes(".pre-v1."));
@@ -229,13 +226,7 @@ test("store recovers a corrupt main database from the latest healthy backup", as
 
     recovered = await AgentInboxStore.open(dbPath);
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, [
-      "0000_v1_initial",
-      "0001_activation_entry_boundary",
-      "0002_host_scoped_lifecycle_retirements",
-      "0003_subscription_tracked_resource_indexes",
-      "0004_provider_raw_payload",
-    ]);
+    assert.deepEqual(state.appliedTags, EXPECTED_MIGRATION_TAGS);
     assert.equal(recovered.getDatabaseHealth().integrityCheck, "ok");
     assert.match(warnings.join("\n"), /recovered local database from/);
     assert.equal(fs.readdirSync(dir).some((name) => name.startsWith("agentinbox.sqlite.corrupt")), true);
@@ -258,13 +249,7 @@ test("store archives a pre-v1 database and starts fresh with the v1 baseline", a
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, [
-      "0000_v1_initial",
-      "0001_activation_entry_boundary",
-      "0002_host_scoped_lifecycle_retirements",
-      "0003_subscription_tracked_resource_indexes",
-      "0004_provider_raw_payload",
-    ]);
+    assert.deepEqual(state.appliedTags, EXPECTED_MIGRATION_TAGS);
     assert.equal(state.hasNewIndex, true);
     assert.equal(state.hasTrackedResourceIndex, true);
     const backups = fs.readdirSync(dir).filter((name) => name.includes(".pre-v1."));
@@ -286,13 +271,7 @@ test("store upgrades source-scoped lifecycle retirements to host-scoped retireme
   const store = await AgentInboxStore.open(dbPath);
   try {
     const state = await readMigrationState(dbPath);
-    assert.deepEqual(state.appliedTags, [
-      "0000_v1_initial",
-      "0001_activation_entry_boundary",
-      "0002_host_scoped_lifecycle_retirements",
-      "0003_subscription_tracked_resource_indexes",
-      "0004_provider_raw_payload",
-    ]);
+    assert.deepEqual(state.appliedTags, EXPECTED_MIGRATION_TAGS);
     assert.deepEqual(state.retirementColumns.includes("host_id"), true);
     assert.deepEqual(state.retirementColumns.includes("source_id"), false);
     assert.equal(state.hasTrackedResourceIndex, true);


### PR DESCRIPTION
## Summary
- add RFC for AgentInbox ↔ Holon operator ingress and reply routes
- add operator transport binding and delivery route persistence
- wire Feishu inbound operator messages to Holon ingress and callback replies back to Feishu

## Verification
- npm test
- npm run build