### PR TITLE
feat: compact CLI inbox output by default, add --full flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -820,9 +820,9 @@ async function main(): Promise<void> {
 
   if (command === "inbox" && normalized[1] === "read") {
     const args = normalized.slice(2);
-    const allowedFlags = ["--agent-id", "--after-entry", "--include-acked", "--limit"];
+    const allowedFlags = ["--agent-id", "--after-entry", "--include-acked", "--limit", "--full"];
     if (positionalArgs(args, ["--agent-id", "--after-entry", "--limit"]).length > 0 || unexpectedFlags(args, allowedFlags).length > 0) {
-      throw new Error("usage: agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked] [--limit N]");
+      throw new Error("usage: agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked] [--limit N] [--full]");
     }
     const selection = await selectAgentForCommand(client, {
       explicitAgentId: takeFlagValue(normalized, "--agent-id"),
@@ -834,7 +834,11 @@ async function main(): Promise<void> {
       limit: parseOptionalLimitArg(normalized),
     });
     const response = await requestRemote<Record<string, unknown>>(client, `/agents/${encodeURIComponent(selection.agentId)}/inbox/entries${query}`, undefined, "GET");
-    console.log(jsonResponse(withCommandMetadata(response.data, selection)));
+    const data = response.data;
+    if (!hasFlag(normalized, "--full") && Array.isArray(data.entries)) {
+      data.entries = (data.entries as Array<Record<string, unknown>>).map(compactInboxEntry);
+    }
+    console.log(jsonResponse(withCommandMetadata(data, selection)));
     return;
   }
 
@@ -859,8 +863,9 @@ async function main(): Promise<void> {
   if (command === "inbox" && normalized[1] === "watch") {
     const args = normalized.slice(2);
     if (positionalArgs(args, ["--agent-id", "--after-entry", "--heartbeat-ms"]).length > 0) {
-      throw new Error("usage: agentinbox inbox watch [--agent-id ID] [--after-entry ID] [--include-acked] [--heartbeat-ms N]");
+      throw new Error("usage: agentinbox inbox watch [--agent-id ID] [--after-entry ID] [--include-acked] [--heartbeat-ms N] [--full]");
     }
+    const fullMode = hasFlag(normalized, "--full");
     const selection = await selectAgentForCommand(client, {
       explicitAgentId: takeFlagValue(normalized, "--agent-id"),
       autoRegister: true,
@@ -879,7 +884,11 @@ async function main(): Promise<void> {
       if (event.event !== "items") {
         continue;
       }
-      console.log(jsonResponse(event));
+      const output = fullMode ? event : {
+        ...event,
+        entries: event.entries.map((e) => compactInboxEntry(e as unknown as Record<string, unknown>)),
+      };
+      console.log(jsonResponse(output));
     }
     return;
   }
@@ -1572,6 +1581,37 @@ function withCommandMetadata<T extends Record<string, unknown>>(data: T, selecti
   };
 }
 
+const COMPACT_ENTRY_FIELDS = [
+  "entryId", "kind", "summary", "eventVariant",
+  "occurredAt", "ackedAt", "deliveryHandle", "metadata",
+] as const;
+
+const COMPACT_DIGEST_FIELDS = [
+  "threadId", "revision", "groupKey", "resourceRef", "eventFamily",
+] as const;
+
+/**
+ * Strip verbose/internal fields from an inbox entry, keeping only the fields
+ * an agent needs for decisions and ack. Use `--full` on `inbox read`/`watch`
+ * to bypass this and see the complete entry.
+ */
+function compactInboxEntry(entry: Record<string, unknown>): Record<string, unknown> {
+  const compact: Record<string, unknown> = {};
+  for (const field of COMPACT_ENTRY_FIELDS) {
+    if (entry[field] !== undefined) {
+      compact[field] = entry[field];
+    }
+  }
+  if (entry.kind === "digest_snapshot") {
+    for (const field of COMPACT_DIGEST_FIELDS) {
+      if (entry[field] !== undefined) {
+        compact[field] = entry[field];
+      }
+    }
+  }
+  return compact;
+}
+
 function normalizeSubscriptionAddOutput(data: Record<string, unknown>, shortcutUsed: boolean): Record<string, unknown> {
   if (shortcutUsed) {
     return data;
@@ -1769,9 +1809,9 @@ Usage:
 Usage:
   agentinbox inbox list [--limit N]
   agentinbox inbox show <agentId>
-  agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked] [--limit N]
+  agentinbox inbox read [--agent-id ID] [--after-entry ID] [--include-acked] [--limit N] [--full]
   agentinbox inbox send --agent-id ID --message TEXT [--sender SENDER]
-  agentinbox inbox watch [--agent-id ID] [--after-entry ID] [--include-acked] [--heartbeat-ms N]
+  agentinbox inbox watch [--agent-id ID] [--after-entry ID] [--include-acked] [--heartbeat-ms N] [--full]
   agentinbox inbox ack [--agent-id ID] (--through <entryId> | --entry <entryId> | --entry-id <entryId> | --all)
   agentinbox inbox policy show [--agent-id ID]
   agentinbox inbox policy set [--agent-id ID] [--enabled|--disabled] [--window-ms N] [--max-items N] [--max-thread-age-ms N]

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -1978,7 +1978,66 @@ test("cli inbox read rejects unsupported flags like --ack", () => {
   try {
     const read = runCli(["inbox", "read", "--ack"], env);
     assert.notEqual(read.status, 0);
-    assert.match(read.stderr, /usage: agentinbox inbox read \[--agent-id ID] \[--after-entry ID] \[--include-acked] \[--limit N]/);
+    assert.match(read.stderr, /usage: agentinbox inbox read \[--agent-id ID] \[--after-entry ID] \[--include-acked] \[--limit N] \[--full]/);
+  } finally {
+    void runCli(["daemon", "stop"], env);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("cli inbox read defaults to compact output and --full restores complete fields", () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-cli-compact-"));
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: homeDir,
+    ITERM_SESSION_ID: "",
+    TERM_SESSION_ID: "",
+    TERM_PROGRAM: "",
+    TMUX_PANE: "%7421",
+    CODEX_THREAD_ID: "thread-compact",
+  };
+
+  try {
+    const register = runCli(["agent", "register"], env);
+    assert.equal(register.status, 0, register.stderr);
+    const registered = JSON.parse(register.stdout) as { agent: { agentId: string } };
+    const agentId = registered.agent.agentId;
+
+    const send = runCli(["inbox", "send", "--agent-id", agentId, "--message", "compact test message"], env);
+    assert.equal(send.status, 0, send.stderr);
+
+    // Default (compact) mode: should NOT contain verbose fields
+    const compactRead = runCli(["inbox", "read", "--agent-id", agentId, "--include-acked"], env);
+    assert.equal(compactRead.status, 0, compactRead.stderr);
+    const compactPayload = JSON.parse(compactRead.stdout) as { entries: Array<Record<string, unknown>> };
+    assert.equal(compactPayload.entries.length, 1);
+    const compactEntry = compactPayload.entries[0];
+    assert.ok(compactEntry.entryId, "compact entry should have entryId");
+    assert.ok(compactEntry.summary, "compact entry should have summary");
+    assert.ok(compactEntry.kind, "compact entry should have kind");
+    assert.ok(compactEntry.metadata, "compact entry should have metadata");
+    assert.equal(compactEntry.rawPayload, undefined, "compact entry should NOT have rawPayload");
+    assert.equal(compactEntry.providerRawPayload, undefined, "compact entry should NOT have providerRawPayload");
+    assert.equal(compactEntry.item, undefined, "compact entry should NOT have item");
+    assert.equal(compactEntry.itemId, undefined, "compact entry should NOT have itemId");
+    assert.equal(compactEntry.inboxId, undefined, "compact entry should NOT have inboxId");
+    assert.equal(compactEntry.sequence, undefined, "compact entry should NOT have sequence");
+    assert.equal(compactEntry.itemIds, undefined, "compact entry should NOT have itemIds");
+    assert.equal(compactEntry.firstItemAt, undefined, "compact entry should NOT have firstItemAt");
+
+    // --full mode: should contain all fields including verbose ones
+    const fullRead = runCli(["inbox", "read", "--agent-id", agentId, "--include-acked", "--full"], env);
+    assert.equal(fullRead.status, 0, fullRead.stderr);
+    const fullPayload = JSON.parse(fullRead.stdout) as { entries: Array<Record<string, unknown>> };
+    assert.equal(fullPayload.entries.length, 1);
+    const fullEntry = fullPayload.entries[0];
+    assert.ok(fullEntry.entryId, "full entry should have entryId");
+    assert.ok(fullEntry.rawPayload, "full entry should have rawPayload");
+    assert.ok(fullEntry.itemId, "full entry should have itemId");
+    assert.ok(fullEntry.inboxId, "full entry should have inboxId");
+    assert.ok(fullEntry.sequence !== undefined, "full entry should have sequence");
+    assert.ok(fullEntry.itemIds, "full entry should have itemIds");
+    assert.ok(fullEntry.firstItemAt, "full entry should have firstItemAt");
   } finally {
     void runCli(["daemon", "stop"], env);
     fs.rmSync(homeDir, { recursive: true, force: true });
@@ -2076,7 +2135,7 @@ test("cli inbox send writes a direct text message into the target inbox", () => 
     const delivered = JSON.parse(send.stdout) as { itemId: string; inboxId: string; activated: boolean };
     assert.equal(delivered.activated, true);
 
-    const read = runCli(["inbox", "read", "--agent-id", registered.agent.agentId, "--include-acked"], env);
+    const read = runCli(["inbox", "read", "--agent-id", registered.agent.agentId, "--include-acked", "--full"], env);
     assert.equal(read.status, 0, read.stderr);
     const payload = JSON.parse(read.stdout) as { entries: Array<{ itemId: string; rawPayload: Record<string, unknown> }> };
     assert.equal(payload.entries.length, 1);


### PR DESCRIPTION
## Summary

-  /  默认输出 compact 格式，只保留 agent 决策需要的字段（、、、、、、、；digest 类型额外保留 // 等）
- 移除 、、、内部 ID 等冗余字段，单 entry 从 ~5665B 降到 ~820B（-86%）
- 添加  flag 恢复完整输出
- 纯 CLI 层裁剪，不改动 API/model 层

Closes #227