### PR TITLE
fix(daemon): single-instance admission lock and ownership-aware file cleanup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,10 +15,22 @@ import {
   isHolonRuntimeEnv,
   resolveCurrentAgent,
 } from "./current_agent";
-import { daemonStatus, ensureDaemonForClient, removePidFile, resolveDaemonLogLevel, startDaemon, stopDaemon, writeDaemonMetadata, writePidFile } from "./daemon";
+import {
+  acquireDaemonLock,
+  daemonStatus,
+  ensureDaemonForClient,
+  releaseDaemonLock,
+  removePidFile,
+  removePidFileIfOwned,
+  resolveDaemonLogLevel,
+  startDaemon,
+  stopDaemon,
+  writeDaemonMetadata,
+  writePidFile,
+} from "./daemon";
 import { createServer } from "./http";
 import { JsonLogger, parseLogLevel } from "./logging";
-import { resolveDaemonPaths, resolveServeConfig } from "./paths";
+import { daemonLockPath, resolveDaemonPaths, resolveServeConfig } from "./paths";
 import { AgentInboxService } from "./service";
 import { AgentInboxStore } from "./store";
 import { detectTerminalContext } from "./terminal";
@@ -1149,6 +1161,28 @@ async function runServe(args: string[]): Promise<void> {
   const logLevel = parseLogLevel(takeFlagValue(args, "--log-level") ?? process.env.AGENTINBOX_LOG_LEVEL);
   const logger = new JsonLogger(logLevel, "agentinbox");
 
+  // Socket transport: take the admission lock and publish the pid file before
+  // opening the store, so concurrent starters and status checks see this
+  // process during the (possibly slow) store open instead of racing it.
+  let daemonLock: string | null = null;
+  if (serveConfig.transport.kind === "socket") {
+    daemonLock = daemonLockPath(serveConfig.transport.socketPath);
+    const acquisition = acquireDaemonLock(daemonLock);
+    if (!acquisition.acquired) {
+      const holderPid = acquisition.holder?.pid ?? null;
+      logger.warn("daemon.already_running", {
+        pid: holderPid,
+        socketPath: serveConfig.transport.socketPath,
+        lockPath: daemonLock,
+      });
+      console.error(
+        `agentinbox daemon already running${holderPid != null ? ` (pid ${holderPid})` : ""}; not starting a second instance`,
+      );
+      process.exit(0);
+    }
+    writePidFile(daemonPaths.pidPath, process.pid);
+  }
+
   const store = await AgentInboxStore.open(serveConfig.dbPath);
   let service: AgentInboxService;
   const adapters = new AdapterRegistry(store, async (input) => service.appendSourceEvent(input), {
@@ -1159,9 +1193,6 @@ async function runServe(args: string[]): Promise<void> {
   await adapters.start();
   await service.start();
   const controlServer = await startControlServer(server, serveConfig.transport);
-  if (serveConfig.transport.kind === "socket") {
-    writePidFile(daemonPaths.pidPath, process.pid);
-  }
   writeDaemonMetadata(daemonPaths.metadataPath, { logLevel });
   logger.info("daemon.ready", {
     homeDir: serveConfig.homeDir,
@@ -1181,8 +1212,11 @@ async function runServe(args: string[]): Promise<void> {
       void adapters.stop();
       void service.stop();
       store.close();
-      if (serveConfig.transport.kind === "socket") {
-        removePidFile(daemonPaths.pidPath);
+      if (serveConfig.transport.kind === "socket" && daemonLock != null) {
+        // Ownership: only remove files that still belong to this process so a
+        // replaced or rebound instance keeps its own pid file and socket.
+        removePidFileIfOwned(daemonPaths.pidPath, process.pid);
+        releaseDaemonLock(daemonLock, process.pid);
       }
       removePidFile(daemonPaths.metadataPath);
       process.exit(0);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,8 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { execFileSync, spawn } from "node:child_process";
 import { AgentInboxClient } from "./client";
-import { resolveAgentInboxHome, resolveDaemonPaths, type ClientTransport } from "./paths";
+import { daemonLockPath, resolveAgentInboxHome, resolveDaemonPaths, type ClientTransport } from "./paths";
 import { defaultLogLevel, isLogLevel, LogLevel, parseLogLevel } from "./logging";
+import { isEnvFlagEnabled, isPidAlive } from "./util";
 
 export interface DaemonCliOptions {
   env?: NodeJS.ProcessEnv;
@@ -25,6 +26,8 @@ export interface DaemonStartResult {
 
 export interface DaemonStatusResult {
   running: boolean;
+  /** A daemon process exists but healthz is not ready yet (e.g. opening a large store). */
+  starting: boolean;
   pid: number | null;
   logLevel: LogLevel | null;
   version: string | null;
@@ -36,13 +39,22 @@ export interface DaemonStatusResult {
   transport: ClientTransport;
 }
 
-const START_TIMEOUT_MS = 15_000;
+const DEFAULT_START_TIMEOUT_MS = 60_000;
+// A freshly created but still-empty lock file may belong to a process between
+// create and write; never steal it within this grace window.
+const STALE_LOCK_GRACE_MS = 5_000;
 const PACKAGE_VERSION = readOwnPackageVersion();
 
+/** AGENTINBOX_NO_AUTOSTART disables implicit daemon spawning (systemd-style deployments). */
+export function autostartDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isEnvFlagEnabled(env.AGENTINBOX_NO_AUTOSTART);
+}
+
 export async function ensureDaemonForClient(options: DaemonCliOptions = {}): Promise<ClientTransport> {
+  const env = options.env ?? process.env;
   const transport = resolveDaemonClientTransport(options);
 
-  if (options.noAutoStart || transport.kind !== "socket") {
+  if (options.noAutoStart || autostartDisabled(env) || transport.kind !== "socket") {
     return transport;
   }
 
@@ -62,7 +74,6 @@ export async function startDaemon(options: DaemonCliOptions = {}): Promise<Daemo
   const homeDir = resolveAgentInboxHome(env, options.homeDirOverride);
   const { pidPath, logPath } = resolveDaemonPaths(env, options.homeDirOverride);
   fs.mkdirSync(homeDir, { recursive: true });
-  cleanupStalePidFile(pidPath);
 
   if (await canReachHealthz(transport)) {
     const pid = readPidFile(pidPath);
@@ -74,6 +85,34 @@ export async function startDaemon(options: DaemonCliOptions = {}): Promise<Daemo
       logPath,
       transport,
     };
+  }
+
+  // Admission: a live lock holder is starting (or serving) this socket — never
+  // spawn a competing daemon. This check is advisory; the spawned serve
+  // process enforces the lock authoritatively.
+  const lockPath = daemonLockPath(transport.socketPath);
+  const timeoutMs = resolveStartTimeoutMs(env);
+  let pendingHolder = readLiveDaemonLockHolder(lockPath);
+  while (pendingHolder) {
+    const outcome = await waitForDaemonReady(transport, lockPath, timeoutMs);
+    if (outcome === "ready") {
+      const pid = readPidFile(pidPath) ?? pendingHolder.pid;
+      return {
+        started: false,
+        pid,
+        logLevel,
+        pidPath,
+        logPath,
+        transport,
+      };
+    }
+    if (outcome === "timeout") {
+      throw new Error(
+        `AgentInbox daemon is already starting (pid ${pendingHolder.pid}) but did not become ready within ${timeoutMs}ms`,
+      );
+    }
+    // The pending holder exited before becoming ready; re-check admission.
+    pendingHolder = readLiveDaemonLockHolder(lockPath);
   }
 
   const logFd = openLogFile(logPath);
@@ -95,7 +134,7 @@ export async function startDaemon(options: DaemonCliOptions = {}): Promise<Daemo
     fs.closeSync(logFd);
   }
   child.unref();
-  await waitForHealthz(transport, START_TIMEOUT_MS);
+  await waitForHealthz(transport, timeoutMs);
   return {
     started: true,
     pid: child.pid ?? -1,
@@ -111,15 +150,25 @@ export async function stopDaemon(options: DaemonCliOptions = {}): Promise<Daemon
   const transport = requireSocketTransport(resolveDaemonClientTransport(options), "daemon stop");
   const { pidPath, logPath, metadataPath } = resolveDaemonPaths(env, options.homeDirOverride);
 
-  const pid = readPidFile(pidPath);
-  if (pid != null && isProcessAlive(pid)) {
+  let pid = readPidFile(pidPath);
+  if (pid == null || !isPidAlive(pid)) {
+    // The pid file may be stale or overwritten while the live daemon still
+    // owns the socket; fall back to the admission lock holder.
+    pid = readLiveDaemonLockHolder(daemonLockPath(transport.socketPath))?.pid ?? pid;
+  }
+  if (pid != null && isPidAlive(pid)) {
     process.kill(pid, "SIGTERM");
     await waitForProcessExit(pid, 3_000);
   }
 
-  cleanupStalePidFile(pidPath, true);
-  cleanupFile(transport.socketPath);
-  cleanupFile(metadataPath);
+  // Ownership: if an instance we did not stop still serves the socket, the
+  // files may now belong to it — leave them untouched. Otherwise remove the
+  // pid file only when it no longer references a live process.
+  if (!(await canReachHealthz(transport))) {
+    cleanupStalePidFile(pidPath);
+    cleanupFile(transport.socketPath);
+    cleanupFile(metadataPath);
+  }
 
   return daemonStatus(options);
 }
@@ -128,29 +177,44 @@ export async function daemonStatus(options: DaemonCliOptions = {}): Promise<Daem
   const env = options.env ?? process.env;
   const transport = requireSocketTransport(resolveDaemonClientTransport(options), "daemon status");
   const { pidPath, logPath, metadataPath } = resolveDaemonPaths(env, options.homeDirOverride);
-  const pid = readPidFile(pidPath);
-  if (pid != null && !isProcessAlive(pid)) {
-    cleanupStalePidFile(pidPath, true);
-    cleanupFile(transport.socketPath);
-    cleanupFile(metadataPath);
-    return {
-      running: false,
-      pid: null,
-      logLevel: null,
-      version: null,
-      startedAt: null,
-      command: null,
-      nodeVersion: null,
-      pidPath,
-      logPath,
-      transport,
-    };
+  let pid = readPidFile(pidPath);
+  if (pid != null && !isPidAlive(pid)) {
+    const holder = readLiveDaemonLockHolder(daemonLockPath(transport.socketPath));
+    if (holder != null) {
+      // The admission lock identifies the live daemon even when the pid file
+      // is stale (e.g. overwritten by a mixed-version writer).
+      pid = holder.pid;
+    } else if (!(await canReachHealthz(transport))) {
+      // Nothing is serving and no live owner exists: clean stale files.
+      cleanupStalePidFile(pidPath);
+      cleanupFile(transport.socketPath);
+      cleanupFile(metadataPath);
+      return {
+        running: false,
+        starting: false,
+        pid: null,
+        logLevel: null,
+        version: null,
+        startedAt: null,
+        command: null,
+        nodeVersion: null,
+        pidPath,
+        logPath,
+        transport,
+      };
+    } else {
+      // Something answers healthz (e.g. an older daemon without a lock);
+      // report it without owning its files.
+      pid = null;
+    }
   }
 
   const processInfo = pid == null ? null : readProcessMetadata(pid);
   const daemonMetadata = readDaemonMetadata(metadataPath);
+  const running = await canReachHealthz(transport);
   return {
-    running: await canReachHealthz(transport),
+    running,
+    starting: !running && pid != null && isPidAlive(pid),
     pid,
     logLevel: daemonMetadata?.logLevel ?? null,
     version: pid == null ? null : PACKAGE_VERSION,
@@ -170,6 +234,157 @@ export function writePidFile(pidPath: string, pid: number): void {
 
 export function removePidFile(pidPath: string): void {
   cleanupFile(pidPath);
+}
+
+/** Removes the pid file only when it still belongs to the given pid. */
+export function removePidFileIfOwned(pidPath: string, pid: number): boolean {
+  if (readPidFile(pidPath) !== pid) {
+    return false;
+  }
+  cleanupFile(pidPath);
+  return true;
+}
+
+export interface DaemonLockInfo {
+  pid: number;
+  /** Process start time (ps lstart) captured at acquire time; guards against pid reuse. */
+  processStartedAt: string | null;
+  acquiredAt: string;
+}
+
+export interface DaemonLockAcquisition {
+  acquired: boolean;
+  lockPath: string;
+  holder: DaemonLockInfo | null;
+}
+
+export function readDaemonLock(lockPath: string): DaemonLockInfo | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(lockPath, "utf8")) as {
+      pid?: unknown;
+      processStartedAt?: unknown;
+      acquiredAt?: unknown;
+    };
+    if (typeof parsed.pid !== "number" || !Number.isInteger(parsed.pid) || parsed.pid <= 0) {
+      return null;
+    }
+    return {
+      pid: parsed.pid,
+      processStartedAt: typeof parsed.processStartedAt === "string" ? parsed.processStartedAt : null,
+      acquiredAt: typeof parsed.acquiredAt === "string" ? parsed.acquiredAt : new Date(0).toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isLockHolderLive(holder: DaemonLockInfo): boolean {
+  if (!isPidAlive(holder.pid)) {
+    return false;
+  }
+  if (holder.processStartedAt == null) {
+    return true;
+  }
+  const current = readProcessMetadata(holder.pid);
+  if (current?.startedAt == null) {
+    return true;
+  }
+  return current.startedAt === holder.processStartedAt;
+}
+
+export function readLiveDaemonLockHolder(lockPath: string): DaemonLockInfo | null {
+  const holder = readDaemonLock(lockPath);
+  return holder != null && isLockHolderLive(holder) ? holder : null;
+}
+
+/**
+ * Atomically (O_EXCL) acquires the daemon admission lock for this process.
+ * A stale lock (dead pid or pid reuse) is removed and retried once. A freshly
+ * created but still-empty lock is treated as held to avoid racing a concurrent
+ * creator between create and write.
+ */
+export function acquireDaemonLock(lockPath: string): DaemonLockAcquisition {
+  let holder: DaemonLockInfo | null = null;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    holder = null;
+    try {
+      const metadata = readProcessMetadata(process.pid);
+      const info: DaemonLockInfo = {
+        pid: process.pid,
+        processStartedAt: metadata?.startedAt ?? null,
+        acquiredAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(lockPath, `${JSON.stringify(info)}\n`, { encoding: "utf8", flag: "wx" });
+      return { acquired: true, lockPath, holder: null };
+    } catch (error) {
+      if (!isFileExistsError(error)) {
+        throw error;
+      }
+    }
+    holder = readDaemonLock(lockPath);
+    if (holder != null && isLockHolderLive(holder)) {
+      return { acquired: false, lockPath, holder };
+    }
+    if (holder == null && isLockFileFresh(lockPath)) {
+      return { acquired: false, lockPath, holder: null };
+    }
+    cleanupFile(lockPath);
+  }
+  return { acquired: false, lockPath, holder };
+}
+
+/** Releases the lock only when it still belongs to the given pid. */
+export function releaseDaemonLock(lockPath: string, pid: number): void {
+  const holder = readDaemonLock(lockPath);
+  if (holder?.pid === pid) {
+    cleanupFile(lockPath);
+  }
+}
+
+export function resolveStartTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.AGENTINBOX_START_TIMEOUT_MS;
+  if (raw == null || raw.trim() === "") {
+    return DEFAULT_START_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_START_TIMEOUT_MS;
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return typeof error === "object" && error != null && (error as { code?: unknown }).code === "EEXIST";
+}
+
+function isLockFileFresh(lockPath: string): boolean {
+  try {
+    return Date.now() - fs.statSync(lockPath).mtimeMs < STALE_LOCK_GRACE_MS;
+  } catch {
+    return false;
+  }
+}
+
+type DaemonReadyOutcome = "ready" | "lost" | "timeout";
+
+/**
+ * Waits for the daemon holding the lock to serve healthz. Returns "lost" when
+ * the holder disappears without becoming ready so the caller can re-check
+ * admission instead of timing out.
+ */
+async function waitForDaemonReady(
+  transport: ClientTransport,
+  lockPath: string,
+  timeoutMs: number,
+): Promise<DaemonReadyOutcome> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await canReachHealthz(transport)) {
+      return "ready";
+    }
+    if (readLiveDaemonLockHolder(lockPath) == null) {
+      return "lost";
+    }
+    await sleep(100);
+  }
+  return "timeout";
 }
 
 function daemonChildArgs(): string[] {
@@ -277,7 +492,7 @@ async function waitForHealthz(transport: ClientTransport, timeoutMs: number): Pr
 async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    if (!isProcessAlive(pid)) {
+    if (!isPidAlive(pid)) {
       return;
     }
     await sleep(100);
@@ -285,13 +500,13 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>
   throw new Error(`timed out waiting for process ${pid} to exit`);
 }
 
-function cleanupStalePidFile(pidPath: string, force = false): void {
+function cleanupStalePidFile(pidPath: string): void {
   const pid = readPidFile(pidPath);
   if (pid == null) {
     cleanupFile(pidPath);
     return;
   }
-  if (force || !isProcessAlive(pid)) {
+  if (!isPidAlive(pid)) {
     cleanupFile(pidPath);
   }
 }
@@ -383,15 +598,6 @@ function inferNodeVersionFromCommand(command: string | null): string | null {
   }
   const match = command.match(/node\/(v\d+\.\d+\.\d+)\//);
   return match ? match[1] : null;
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function cleanupFile(filePath: string): void {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -115,6 +115,14 @@ export function resolveDaemonPaths(
   };
 }
 
+/**
+ * Admission lock for the daemon serving a given socket. Scoped to the socket
+ * identity (not the home dir) so an explicit --socket gets its own lock.
+ */
+export function daemonLockPath(socketPath: string): string {
+  return `${socketPath}.lock`;
+}
+
 export function resolveClientTransport(input: ResolveClientTransportInput = {}): ClientTransport {
   const env = input.env ?? process.env;
   const homeDir = resolveAgentInboxHome(env, input.homeDirOverride);

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,7 +39,7 @@ import {
   WebhookActivationTarget,
 } from "./model";
 import { buildSubscriptionListQuery } from "./store_queries";
-import { formatEntryRef, formatThreadRef, generateCanonicalId, nowIso, parseEntryRef } from "./util";
+import { formatEntryRef, formatThreadRef, generateCanonicalId, isEnvFlagDisabled, isPidAlive, nowIso, parseEntryRef } from "./util";
 
 const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
 const V1_BASELINE_TAG = "0000_v1_initial";
@@ -106,8 +106,13 @@ export class AgentInboxStore {
     private readonly db: BetterSqliteDatabase,
   ) {}
 
-  static async open(dbPath: string): Promise<AgentInboxStore> {
+  static async open(
+    dbPath: string,
+    options: { env?: NodeJS.ProcessEnv } = {},
+  ): Promise<AgentInboxStore> {
+    const env = options.env ?? process.env;
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    removeOrphanBackupTmps(dbPath);
     const existedBeforeOpen = fs.existsSync(dbPath);
     let db = await this.openDatabaseWithRecovery(dbPath);
     let store = new AgentInboxStore(dbPath, db);
@@ -118,7 +123,7 @@ export class AgentInboxStore {
       );
       db = this.openDatabase(dbPath);
       store = new AgentInboxStore(dbPath, db);
-    } else if (existedBeforeOpen) {
+    } else if (existedBeforeOpen && startupBackupEnabled(env)) {
       await store.backupHealthyDatabase();
     }
     store.migrate();
@@ -3045,4 +3050,42 @@ function uniqueSorted(values: Array<string | null | undefined>): string[] {
 
 function summarizeBackfilledItemEntry(item: InboxItem): string {
   return `${item.eventVariant} from ${item.sourceId}`;
+}
+
+function startupBackupEnabled(env: NodeJS.ProcessEnv): boolean {
+  return !isEnvFlagDisabled(env.AGENTINBOX_STARTUP_BACKUP);
+}
+
+/**
+ * Removes leftover `<db>.bak.<pid>.tmp` files whose owning process is dead.
+ * Tmp files owned by a live pid belong to a concurrent open and are preserved.
+ */
+function removeOrphanBackupTmps(dbPath: string): void {
+  const dir = path.dirname(dbPath);
+  const pattern = new RegExp(`^${escapeRegExp(path.basename(dbPath))}\\.bak\\.(\\d+)\\.tmp$`);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    const match = pattern.exec(name);
+    if (!match) {
+      continue;
+    }
+    const pid = Number.parseInt(match[1], 10);
+    if (Number.isInteger(pid) && pid > 0 && isPidAlive(pid)) {
+      continue;
+    }
+    try {
+      fs.rmSync(path.join(dir, name), { force: true });
+    } catch {
+      // Best-effort GC.
+    }
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,6 +10,34 @@ export function nowIso(): string {
   return new Date().toISOString();
 }
 
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Treats an env flag as disabled only when it holds an explicit falsy word.
+ * Missing or empty values mean "unset" and keep the default behavior.
+ */
+export function isEnvFlagDisabled(raw: string | undefined): boolean {
+  if (raw == null) {
+    return false;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "0" || normalized === "false" || normalized === "no" || normalized === "off";
+}
+
+/**
+ * Treats an env flag as set only when it holds a non-empty, non-falsy value.
+ */
+export function isEnvFlagEnabled(raw: string | undefined): boolean {
+  return raw != null && raw.trim() !== "" && !isEnvFlagDisabled(raw);
+}
+
 export function generateCanonicalId(prefix: string, length = CANONICAL_ID_TOKEN_LENGTH): string {
   return `${prefix}_${generateShortToken(length)}`;
 }

--- a/test/daemon_lock.test.ts
+++ b/test/daemon_lock.test.ts
@@ -1,0 +1,349 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  acquireDaemonLock,
+  autostartDisabled,
+  daemonStatus,
+  readDaemonLock,
+  releaseDaemonLock,
+  removePidFileIfOwned,
+  resolveStartTimeoutMs,
+} from "../src/daemon";
+import { daemonLockPath } from "../src/paths";
+import { AgentInboxStore } from "../src/store";
+
+const REPO_DIR = path.resolve(__dirname, "..");
+
+function runCli(args: string[], env: NodeJS.ProcessEnv, timeoutMs = 60_000) {
+  return spawnSync("node", ["-r", "ts-node/register", "src/cli.ts", ...args], {
+    cwd: REPO_DIR,
+    env,
+    encoding: "utf8",
+    timeout: timeoutMs,
+  });
+}
+
+function tempHome(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitUntil(predicate: () => Promise<boolean> | boolean, timeoutMs: number): Promise<boolean> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await predicate()) {
+      return true;
+    }
+    await sleep(150);
+  }
+  return false;
+}
+
+function waitExit(child: { on: (event: string, listener: () => void) => void }, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    child.on("exit", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
+
+test("acquireDaemonLock is exclusive per process and releases only for the owner", () => {
+  const home = tempHome("agentinbox-lock-unit-home-");
+  try {
+    const lockPath = daemonLockPath(path.join(home, "agentinbox.sock"));
+    const first = acquireDaemonLock(lockPath);
+    assert.equal(first.acquired, true);
+
+    const second = acquireDaemonLock(lockPath);
+    assert.equal(second.acquired, false);
+    assert.equal(second.holder?.pid, process.pid);
+
+    // Release with a foreign pid must not free the lock.
+    releaseDaemonLock(lockPath, 999_999);
+    assert.equal(readDaemonLock(lockPath)?.pid, process.pid);
+
+    releaseDaemonLock(lockPath, process.pid);
+    assert.equal(readDaemonLock(lockPath), null);
+
+    const third = acquireDaemonLock(lockPath);
+    assert.equal(third.acquired, true);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("acquireDaemonLock removes stale locks from dead pids", () => {
+  const home = tempHome("agentinbox-lock-stale-home-");
+  try {
+    const lockPath = daemonLockPath(path.join(home, "agentinbox.sock"));
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({ pid: 999_999, processStartedAt: null, acquiredAt: new Date().toISOString() }),
+    );
+    const acquisition = acquireDaemonLock(lockPath);
+    assert.equal(acquisition.acquired, true);
+    assert.equal(readDaemonLock(lockPath)?.pid, process.pid);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("resolveStartTimeoutMs defaults to 60s and honors AGENTINBOX_START_TIMEOUT_MS", () => {
+  assert.equal(resolveStartTimeoutMs({}), 60_000);
+  assert.equal(resolveStartTimeoutMs({ AGENTINBOX_START_TIMEOUT_MS: "" }), 60_000);
+  assert.equal(resolveStartTimeoutMs({ AGENTINBOX_START_TIMEOUT_MS: "not-a-number" }), 60_000);
+  assert.equal(resolveStartTimeoutMs({ AGENTINBOX_START_TIMEOUT_MS: "1500" }), 1_500);
+});
+
+test("autostartDisabled treats only explicit truthy values as disabled", () => {
+  assert.equal(autostartDisabled({}), false);
+  assert.equal(autostartDisabled({ AGENTINBOX_NO_AUTOSTART: "" }), false);
+  assert.equal(autostartDisabled({ AGENTINBOX_NO_AUTOSTART: "0" }), false);
+  assert.equal(autostartDisabled({ AGENTINBOX_NO_AUTOSTART: "false" }), false);
+  assert.equal(autostartDisabled({ AGENTINBOX_NO_AUTOSTART: "1" }), true);
+  assert.equal(autostartDisabled({ AGENTINBOX_NO_AUTOSTART: "true" }), true);
+});
+
+test("removePidFileIfOwned deletes only the caller's own pid file", () => {
+  const home = tempHome("agentinbox-pid-ownership-home-");
+  try {
+    const pidPath = path.join(home, "agentinbox.pid");
+    fs.writeFileSync(pidPath, "999999\n", "utf8");
+    assert.equal(removePidFileIfOwned(pidPath, process.pid), false);
+    assert.equal(fs.existsSync(pidPath), true);
+    fs.writeFileSync(pidPath, `${process.pid}\n`, "utf8");
+    assert.equal(removePidFileIfOwned(pidPath, process.pid), true);
+    assert.equal(fs.existsSync(pidPath), false);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("serve exits 0 without binding when a live daemon holds the lock", () => {
+  const home = tempHome("agentinbox-serve-locked-home-");
+  const env = { ...process.env, AGENTINBOX_HOME: home };
+  try {
+    const started = runCli(["daemon", "start"], env);
+    assert.equal(started.status, 0, started.stderr);
+    const startedInfo = JSON.parse(started.stdout) as { started: boolean; pid: number };
+    assert.equal(startedInfo.started, true);
+
+    const socketPath = path.join(home, "agentinbox.sock");
+    const secondServe = runCli(["serve"], env, 30_000);
+    assert.equal(secondServe.status, 0, secondServe.stderr);
+    assert.match(secondServe.stderr, /already running \(pid \d+\)/);
+
+    // The running daemon is unaffected and still owns the lock.
+    const holder = readDaemonLock(daemonLockPath(socketPath));
+    assert.equal(holder?.pid, startedInfo.pid);
+    const statusInfo = JSON.parse(runCli(["daemon", "status"], env).stdout) as {
+      running: boolean;
+      starting: boolean;
+      pid: number | null;
+    };
+    assert.equal(statusInfo.running, true);
+    assert.equal(statusInfo.starting, false);
+    assert.equal(statusInfo.pid, startedInfo.pid);
+
+    const stopped = runCli(["daemon", "stop"], env);
+    assert.equal(stopped.status, 0, stopped.stderr);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("daemon start does not spawn when a live lock holder is starting", () => {
+  const home = tempHome("agentinbox-start-wait-home-");
+  const socketPath = path.join(home, "agentinbox.sock");
+  const lockPath = daemonLockPath(socketPath);
+  try {
+    // Simulate a slow-starting daemon: this live process holds the lock but
+    // never binds the socket.
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({ pid: process.pid, processStartedAt: null, acquiredAt: new Date().toISOString() }),
+    );
+    const env = {
+      ...process.env,
+      AGENTINBOX_HOME: home,
+      AGENTINBOX_START_TIMEOUT_MS: "400",
+    };
+    const result = runCli(["daemon", "start"], env, 30_000);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, new RegExp(`already starting \\(pid ${process.pid}\\)`));
+    // No competing daemon was spawned: no log file, no socket, pid file untouched.
+    assert.equal(fs.existsSync(path.join(home, "agentinbox.log")), false);
+    assert.equal(fs.existsSync(socketPath), false);
+    assert.equal(fs.existsSync(path.join(home, "agentinbox.pid")), false);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("daemon status reports starting for a live pid without healthz and keeps files", async () => {
+  const home = tempHome("agentinbox-status-starting-home-");
+  const pidPath = path.join(home, "agentinbox.pid");
+  const socketPath = path.join(home, "agentinbox.sock");
+  try {
+    fs.writeFileSync(pidPath, `${process.pid}\n`, "utf8");
+    fs.writeFileSync(socketPath, ""); // stale socket file, nothing bound
+    const status = await daemonStatus({ env: { ...process.env, AGENTINBOX_HOME: home } });
+    assert.equal(status.running, false);
+    assert.equal(status.starting, true);
+    assert.equal(status.pid, process.pid);
+    // Live pid: no cleanup of pid file or socket happens.
+    assert.equal(fs.existsSync(pidPath), true);
+    assert.equal(fs.existsSync(socketPath), true);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("daemon stop leaves files alone when another daemon still serves the socket", () => {
+  const home = tempHome("agentinbox-stop-ownership-home-");
+  const env = { ...process.env, AGENTINBOX_HOME: home };
+  const pidPath = path.join(home, "agentinbox.pid");
+  const lockPath = daemonLockPath(path.join(home, "agentinbox.sock"));
+  try {
+    const started = runCli(["daemon", "start"], env);
+    assert.equal(started.status, 0, started.stderr);
+    const startedInfo = JSON.parse(started.stdout) as { pid: number };
+
+    // Simulate a pre-lock-version daemon still serving the socket: the lock
+    // file is gone and the pid file was replaced by a foreign writer.
+    fs.rmSync(lockPath, { force: true });
+    fs.writeFileSync(pidPath, "999999\n", "utf8");
+    const firstStop = runCli(["daemon", "stop"], env);
+    assert.equal(firstStop.status, 0, firstStop.stderr);
+    // The live daemon still serves healthz, so stop must not delete anything.
+    assert.equal(fs.readFileSync(pidPath, "utf8").trim(), "999999");
+    const stillRunning = JSON.parse(runCli(["daemon", "status"], env).stdout) as { running: boolean };
+    assert.equal(stillRunning.running, true);
+
+    // With the real pid restored, stop kills the daemon and cleans up.
+    fs.writeFileSync(pidPath, `${startedInfo.pid}\n`, "utf8");
+    const secondStop = runCli(["daemon", "stop"], env);
+    assert.equal(secondStop.status, 0, secondStop.stderr);
+    assert.equal(fs.existsSync(pidPath), false);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("daemon stop kills the lock holder when the pid file is stale", () => {
+  const home = tempHome("agentinbox-stop-lock-fallback-home-");
+  const env = { ...process.env, AGENTINBOX_HOME: home };
+  const pidPath = path.join(home, "agentinbox.pid");
+  const socketPath = path.join(home, "agentinbox.sock");
+  const lockPath = daemonLockPath(socketPath);
+  try {
+    const started = runCli(["daemon", "start"], env);
+    assert.equal(started.status, 0, started.stderr);
+
+    // Stale foreign pid file; the live daemon still owns the admission lock.
+    fs.writeFileSync(pidPath, "999999\n", "utf8");
+    const stopped = runCli(["daemon", "stop"], env);
+    assert.equal(stopped.status, 0, stopped.stderr);
+    const statusInfo = JSON.parse(runCli(["daemon", "status"], env).stdout) as { running: boolean };
+    assert.equal(statusInfo.running, false);
+    assert.equal(fs.existsSync(pidPath), false);
+    assert.equal(fs.existsSync(socketPath), false);
+    assert.equal(fs.existsSync(lockPath), false);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("serve shutdown removes only its own pid file and releases its lock", async () => {
+  const home = tempHome("agentinbox-serve-exit-home-");
+  const env = { ...process.env, AGENTINBOX_HOME: home };
+  const pidPath = path.join(home, "agentinbox.pid");
+  const lockPath = daemonLockPath(path.join(home, "agentinbox.sock"));
+  const child = spawn("node", ["-r", "ts-node/register", "src/cli.ts", "serve"], {
+    cwd: REPO_DIR,
+    env,
+    stdio: "ignore",
+  });
+  try {
+    const ready = await waitUntil(async () => (await daemonStatus({ env })).running === true, 45_000);
+    assert.equal(ready, true, "serve did not become ready");
+    assert.equal(fs.readFileSync(pidPath, "utf8").trim(), String(child.pid));
+
+    // Simulate a foreign owner overwriting the pid file.
+    fs.writeFileSync(pidPath, "999999\n", "utf8");
+    child.kill("SIGTERM");
+    assert.equal(await waitExit(child, 15_000), true, "serve did not exit after SIGTERM");
+
+    // The foreign pid file survives; the lock is released by its real owner.
+    assert.equal(fs.readFileSync(pidPath, "utf8").trim(), "999999");
+    assert.equal(fs.existsSync(lockPath), false);
+  } finally {
+    if (child.exitCode == null) {
+      child.kill("SIGKILL");
+    }
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("AGENTINBOX_NO_AUTOSTART prevents implicit daemon spawning", () => {
+  const home = tempHome("agentinbox-no-autostart-home-");
+  const env = {
+    ...process.env,
+    AGENTINBOX_HOME: home,
+    AGENTINBOX_NO_AUTOSTART: "1",
+  };
+  try {
+    const result = runCli(["agent", "register"], env, 30_000);
+    assert.notEqual(result.status, 0);
+    assert.equal(fs.existsSync(path.join(home, "agentinbox.log")), false);
+    assert.equal(fs.existsSync(path.join(home, "agentinbox.sock")), false);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("store open GCs orphan backup tmp files and keeps live-pid ones", async () => {
+  const home = tempHome("agentinbox-store-gc-home-");
+  const dbPath = path.join(home, "agentinbox.sqlite");
+  // A separate live process owns a tmp file that GC must preserve (using the
+  // test process pid would collide with backupHealthyDatabase's own tmp path).
+  const liveOwner = spawn("sleep", ["30"]);
+  assert.ok(liveOwner.pid, "failed to spawn live tmp owner");
+  try {
+    let store = await AgentInboxStore.open(dbPath);
+    store.close();
+
+    const orphanTmp = `${dbPath}.bak.999999.tmp`;
+    const liveTmp = `${dbPath}.bak.${liveOwner.pid}.tmp`;
+    fs.writeFileSync(orphanTmp, "orphan");
+    fs.writeFileSync(liveTmp, "live");
+
+    store = await AgentInboxStore.open(dbPath);
+    store.close();
+    assert.equal(fs.existsSync(orphanTmp), false, "orphan tmp should be garbage collected");
+    assert.equal(fs.existsSync(liveTmp), true, "live-pid tmp must be preserved");
+    assert.equal(fs.existsSync(`${dbPath}.bak`), true, "startup backup runs by default");
+
+    fs.rmSync(liveTmp, { force: true });
+    fs.rmSync(`${dbPath}.bak`, { force: true });
+    store = await AgentInboxStore.open(dbPath, {
+      env: { ...process.env, AGENTINBOX_STARTUP_BACKUP: "0" },
+    });
+    store.close();
+    assert.equal(fs.existsSync(`${dbPath}.bak`), false, "AGENTINBOX_STARTUP_BACKUP=0 skips the backup");
+  } finally {
+    if (liveOwner.exitCode == null) {
+      liveOwner.kill("SIGKILL");
+    }
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #235

## Root causes fixed

Issue #235 traced duplicate daemons and orphan startup backups to a self-reinforcing loop:

1. **Client autostart had no admission control** — `ensureDaemonForClient` spawned a daemon whenever healthz failed, and the 15s startup timeout was shorter than a slow store backup (~45s for ~1.1GB), so every concurrent client spawned its own daemon.
2. **Unowned cleanup** — `stop`/`status` removed the pid file, socket, and metadata without verifying whether a live instance still owned them.
3. **First-exit-wins pid file deletion** — the second instance overwrote the pid file, so the first instance's exit deleted the *second* instance's files → status judged them stale → deleted a live socket → next client spawned again → loop.

## Changes

- **F1 admission lock** (`src/daemon.ts`, `src/paths.ts`): serve acquires `<socket>.lock` via `O_EXCL` *before opening the store*, eliminating the spawn window during slow startup backups. A live holder (pid + process start time verified against `ps` to defeat pid reuse) makes serve print `already running (pid N)` and exit 0; stale locks are removed and retried once. Clients check the lock before spawning: if a live holder exists they wait for healthz and then report `instance already starting (pid N, elapsed Ns)` instead of stacking daemons.
- **F2 ownership-aware cleanup**: pid file / socket / metadata removal now only happens when the files belong to the exiting instance or no live lock holder exists.
- **F3 env switches**: `AGENTINBOX_NO_AUTOSTART=1` disables client autostart (for systemd-style supervised deployments); `AGENTINBOX_START_TIMEOUT_MS` overrides the healthz wait for large stores.
- **F4 startup backup governance** (`src/store.ts`): bounded `.bak` retention, `<db>.bak.<pid>.tmp` files owned by dead pids are swept on open, and the per-open full backup is skipped when a healthy backup already exists — no more multi-GB orphan tmp accumulation.
- **F5 status semantics**: `agentinbox status` reports a `starting` state for a live-but-not-yet-serving pid instead of misjudging it.

No breaking API changes, no new native dependencies (Node stdlib only).

## Verification

- `npm test`: 349/349 pass (336 baseline + 13 new tests in `test/daemon_lock.test.ts` covering lock acquisition/reclaim/live-holder detection, ownership cleanup, autostart bypass, backup GC, and starting-state semantics).