### PR TITLE
fix(store): make startup backup and health checks event-driven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ The format is intentionally simple during public beta:
 
 ## [Unreleased]
 
+### Changed
+
+- Startup database handling is event-driven instead of unconditional (#237):
+  regular opens verify the database with `PRAGMA quick_check` (escalating to a
+  full `integrity_check` only when the quick pass fails) and no longer rewrite
+  a full backup on every startup.
+- A full backup is now taken automatically only before pending schema
+  migrations run, named `<db>.pre-migrate-v<N>.bak` and bounded by
+  `AGENTINBOX_MIGRATION_BACKUP_KEEP` (default 5; `0` keeps all) (#237).
+- `AGENTINBOX_STARTUP_BACKUP` now defaults to off; setting it to `1` restores
+  the legacy v1.5.2 behavior of an unconditional backup plus a full
+  `integrity_check` on every open (#237).
+- Status diagnostics now report `quickCheck` instead of running a full
+  `integrity_check` on every `status` call (#237).
+
+### Added
+
+- `agentinbox backup` writes a verified `<db>.bak` snapshot on demand for
+  scheduled or pre-upgrade snapshots; recovery considers manual and
+  pre-migration backups, most recent first (#237).
+
+### Fixed
+
+- Corrected the v1.5.2 release notes claim that "an existing healthy backup
+  is reused instead of being rewritten": that behavior was not implemented in
+  v1.5.2 and startup backups were rewritten on every open. The event-driven
+  model above replaces it (#237).
+
 ## [1.5.2] - 2026-09-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -299,6 +299,22 @@ that database next to the DB path (for example,
 `~/.agentinbox/agentinbox.sqlite.pre-v1.<timestamp>.bak`) and starts with a
 fresh v1 database; pre-v1 local data is not imported.
 
+## Database Backups
+
+Startup backups are event-driven, not unconditional:
+
+- before pending schema migrations run, a full backup is written to
+  `<db>.pre-migrate-v<N>.bak` (bounded by `AGENTINBOX_MIGRATION_BACKUP_KEEP`,
+  default 5; `0` keeps all)
+- `agentinbox backup [--home DIR] [--state PATH]` writes a manual snapshot to
+  `<db>.bak` on demand, for scheduled or pre-upgrade snapshots
+- regular opens verify the database with `PRAGMA quick_check` and escalate to
+  a full `integrity_check` only when the quick pass fails; recovery considers
+  manual and pre-migration backups, most recent first
+
+Setting `AGENTINBOX_STARTUP_BACKUP=1` restores the legacy behavior of backing
+up (and fully checking) the database on every open.
+
 ## License
 
 Apache-2.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,15 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (command === "backup") {
+    if (hasHelpFlag(normalized.slice(1))) {
+      printHelp(["backup"]);
+      return;
+    }
+    await runBackup(normalized.slice(1));
+    return;
+  }
+
   if (hasHelpFlag(normalized.slice(1))) {
     printHelp([command]);
     return;
@@ -1105,6 +1114,7 @@ const COMMAND_SHELL_SPECS: Array<{ name: string; group: boolean; summary: string
   { name: "subscription", group: true, summary: "Manage source subscriptions." },
   { name: "inbox", group: true, summary: "Read and manage agent inboxes." },
   { name: "gc", group: false, summary: "Run garbage collection." },
+  { name: "backup", group: false, summary: "Write a local database backup snapshot." },
   { name: "deliver", group: true, summary: "Send outbound delivery actions." },
   { name: "status", group: false, summary: "Show daemon status." },
   { name: "version", group: false, summary: "Show CLI version." },
@@ -1145,6 +1155,25 @@ function parseCommanderShell(args: string[]): CommanderShellParse {
   return {
     isBareGroup: Boolean(COMMAND_SHELL_SPECS.find((item) => item.name === spec?.name())?.group && args.length === 1),
   };
+}
+
+async function runBackup(args: string[]): Promise<void> {
+  const serveConfig = resolveServeConfig({
+    env: process.env,
+    homeDirOverride: takeFlagValue(args, "--home"),
+    statePathOverride: takeFlagValue(args, "--state"),
+  });
+  const store = await AgentInboxStore.open(serveConfig.dbPath);
+  try {
+    const backupPath = await store.backupDatabase();
+    console.log(jsonResponse({
+      ok: true,
+      dbPath: serveConfig.dbPath,
+      backupPath,
+    }));
+  } finally {
+    store.close();
+  }
 }
 
 async function runServe(args: string[]): Promise<void> {
@@ -1905,6 +1934,14 @@ Usage:
   agentinbox daemon start [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock] [--log-level error|warn|info|debug|trace]
   agentinbox daemon stop [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
   agentinbox daemon status [--home ~/.agentinbox] [--socket ~/.agentinbox/agentinbox.sock]
+`,
+    backup: `agentinbox backup
+
+Usage:
+  agentinbox backup [--home ~/.agentinbox] [--state ~/.agentinbox/agentinbox.sqlite]
+
+Writes a verified snapshot to <db>.bak (replaces the previous manual backup).
+Pre-migration backups (<db>.pre-migrate-v<N>.bak) are created automatically.
 `,
     host: `agentinbox host
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,7 +39,7 @@ import {
   WebhookActivationTarget,
 } from "./model";
 import { buildSubscriptionListQuery } from "./store_queries";
-import { formatEntryRef, formatThreadRef, generateCanonicalId, isEnvFlagDisabled, isPidAlive, nowIso, parseEntryRef } from "./util";
+import { formatEntryRef, formatThreadRef, generateCanonicalId, isEnvFlagEnabled, isPidAlive, nowIso, parseEntryRef } from "./util";
 
 const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
 const V1_BASELINE_TAG = "0000_v1_initial";
@@ -73,7 +73,7 @@ interface DigestThreadRecord {
 }
 
 export interface DatabaseHealth {
-  integrityCheck: string;
+  quickCheck: string;
   journalMode: string;
   foreignKeys: boolean;
 }
@@ -114,8 +114,12 @@ export class AgentInboxStore {
     fs.mkdirSync(path.dirname(dbPath), { recursive: true });
     removeOrphanBackupTmps(dbPath);
     const existedBeforeOpen = fs.existsSync(dbPath);
-    let db = await this.openDatabaseWithRecovery(dbPath);
+    // Legacy AGENTINBOX_STARTUP_BACKUP=1 mode pays for a full check and an
+    // unconditional backup on every open, matching v1.5.2 behavior.
+    const legacyStartupBackup = legacyStartupBackupEnabled(env);
+    let db = await this.openDatabaseWithRecovery(dbPath, legacyStartupBackup);
     let store = new AgentInboxStore(dbPath, db);
+    let archivedPreV1 = false;
     if (existedBeforeOpen && store.shouldArchivePreV1Database()) {
       const archivedPath = store.archivePreV1Database();
       console.warn(
@@ -123,17 +127,21 @@ export class AgentInboxStore {
       );
       db = this.openDatabase(dbPath);
       store = new AgentInboxStore(dbPath, db);
-    } else if (existedBeforeOpen && startupBackupEnabled(env)) {
-      await store.backupHealthyDatabase();
+      archivedPreV1 = true;
+    } else if (existedBeforeOpen && legacyStartupBackup) {
+      await store.backupDatabase();
     }
-    store.migrate();
+    await store.migrate({ existedBeforeOpen: existedBeforeOpen && !archivedPreV1, env });
     store.persist();
     return store;
   }
 
-  private static async openDatabaseWithRecovery(dbPath: string): Promise<BetterSqliteDatabase> {
+  private static async openDatabaseWithRecovery(
+    dbPath: string,
+    fullCheck: boolean,
+  ): Promise<BetterSqliteDatabase> {
     try {
-      return this.openDatabase(dbPath);
+      return this.openDatabase(dbPath, fullCheck);
     } catch (error) {
       if (!fs.existsSync(dbPath)) {
         throw error;
@@ -148,21 +156,31 @@ export class AgentInboxStore {
       console.warn(
         `[agentinbox] recovered local database from ${backupPath}; archived corrupt database to ${corruptPath}.`,
       );
-      return this.openDatabase(dbPath);
+      return this.openDatabase(dbPath, fullCheck);
     }
   }
 
-  private static openDatabase(dbPath: string): BetterSqliteDatabase {
+  private static openDatabase(dbPath: string, fullCheck = false): BetterSqliteDatabase {
     const db = new BetterSqlite3(dbPath);
     db.pragma("busy_timeout = 5000");
     db.pragma("journal_mode = WAL");
     db.pragma("synchronous = NORMAL");
     db.pragma("foreign_keys = ON");
-    this.assertHealthy(db, dbPath);
+    this.assertHealthy(db, dbPath, fullCheck);
     return db;
   }
 
-  private static assertHealthy(db: BetterSqliteDatabase, dbPath: string): void {
+  /**
+   * Verifies database integrity. Regular opens run `quick_check` and only
+   * escalate to a full `integrity_check` when the quick pass fails, so large
+   * databases do not pay a full scan on every startup. Conservative callers
+   * (legacy `AGENTINBOX_STARTUP_BACKUP=1` mode, recovery-candidate
+   * validation) pass `fullCheck`.
+   */
+  private static assertHealthy(db: BetterSqliteDatabase, dbPath: string, fullCheck: boolean): void {
+    if (!fullCheck && db.pragma("quick_check", { simple: true }) === "ok") {
+      return;
+    }
     const result = db.pragma("integrity_check", { simple: true });
     if (result !== "ok") {
       db.close();
@@ -175,7 +193,7 @@ export class AgentInboxStore {
     for (const candidate of candidates) {
       try {
         const db = new BetterSqlite3(candidate, { readonly: true, fileMustExist: true });
-        this.assertHealthy(db, candidate);
+        this.assertHealthy(db, candidate, true);
         db.close();
         return candidate;
       } catch {
@@ -188,16 +206,31 @@ export class AgentInboxStore {
   private static listBackupCandidates(dbPath: string): string[] {
     const dir = path.dirname(dbPath);
     const baseName = path.basename(dbPath);
-    const startupBackups = fs.existsSync(dir)
-      ? fs.readdirSync(dir)
-        .filter((name) => name.startsWith(`${baseName}.startup.`) && name.endsWith(".bak"))
-        .sort()
-        .reverse()
-        .map((name) => path.join(dir, name))
-      : [];
-    return [`${dbPath}.bak`, ...startupBackups].filter((candidate, index, all) =>
-      fs.existsSync(candidate) && all.indexOf(candidate) === index,
-    );
+    const preMigrationPattern = new RegExp(`^${escapeRegExp(baseName)}\\.pre-migrate-v(\\d+)\\.bak$`);
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      return [];
+    }
+    const candidates: Array<{ path: string; version: number; modifiedAtMs: number }> = [];
+    for (const name of entries) {
+      const candidatePath = path.join(dir, name);
+      if (name === `${baseName}.bak`) {
+        candidates.push({ path: candidatePath, version: 0, modifiedAtMs: backupMtimeMs(candidatePath) });
+        continue;
+      }
+      const preMigration = preMigrationPattern.exec(name);
+      if (preMigration) {
+        candidates.push({
+          path: candidatePath,
+          version: Number.parseInt(preMigration[1]!, 10),
+          modifiedAtMs: backupMtimeMs(candidatePath),
+        });
+      }
+    }
+    candidates.sort((left, right) => right.modifiedAtMs - left.modifiedAtMs || right.version - left.version);
+    return candidates.map((candidate) => candidate.path);
   }
 
   private static nextPath(base: string): string {
@@ -221,14 +254,24 @@ export class AgentInboxStore {
 
   getDatabaseHealth(): DatabaseHealth {
     return {
-      integrityCheck: String(this.db.pragma("integrity_check", { simple: true })),
+      quickCheck: String(this.db.pragma("quick_check", { simple: true })),
       journalMode: String(this.db.pragma("journal_mode", { simple: true })),
       foreignKeys: Number(this.db.pragma("foreign_keys", { simple: true })) === 1,
     };
   }
 
-  private async backupHealthyDatabase(): Promise<void> {
+  /**
+   * Writes a snapshot to `<db>.bak`, used by `agentinbox backup` and by the
+   * opt-in legacy `AGENTINBOX_STARTUP_BACKUP=1` startup backup. The open-time
+   * health check has already run against this handle. Returns the backup path.
+   */
+  async backupDatabase(): Promise<string> {
     const backupPath = `${this.dbPath}.bak`;
+    await this.writeBackupTo(backupPath);
+    return backupPath;
+  }
+
+  private async writeBackupTo(backupPath: string): Promise<void> {
     const tmpPath = `${backupPath}.${process.pid}.tmp`;
     try {
       fs.rmSync(tmpPath, { force: true });
@@ -239,12 +282,19 @@ export class AgentInboxStore {
     }
   }
 
-  private migrate(): void {
+  private async migrate(options: { existedBeforeOpen: boolean; env: NodeJS.ProcessEnv }): Promise<void> {
     const migrations = this.loadSqlMigrations();
     this.ensureDrizzleMigrationsTable();
     const applied = this.listAppliedMigrationTags();
 
     const pending = migrations.filter((migration) => !applied.has(migration.tag));
+    if (options.existedBeforeOpen && pending.length > 0) {
+      const backupPath = await this.backupBeforeMigration(migrations.length);
+      console.warn(
+        `[agentinbox] pending schema migrations detected; backed up the local database to ${backupPath} before migrating to schema v${migrations.length}.`,
+      );
+      this.pruneMigrationBackups(options.env);
+    }
     for (const migration of pending) {
       this.applyMigration(migration);
     }
@@ -252,6 +302,42 @@ export class AgentInboxStore {
     this.ensureInboxEntryBackfill();
 
     this.setUserVersion(migrations.length);
+  }
+
+  private async backupBeforeMigration(targetVersion: number): Promise<string> {
+    const backupPath = `${this.dbPath}.pre-migrate-v${targetVersion}.bak`;
+    await this.writeBackupTo(backupPath);
+    return backupPath;
+  }
+
+  /**
+   * Keeps only the newest `AGENTINBOX_MIGRATION_BACKUP_KEEP` pre-migration
+   * backups (default 5; values <= 0 keep everything). Migration backups are
+   * rare, so pruning only runs right after a new one is written.
+   */
+  private pruneMigrationBackups(env: NodeJS.ProcessEnv): void {
+    const keep = migrationBackupKeep(env);
+    if (keep <= 0) {
+      return;
+    }
+    const dir = path.dirname(this.dbPath);
+    const pattern = new RegExp(`^${escapeRegExp(path.basename(this.dbPath))}\\.pre-migrate-v(\\d+)\\.bak$`);
+    const entries: Array<{ path: string; version: number }> = [];
+    for (const name of fs.readdirSync(dir)) {
+      const match = pattern.exec(name);
+      if (!match) {
+        continue;
+      }
+      entries.push({ path: path.join(dir, name), version: Number.parseInt(match[1]!, 10) });
+    }
+    entries.sort((left, right) => right.version - left.version);
+    for (const entry of entries.slice(keep)) {
+      try {
+        fs.rmSync(entry.path, { force: true });
+      } catch {
+        // Best-effort pruning.
+      }
+    }
   }
 
   private loadSqlMigrations(): SqlMigration[] {
@@ -3052,17 +3138,40 @@ function summarizeBackfilledItemEntry(item: InboxItem): string {
   return `${item.eventVariant} from ${item.sourceId}`;
 }
 
-function startupBackupEnabled(env: NodeJS.ProcessEnv): boolean {
-  return !isEnvFlagDisabled(env.AGENTINBOX_STARTUP_BACKUP);
+const DEFAULT_MIGRATION_BACKUP_KEEP = 5;
+
+/**
+ * Backups are event-driven: a full database backup is taken only before
+ * pending schema migrations run, plus explicit `agentinbox backup` snapshots.
+ * Setting `AGENTINBOX_STARTUP_BACKUP=1` opts back into the legacy v1.5.2
+ * behavior of an unconditional backup and a full `integrity_check` on every
+ * open.
+ */
+function legacyStartupBackupEnabled(env: NodeJS.ProcessEnv): boolean {
+  return isEnvFlagEnabled(env.AGENTINBOX_STARTUP_BACKUP);
+}
+
+function migrationBackupKeep(env: NodeJS.ProcessEnv): number {
+  const parsed = Number.parseInt(env.AGENTINBOX_MIGRATION_BACKUP_KEEP ?? "", 10);
+  return Number.isInteger(parsed) ? parsed : DEFAULT_MIGRATION_BACKUP_KEEP;
+}
+
+function backupMtimeMs(candidatePath: string): number {
+  try {
+    return fs.statSync(candidatePath).mtimeMs;
+  } catch {
+    return 0;
+  }
 }
 
 /**
- * Removes leftover `<db>.bak.<pid>.tmp` files whose owning process is dead.
- * Tmp files owned by a live pid belong to a concurrent open and are preserved.
+ * Removes leftover `<db>.*.bak.<pid>.tmp` files (manual and pre-migration
+ * backup temporaries) whose owning process is dead. Tmp files owned by a live
+ * pid belong to a concurrent open and are preserved.
  */
 function removeOrphanBackupTmps(dbPath: string): void {
   const dir = path.dirname(dbPath);
-  const pattern = new RegExp(`^${escapeRegExp(path.basename(dbPath))}\\.bak\\.(\\d+)\\.tmp$`);
+  const pattern = new RegExp(`^${escapeRegExp(path.basename(dbPath))}\\.(?:.+\\.)?bak\\.(\\d+)\\.tmp$`);
   let entries: string[];
   try {
     entries = fs.readdirSync(dir);

--- a/test/control_plane.test.ts
+++ b/test/control_plane.test.ts
@@ -348,10 +348,10 @@ test("cli accepts --json as a no-op compatibility flag on default JSON commands"
     assert.equal(status.status, 0, status.stderr);
     const parsedStatus = JSON.parse(status.stdout) as {
       counts?: { agents?: number };
-      diagnostics?: { database?: { integrityCheck?: string }; daemon?: { status?: string } };
+      diagnostics?: { database?: { quickCheck?: string }; daemon?: { status?: string } };
     };
     assert.equal(typeof parsedStatus.counts?.agents, "number");
-    assert.equal(parsedStatus.diagnostics?.database?.integrityCheck, "ok");
+    assert.equal(parsedStatus.diagnostics?.database?.quickCheck, "ok");
     assert.equal(parsedStatus.diagnostics?.daemon?.status, "running");
 
     const registered = runCli(["agent", "register"], env);
@@ -1276,7 +1276,7 @@ test("control plane source views surface backend managed runtime state", async (
 
       const status = await client.request<{
         diagnostics: {
-          database: { integrityCheck: string; journalMode: string; foreignKeys: boolean };
+          database: { quickCheck: string; journalMode: string; foreignKeys: boolean };
           sources: { total: number; active: number; paused: number; error: number };
           activationDispatch: { total: number; dirty: number; notified: number; pendingNewItems: number; deferredAttempts: number };
         };
@@ -1296,7 +1296,7 @@ test("control plane source views surface backend managed runtime state", async (
         }>;
       }>("/status", undefined, "GET");
       assert.equal(status.statusCode, 200);
-      assert.equal(status.data.diagnostics.database.integrityCheck, "ok");
+      assert.equal(status.data.diagnostics.database.quickCheck, "ok");
       assert.equal(typeof status.data.diagnostics.database.journalMode, "string");
       assert.equal(status.data.diagnostics.database.foreignKeys, true);
       assert.equal(status.data.diagnostics.sources.total >= 1, true);

--- a/test/daemon_lock.test.ts
+++ b/test/daemon_lock.test.ts
@@ -331,19 +331,37 @@ test("store open GCs orphan backup tmp files and keeps live-pid ones", async () 
     store.close();
     assert.equal(fs.existsSync(orphanTmp), false, "orphan tmp should be garbage collected");
     assert.equal(fs.existsSync(liveTmp), true, "live-pid tmp must be preserved");
-    assert.equal(fs.existsSync(`${dbPath}.bak`), true, "startup backup runs by default");
+    assert.equal(fs.existsSync(`${dbPath}.bak`), false, "startup backup no longer runs by default");
 
     fs.rmSync(liveTmp, { force: true });
-    fs.rmSync(`${dbPath}.bak`, { force: true });
     store = await AgentInboxStore.open(dbPath, {
-      env: { ...process.env, AGENTINBOX_STARTUP_BACKUP: "0" },
+      env: { ...process.env, AGENTINBOX_STARTUP_BACKUP: "1" },
     });
     store.close();
-    assert.equal(fs.existsSync(`${dbPath}.bak`), false, "AGENTINBOX_STARTUP_BACKUP=0 skips the backup");
+    assert.equal(fs.existsSync(`${dbPath}.bak`), true, "AGENTINBOX_STARTUP_BACKUP=1 restores the legacy startup backup");
   } finally {
     if (liveOwner.exitCode == null) {
       liveOwner.kill("SIGKILL");
     }
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("agentinbox backup writes a snapshot without a daemon", async () => {
+  const home = tempHome("agentinbox-backup-cli-home-");
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    AGENTINBOX_HOME: home,
+    AGENTINBOX_NO_AUTOSTART: "1",
+  };
+  try {
+    const result = runCli(["backup"], env);
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout) as { ok?: boolean; backupPath?: string };
+    assert.equal(payload.ok, true);
+    assert.ok(payload.backupPath?.endsWith("agentinbox.sqlite.bak"), `unexpected backupPath: ${String(payload.backupPath)}`);
+    assert.equal(fs.existsSync(payload.backupPath!), true, "backup snapshot exists");
+  } finally {
     fs.rmSync(home, { recursive: true, force: true });
   }
 });

--- a/test/store_migration.test.ts
+++ b/test/store_migration.test.ts
@@ -168,7 +168,7 @@ test("store opens databases with WAL journaling and foreign keys enabled", async
   const store = await AgentInboxStore.open(dbPath);
   try {
     const health = store.getDatabaseHealth();
-    assert.equal(health.integrityCheck, "ok");
+    assert.equal(health.quickCheck, "ok");
     assert.equal(health.journalMode, "wal");
     assert.equal(health.foreignKeys, true);
   } finally {
@@ -214,10 +214,8 @@ test("store recovers a corrupt main database from the latest healthy backup", as
   };
   try {
     const first = await AgentInboxStore.open(dbPath);
+    await first.backupDatabase();
     first.close();
-
-    const reopened = await AgentInboxStore.open(dbPath);
-    reopened.close();
     assert.equal(fs.existsSync(`${dbPath}.bak`), true);
 
     fs.rmSync(`${dbPath}-wal`, { force: true });
@@ -227,7 +225,7 @@ test("store recovers a corrupt main database from the latest healthy backup", as
     recovered = await AgentInboxStore.open(dbPath);
     const state = await readMigrationState(dbPath);
     assert.deepEqual(state.appliedTags, EXPECTED_MIGRATION_TAGS);
-    assert.equal(recovered.getDatabaseHealth().integrityCheck, "ok");
+    assert.equal(recovered.getDatabaseHealth().quickCheck, "ok");
     assert.match(warnings.join("\n"), /recovered local database from/);
     assert.equal(fs.readdirSync(dir).some((name) => name.startsWith("agentinbox.sqlite.corrupt")), true);
   } finally {
@@ -302,6 +300,127 @@ test("store archives repeated pre-v1 databases without clobbering earlier backup
     assert.equal(backups.length, 2);
     assert.notEqual(backups[0], backups[1]);
   } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("store backs up an existing database before applying pending migrations", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-migrate-backup-"));
+  const dbPath = path.join(dir, "agentinbox.sqlite");
+  await createV1BaselineDbWithSourceScopedLifecycleRetirement(dbPath);
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map((arg) => String(arg)).join(" "));
+  };
+  let store: AgentInboxStore | null = null;
+  try {
+    store = await AgentInboxStore.open(dbPath);
+    const migrationBackup = `${dbPath}.pre-migrate-v${EXPECTED_MIGRATION_TAGS.length}.bak`;
+    assert.equal(fs.existsSync(migrationBackup), true, "pending migrations trigger a pre-migration backup");
+    assert.equal(fs.existsSync(`${dbPath}.bak`), false, "no unconditional startup backup");
+    assert.match(warnings.join("\n"), /pending schema migrations detected/);
+  } finally {
+    console.warn = originalWarn;
+    store?.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("store does not create backups when reopening a fully migrated database", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-migrate-reopen-nobackup-"));
+  const dbPath = path.join(dir, "agentinbox.sqlite");
+  const first = await AgentInboxStore.open(dbPath);
+  first.close();
+
+  const second = await AgentInboxStore.open(dbPath);
+  second.close();
+  try {
+    const backups = fs.readdirSync(dir).filter((name) => name.endsWith(".bak"));
+    assert.deepEqual(backups, []);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("AGENTINBOX_STARTUP_BACKUP=1 restores the legacy unconditional startup backup", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-legacy-startup-backup-"));
+  const dbPath = path.join(dir, "agentinbox.sqlite");
+  const env = { ...process.env, AGENTINBOX_STARTUP_BACKUP: "1" };
+  const first = await AgentInboxStore.open(dbPath, { env });
+  first.close();
+
+  const second = await AgentInboxStore.open(dbPath, { env });
+  second.close();
+  try {
+    assert.equal(fs.existsSync(`${dbPath}.bak`), true, "legacy mode backs up on every open");
+    fs.rmSync(`${dbPath}.bak`, { force: true });
+    const third = await AgentInboxStore.open(dbPath);
+    third.close();
+    assert.equal(fs.existsSync(`${dbPath}.bak`), false, "default mode no longer backs up on open");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("store recovers a corrupt database from a pre-migration backup", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-recover-pre-migrate-"));
+  const dbPath = path.join(dir, "agentinbox.sqlite");
+  await createV1BaselineDbWithSourceScopedLifecycleRetirement(dbPath);
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map((arg) => String(arg)).join(" "));
+  };
+  let recovered: AgentInboxStore | null = null;
+  try {
+    const first = await AgentInboxStore.open(dbPath);
+    first.close();
+    fs.rmSync(`${dbPath}-wal`, { force: true });
+    fs.rmSync(`${dbPath}-shm`, { force: true });
+    fs.writeFileSync(dbPath, "not a sqlite database");
+
+    recovered = await AgentInboxStore.open(dbPath);
+    const state = await readMigrationState(dbPath);
+    assert.deepEqual(state.appliedTags, EXPECTED_MIGRATION_TAGS);
+    assert.match(warnings.join("\n"), /recovered local database from .*pre-migrate-v6\.bak/);
+  } finally {
+    console.warn = originalWarn;
+    recovered?.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("store prunes old pre-migration backups beyond AGENTINBOX_MIGRATION_BACKUP_KEEP", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentinbox-migrate-backup-prune-"));
+  const dbPath = path.join(dir, "agentinbox.sqlite");
+  await createV1BaselineDbWithSourceScopedLifecycleRetirement(dbPath);
+  const baseName = path.basename(dbPath);
+  for (const version of [1, 2, 3, 4, 5]) {
+    fs.writeFileSync(path.join(dir, `${baseName}.pre-migrate-v${version}.bak`), "stale");
+  }
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map((arg) => String(arg)).join(" "));
+  };
+  let store: AgentInboxStore | null = null;
+  try {
+    store = await AgentInboxStore.open(dbPath, {
+      env: { ...process.env, AGENTINBOX_MIGRATION_BACKUP_KEEP: "3" },
+    });
+    const remaining = fs.readdirSync(dir)
+      .filter((name) => name.includes(".pre-migrate-v"))
+      .sort()
+      .reverse();
+    assert.deepEqual(remaining, [
+      `${baseName}.pre-migrate-v6.bak`,
+      `${baseName}.pre-migrate-v5.bak`,
+      `${baseName}.pre-migrate-v4.bak`,
+    ]);
+  } finally {
+    console.warn = originalWarn;
+    store?.close();
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Fixes #237

## Problem

v1.5.2 takes a full database backup and runs a full `integrity_check` on **every** open of the database. For a large database (the reporter's is 1.1 GiB) every restart pays ~69s+ before the daemon can serve. Restarts have no correlation with corruption risk, so the trigger was wrong: the moments that actually deserve a snapshot are "the schema is about to change" and "a human asks for one".

Also, the v1.5.2 release notes claimed *"an existing healthy backup is reused instead of being rewritten"* — that behavior was not implemented. Backups were rewritten on every open, and `listBackupCandidates()` still read a legacy `.startup.*.bak` naming scheme that nothing produced (dead code). This PR corrects that.

## Changes

**Event-driven backups (`src/store.ts`)**
- Regular opens no longer back up the database and verify with `PRAGMA quick_check` instead of `integrity_check`; a full check runs only when the quick pass fails (then the existing recovery path applies)
- A full backup is taken automatically **only before pending schema migrations run**, named `<db>.pre-migrate-v<N>.bak`, keeping the newest `AGENTINBOX_MIGRATION_BACKUP_KEEP` (default 5; `0` keeps all)
- `listBackupCandidates()` now matches actual backup names (`.bak` manual + `.pre-migrate-v<N>.bak`), ordered most recent first — recovery previously could only ever see a single generation
- `getDatabaseHealth()` (used by status diagnostics) reports `quickCheck` so `status` no longer full-scans on every call

**Manual backup (`src/cli.ts`)**
- New `agentinbox backup [--home DIR] [--state PATH]` command writes a verified `<db>.bak` snapshot on demand (for cron or pre-upgrade snapshots)

**Opt-in legacy mode**
- `AGENTINBOX_STARTUP_BACKUP` now defaults to **off**; setting `AGENTINBOX_STARTUP_BACKUP=1` restores the v1.5.2 behavior of an unconditional backup plus full `integrity_check` on every open

**Tests**: updated affected cases and added coverage for migration-triggered backup + pruning, quick_check escalation, manual backup, and legacy opt-in compatibility. Full suite: 355/355 pass.

## Trade-off (deliberate)

Users who never upgrade and never run `agentinbox backup` no longer get a routine `.bak` refreshed at startup. Such a same-disk snapshot mainly protects against software corrupting the DB — which is exactly when migration backups fire — and `quick_check` still catches corruption at every open.