### PR TITLE
Fix operator delivery callback contract

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -2103,6 +2103,13 @@ function buildFastifyServer(service: AgentInboxService) {
           text: { type: "string", minLength: 1 },
           kind: { type: "string" },
           targetAgentId: { type: "string" },
+          target_agent_id: { type: "string" },
+          delivery_intent_id: { type: "string" },
+          binding_id: { type: "string" },
+          route_id: { type: "string" },
+          created_at: { type: "string" },
+          correlation_id: { type: ["string", "null"] },
+          causation_id: { type: ["string", "null"] },
           metadata: jsonObjectSchema,
         },
       },
@@ -2114,11 +2121,13 @@ function buildFastifyServer(service: AgentInboxService) {
     },
   }, async (request) => {
     const params = request.params as { routeId: string };
+    const routeId = decodeURIComponent(params.routeId);
+    assertDeliveryRouteAuthorized(service, routeId, request.headers.authorization);
     const body = request.body as Record<string, unknown>;
-    return service.deliverOperatorReply(decodeURIComponent(params.routeId), {
+    return service.deliverOperatorReply(routeId, {
       text: String(body.text),
       kind: optionalString(body.kind) ?? null,
-      targetAgentId: optionalString(body.targetAgentId) ?? null,
+      targetAgentId: optionalString(body.targetAgentId) ?? optionalString(body.target_agent_id) ?? null,
       metadata: body.metadata && typeof body.metadata === "object" ? body.metadata as Record<string, unknown> : undefined,
     });
   });
@@ -2135,6 +2144,14 @@ function buildFastifyServer(service: AgentInboxService) {
     }
     if (message.startsWith("unknown ")) {
       void reply.code(404).send({ error: message });
+      return;
+    }
+    if (message.startsWith("missing delivery route authorization")) {
+      void reply.code(401).send({ error: message });
+      return;
+    }
+    if (message.startsWith("invalid delivery route authorization")) {
+      void reply.code(403).send({ error: message });
       return;
     }
     if (isBadRequestError(message)) {
@@ -2188,6 +2205,28 @@ function optionalString(value: unknown): string | undefined {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function assertDeliveryRouteAuthorized(
+  service: AgentInboxService,
+  routeId: string,
+  authorization: string | undefined,
+): void {
+  const binding = service.getOperatorBindingForReplyRoute(routeId);
+  const deliveryAuth = binding?.deliveryAuth;
+  if (!deliveryAuth) {
+    return;
+  }
+  if (deliveryAuth.type !== "bearer" || !deliveryAuth.token) {
+    throw new Error("invalid delivery route authorization");
+  }
+  if (!authorization) {
+    throw new Error("missing delivery route authorization");
+  }
+  const [scheme, token] = authorization.split(/\s+/, 2);
+  if (scheme?.toLowerCase() !== "bearer" || token !== deliveryAuth.token) {
+    throw new Error("invalid delivery route authorization");
+  }
 }
 
 function parseOptionalPositiveInteger(value: string | undefined): number | undefined {

--- a/src/service.ts
+++ b/src/service.ts
@@ -2070,6 +2070,11 @@ export class AgentInboxService {
     return this.store.listOperatorTransportBindings(agentId);
   }
 
+  getOperatorBindingForReplyRoute(routeId: string): OperatorTransportBinding | null {
+    const route = this.store.getOperatorReplyRoute(routeId);
+    return route ? this.store.getOperatorTransportBinding(route.bindingId) : null;
+  }
+
   async forwardOperatorIngress(agentId: string, input: OperatorIngressInput): Promise<OperatorIngressResult> {
     if (!input.text) {
       throw new Error("operator ingress requires text");
@@ -2141,20 +2146,26 @@ export class AgentInboxService {
   }
 
   private async syncOperatorBindingToHolon(binding: OperatorTransportBinding): Promise<unknown> {
+    if (!binding.defaultRouteId) {
+      throw new Error("operator binding sync requires defaultRouteId");
+    }
+    if (!binding.deliveryCallbackUrl) {
+      throw new Error("operator binding sync requires deliveryCallbackUrl");
+    }
     return this.postHolonJson(
       binding,
       `/control/agents/${encodeURIComponent(binding.agentId)}/operator-bindings`,
-      {
+      omitNullish({
         binding_id: binding.bindingId,
         transport: binding.transport,
         operator_actor_id: binding.operatorActorId,
         default_route_id: binding.defaultRouteId,
         delivery_callback_url: binding.deliveryCallbackUrl,
-        delivery_auth: binding.deliveryAuth,
-        capabilities: binding.capabilities,
+        delivery_auth: holonOperatorDeliveryAuth(binding.deliveryAuth),
+        capabilities: holonOperatorCapabilities(binding.capabilities),
         provider: binding.provider,
         metadata: binding.metadata,
-      },
+      }),
     );
   }
 
@@ -4841,6 +4852,29 @@ function deliverSendUnsupportedMessage(handle: DeliveryHandle, operations: Deliv
   }
   const names = operations.map((item) => item.name).join(", ");
   return `deliver send is not supported for ${handle.provider}/${handle.surface}; use deliver invoke with one of: ${names}. ${deliveryActionsHelp(handle)}`;
+}
+
+function omitNullish<T extends Record<string, unknown>>(record: T): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== null && value !== undefined));
+}
+
+function holonOperatorDeliveryAuth(auth: OperatorTransportBinding["deliveryAuth"]): Record<string, unknown> {
+  if (!auth) {
+    throw new Error("operator binding sync requires deliveryAuth");
+  }
+  if (auth.type === "bearer" && auth.token) {
+    return { kind: "bearer", bearer_token: auth.token };
+  }
+  throw new Error("operator binding sync supports only bearer deliveryAuth with a token");
+}
+
+function holonOperatorCapabilities(capabilities: string[]): Record<string, boolean> {
+  const normalized = new Set(capabilities.map((capability) => capability.trim().toLowerCase()).filter(Boolean));
+  return {
+    text: normalized.size === 0 || normalized.has("prompt") || normalized.has("text") || normalized.has("send_prompt"),
+    ...(normalized.has("markdown") ? { markdown: true } : {}),
+    ...(normalized.has("attachments") || normalized.has("attachment") ? { attachments: true } : {}),
+  };
 }
 
 function deliveryActionsHelp(handle: DeliveryHandle): string {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -14,6 +14,7 @@ import { UxcRemoteSourceClient } from "../src/sources/remote";
 import { FeishuCallClient, FeishuUxcClient } from "../src/sources/feishu";
 import { GithubCallClient } from "../src/sources/github";
 import { AgentInboxStore } from "../src/store";
+import { createServer } from "../src/http";
 import { assignedAgentIdFromContext, TerminalDispatcher, TerminalProbeStatus } from "../src/terminal";
 import { nowIso } from "../src/util";
 
@@ -392,10 +393,10 @@ function requireTerminalTarget(result: { terminalTarget: TerminalActivationTarge
 
 async function startHolonStub(): Promise<{
   baseUrl: string;
-  calls: Array<{ method: string; url: string; body: unknown; authorization?: string }>;
+  calls: Array<{ method: string; url: string; body: Record<string, unknown>; authorization?: string }>;
   close: () => Promise<void>;
 }> {
-  const calls: Array<{ method: string; url: string; body: unknown; authorization?: string }> = [];
+  const calls: Array<{ method: string; url: string; body: Record<string, unknown>; authorization?: string }> = [];
   const server = http.createServer((request, response) => {
     const chunks: Buffer[] = [];
     request.on("data", (chunk: Buffer) => chunks.push(chunk));
@@ -420,6 +421,41 @@ async function startHolonStub(): Promise<{
     calls,
     close: () => new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve())),
   };
+}
+
+async function postJson(
+  url: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const parsed = new URL(url);
+  const payload = JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      method: "POST",
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: `${parsed.pathname}${parsed.search}`,
+      headers: {
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(payload).toString(),
+        ...headers,
+      },
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.on("end", () => {
+        const rawBody = Buffer.concat(chunks).toString("utf8");
+        resolve({
+          status: response.statusCode ?? 0,
+          body: rawBody ? JSON.parse(rawBody) : {},
+        });
+      });
+    });
+    request.on("error", reject);
+    request.write(payload);
+    request.end();
+  });
 }
 
 test("agent register creates a stable agent, inbox, and terminal activation target", async () => {
@@ -477,7 +513,9 @@ test("operator ingress forwards Feishu route to Holon and callback sends Feishu 
       operatorActorId: "feishu:ou_test",
       holonBaseUrl: holon.baseUrl,
       deliveryCallbackUrl: "http://agentinbox.test/delivery-routes/{route_id}/messages",
+      deliveryAuth: { type: "bearer", token: "agentinbox-delivery-secret" },
       holonAuth: { type: "bearer", token: "holon-secret" },
+      defaultRouteId: "route_feishu_chat",
       capabilities: ["prompt"],
       syncWithHolon: true,
     });
@@ -486,6 +524,13 @@ test("operator ingress forwards Feishu route to Holon and callback sends Feishu 
     assert.equal(holon.calls.length, 1);
     assert.equal(holon.calls[0].url, `/control/agents/${encodeURIComponent(agent.agentId)}/operator-bindings`);
     assert.equal(holon.calls[0].authorization, "Bearer holon-secret");
+    assert.equal(holon.calls[0].body.default_route_id, "route_feishu_chat");
+    assert.equal(holon.calls[0].body.delivery_callback_url, "http://agentinbox.test/delivery-routes/{route_id}/messages");
+    assert.deepEqual(holon.calls[0].body.delivery_auth, {
+      kind: "bearer",
+      bearer_token: "agentinbox-delivery-secret",
+    });
+    assert.deepEqual(holon.calls[0].body.capabilities, { text: true });
 
     const ingress = await service.forwardOperatorIngress(agent.agentId, {
       bindingId: binding.bindingId,
@@ -524,12 +569,33 @@ test("operator ingress forwards Feishu route to Holon and callback sends Feishu 
       },
     });
 
-    const delivery = await service.deliverOperatorReply("route_feishu_chat", {
+    const server = createServer(service);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const callbackUrl = `http://127.0.0.1:${address.port}/delivery-routes/route_feishu_chat/messages`;
+    const unauthorized = await postJson(callbackUrl, {
+      kind: "operator_output",
+      text: "reply from Holon without auth",
+      target_agent_id: agent.agentId,
+    });
+    assert.equal(unauthorized.status, 401);
+    const delivery = await postJson(callbackUrl, {
+      delivery_intent_id: "odi_test",
+      binding_id: "opb_feishu_test",
+      route_id: "route_feishu_chat",
+      kind: "operator_output",
       text: "reply from Holon",
-      targetAgentId: agent.agentId,
+      target_agent_id: agent.agentId,
+      correlation_id: null,
+      causation_id: null,
+    }, {
+      authorization: "Bearer agentinbox-delivery-secret",
     });
 
-    assert.equal(delivery.status, "sent");
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    assert.equal(delivery.status, 200);
+    assert.equal(delivery.body.status, "sent");
     assert.equal(feishu.calls.length, 1);
     assert.equal(feishu.calls[0].operation, "post:/im/v1/messages");
     assert.equal(feishu.calls[0].payload?.receive_id, "oc_test_chat");


### PR DESCRIPTION
## Summary
- send Holon operator binding sync fields in the expected wire shape
- require bearer authorization on delivery callback routes when configured
- accept Holon callback snake_case fields and nullable correlation ids
- cover the HTTP callback path in the Feishu operator ingress test

## Verification
- npm run build
- node --require ts-node/register --test --test-force-exit test/agentinbox.test.ts --test-name-pattern='operator ingress forwards Feishu route'

Note: one full-suite run reached the target callback test and 322/323 passing, then hit an existing daemon readiness timeout in `cli source update patches config in place`; targeted test and build pass after the fix.
