### PR TITLE
Fix follow template argument validation order

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -580,6 +580,7 @@ export class AgentInboxService {
         if (!templateSpec) {
           continue;
         }
+        validateFollowTemplateArgs(templateSpec.argsSchema ?? [], templateArgs, templateSpec.templateId);
         await this.adapters.sourceAdapterFor(source.sourceType).validateSource?.(source);
         return { source, templateSpec };
       } catch (error) {

--- a/test/agentinbox.test.ts
+++ b/test/agentinbox.test.ts
@@ -1290,6 +1290,31 @@ test("stream schema preview supports builtin remote-backed aliases without persi
   }
 });
 
+test("follow github pr reports missing owner before preview source validation", async () => {
+  const { store, service, dir } = await makeService();
+  try {
+    const registered = service.registerAgent({
+      backend: "tmux",
+      runtimeKind: "codex",
+      runtimeSessionId: "follow-missing-owner-thread",
+      tmuxPaneId: "%follow-missing-owner",
+    });
+    await assert.rejects(
+      service.follow({
+        agentId: registered.agent.agentId,
+        providerOrKind: "github",
+        template: "pr",
+        templateArgs: { number: 2040, withCi: true },
+      }),
+      /follow template github\.pr requires argument owner/,
+    );
+  } finally {
+    await service.stop();
+    store.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("remote_source capability hooks override resolved schema fields and advertise shortcut/lifecycle support", async () => {
   const { store, service, dir } = await makeService();
   try {


### PR DESCRIPTION
## Summary
- validate follow template arguments before preview source validation
- add regression coverage for missing github.pr owner argument

## Verification
- npm run build
- npm test -- --test-name-pattern='follow github pr reports missing owner|stream schema preview supports builtin remote-backed aliases' (completed as full test run: 324 passed)